### PR TITLE
Feature/itbl 3821 os notification payload

### DIFF
--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableNotification.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableNotification.java
@@ -243,4 +243,19 @@ public class IterableNotification extends NotificationCompat.Builder {
 
         return isGhostPush;
     }
+
+    /**
+     * Returns if the given notification has an empty body
+     * @param extras
+     * @return
+     */
+    static boolean isEmptyBody(Bundle extras) {
+        String notificationBody = "";
+        if (extras.containsKey(IterableConstants.ITERABLE_DATA_KEY)) {
+            String iterableData = extras.getString(IterableConstants.ITERABLE_DATA_KEY);
+            notificationBody = extras.getString(IterableConstants.ITERABLE_DATA_BODY, "");
+        }
+
+        return notificationBody.isEmpty();
+    }
 }

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterablePushReceiver.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterablePushReceiver.java
@@ -45,7 +45,7 @@ public class IterablePushReceiver extends BroadcastReceiver{
     private void handlePushReceived(Context context, Intent intent) {
         if (intent.hasExtra(IterableConstants.ITERABLE_DATA_KEY)) {
             Bundle extras =  intent.getExtras();
-            if (!IterableNotification.isGhostPush(extras)) {
+            if (!IterableNotification.isGhostPush(extras) && !IterableNotification.isEmptyBody(extras)) {
                 IterableLogger.d(TAG, "Iterable push received " + extras);
                 Context appContext = context.getApplicationContext();
                 PackageManager packageManager = appContext.getPackageManager();

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterablePushReceiver.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterablePushReceiver.java
@@ -45,23 +45,27 @@ public class IterablePushReceiver extends BroadcastReceiver{
     private void handlePushReceived(Context context, Intent intent) {
         if (intent.hasExtra(IterableConstants.ITERABLE_DATA_KEY)) {
             Bundle extras =  intent.getExtras();
-            if (!IterableNotification.isGhostPush(extras) && !IterableNotification.isEmptyBody(extras)) {
-                IterableLogger.d(TAG, "Iterable push received " + extras);
-                Context appContext = context.getApplicationContext();
-                PackageManager packageManager = appContext.getPackageManager();
-                Intent packageIntent = packageManager.getLaunchIntentForPackage(appContext.getPackageName());
-                ComponentName componentPackageName = packageIntent.getComponent();
-                String mainClassName = componentPackageName.getClassName();
-                Class mainClass = null;
-                try {
-                    mainClass = Class.forName(mainClassName);
-                } catch (ClassNotFoundException e) {
-                    IterableLogger.w(TAG, e.toString());
-                }
+            if (!IterableNotification.isGhostPush(extras)) {
+                if (!IterableNotification.isEmptyBody(extras)) {
+                    IterableLogger.d(TAG, "Iterable push received " + extras);
+                    Context appContext = context.getApplicationContext();
+                    PackageManager packageManager = appContext.getPackageManager();
+                    Intent packageIntent = packageManager.getLaunchIntentForPackage(appContext.getPackageName());
+                    ComponentName componentPackageName = packageIntent.getComponent();
+                    String mainClassName = componentPackageName.getClassName();
+                    Class mainClass = null;
+                    try {
+                        mainClass = Class.forName(mainClassName);
+                    } catch (ClassNotFoundException e) {
+                        IterableLogger.w(TAG, e.toString());
+                    }
 
-                IterableNotification notificationBuilder = IterableNotification.createNotification(
-                        appContext, intent.getExtras(), mainClass);
-                new IterableNotificationBuilder().execute(notificationBuilder);
+                    IterableNotification notificationBuilder = IterableNotification.createNotification(
+                            appContext, intent.getExtras(), mainClass);
+                    new IterableNotificationBuilder().execute(notificationBuilder);
+                } else {
+                    IterableLogger.d(TAG, "Iterable OS notification push received");
+                }
             } else {
                 IterableLogger.d(TAG, "Iterable ghost silent push received");
             }


### PR DESCRIPTION
Updated the SDK to match the backend pushService. OS based notifications should not get rendered by the SDK when no body field is present in the data payload.