### PR TITLE
[ITBL-4495] Remove references to internal fields in NotificationCompat.Builder

### DIFF
--- a/iterableapi/src/androidTest/java/com/iterable/iterableapi/IterableNotificationTest.java
+++ b/iterableapi/src/androidTest/java/com/iterable/iterableapi/IterableNotificationTest.java
@@ -1,6 +1,7 @@
 package com.iterable.iterableapi;
 
 import android.app.Application;
+import android.app.Notification;
 import android.app.NotificationManager;
 import android.content.Context;
 import android.os.Build;
@@ -65,7 +66,7 @@ public class IterableNotificationTest extends ApplicationTestCase<Application> {
 
         IterableNotificationBuilder iterableNotification = IterableNotificationBuilder.createNotification(getContext(), notif, Application.class);
         IterableNotificationBuilder.postNotificationOnDevice(appContext, iterableNotification);
-        assertEquals("IterableAPI", iterableNotification.mContentTitle);
+        assertEquals("IterableAPI", iterableNotification.build().extras.getString(Notification.EXTRA_TITLE));
 //        It looks like mNotificationManager.notify(iterableNotification.requestCode, iterableNotification.build());
 //        is the culprit here for the flaky tests. This thread is spun up by the android system. Unless we do dependency injection and mock the notificationManager, it'll be hard to make this unflake.
         Thread.sleep(1000);
@@ -84,7 +85,7 @@ public class IterableNotificationTest extends ApplicationTestCase<Application> {
 
         IterableNotificationBuilder iterableNotification = IterableNotificationBuilder.createNotification(getContext(), notif, Application.class);
         IterableNotificationBuilder.postNotificationOnDevice(appContext, iterableNotification);
-        assertEquals("IterableAPI", iterableNotification.mContentTitle);
+        assertEquals("IterableAPI", iterableNotification.build().extras.getString(Notification.EXTRA_TITLE));
 //        It looks like mNotificationManager.notify(iterableNotification.requestCode, iterableNotification.build());
 //        is the culprit here for the flaky tests. This thread is spun up by the android system. Unless we do dependency injection and mock the notificationManager, it'll be hard to make this unflake.
         Thread.sleep(100);

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableNotificationBuilder.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableNotificationBuilder.java
@@ -64,6 +64,8 @@ public class IterableNotificationBuilder extends NotificationCompat.Builder {
      * Download any optional images
      */
     public Notification build() {
+        NotificationCompat.Style style = null;
+
         if (this.imageUrl != null) {
             try {
                 URL url = new URL(this.imageUrl);
@@ -72,9 +74,9 @@ public class IterableNotificationBuilder extends NotificationCompat.Builder {
                 connection.connect();
                 Bitmap notificationImage = BitmapFactory.decodeStream(connection.getInputStream());
                 if (notificationImage != null) {
-                    this.setStyle(new NotificationCompat.BigPictureStyle()
+                    style = new NotificationCompat.BigPictureStyle()
                             .bigPicture(notificationImage)
-                            .setSummaryText(expandedContent));
+                            .setSummaryText(expandedContent);
                 } else {
                     IterableLogger.e(TAG, "Notification image could not be loaded from url: " + this.imageUrl);
                 }
@@ -86,9 +88,11 @@ public class IterableNotificationBuilder extends NotificationCompat.Builder {
         }
 
         //Sets the default BigTextStyle if the imageUrl isn't set or cannot be loaded.
-        if (this.mStyle == null) {
-            this.setStyle(new NotificationCompat.BigTextStyle().bigText(expandedContent));
+        if (style == null) {
+            style = new NotificationCompat.BigTextStyle().bigText(expandedContent);
         }
+
+        this.setStyle(style);
 
         return super.build();
     }


### PR DESCRIPTION
For compatibility with support library version 27.