### PR TITLE
[ITBL-5183] Refactor SDK initialization

### DIFF
--- a/iterableapi/src/androidTest/java/com/iterable/iterableapi/IterableTestUtils.java
+++ b/iterableapi/src/androidTest/java/com/iterable/iterableapi/IterableTestUtils.java
@@ -11,7 +11,11 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class IterableTestUtils {
-    public static void createIterableApi() {
+    public static void legacyInitIterableApi() {
         IterableApi.sharedInstanceWithApiKey(InstrumentationRegistry.getTargetContext(), "fake_key", "test_email");
+    }
+
+    public static void initIterableApi(IterableConfig config) {
+        IterableApi.initialize(InstrumentationRegistry.getTargetContext(), "fake_key", config);
     }
 }

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableActionRunner.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableActionRunner.java
@@ -24,6 +24,11 @@ class IterableActionRunner {
             return false;
         }
 
+        // Do not handle actions and try to open URLs unless the SDK is initialized with a new init method
+        if (IterableApi.sharedInstance.sdkCompatEnabled) {
+            return false;
+        }
+
         if (action.isOfType(IterableAction.ACTION_TYPE_OPEN_URL)) {
             return openUri(context, Uri.parse(action.getData()), action);
         } else {
@@ -42,8 +47,8 @@ class IterableActionRunner {
      * `false` if the handler did not handle this URL and no activity was found to open it with
      */
     private static boolean openUri(@NonNull Context context, @NonNull Uri uri, @NonNull IterableAction action) {
-        if (IterableApi.sharedInstance.urlHandler != null) {
-            if (IterableApi.sharedInstance.urlHandler.handleIterableURL(uri, action)) {
+        if (IterableApi.sharedInstance.config.urlHandler != null) {
+            if (IterableApi.sharedInstance.config.urlHandler.handleIterableURL(uri, action)) {
                 return true;
             }
         }
@@ -83,8 +88,8 @@ class IterableActionRunner {
     private static boolean callCustomActionIfSpecified(@NonNull IterableAction action) {
         if (action.getType() != null && !action.getType().isEmpty()) {
             // Call custom action handler
-            if (IterableApi.sharedInstance.customActionHandler != null) {
-                return IterableApi.sharedInstance.customActionHandler.handleIterableCustomAction(action);
+            if (IterableApi.sharedInstance.config.customActionHandler != null) {
+                return IterableApi.sharedInstance.config.customActionHandler.handleIterableCustomAction(action);
             }
         }
         return false;

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
@@ -1,6 +1,7 @@
 package com.iterable.iterableapi;
 
 import android.app.Activity;
+import android.app.Application;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
@@ -40,14 +41,14 @@ public class IterableApi {
     public static final IterableApi sharedInstance = new IterableApi();
 
     private Context _applicationContext;
+    IterableConfig config;
+    boolean sdkCompatEnabled;
     private String _apiKey;
     private String _email;
     private String _userId;
     private boolean _debugMode;
     private Bundle _payloadData;
     private IterableNotificationData _notificationData;
-    IterableUrlHandler urlHandler;
-    IterableCustomActionHandler customActionHandler;
 
     private static Pattern deeplinkPattern = Pattern.compile(IterableConstants.ITBL_DEEPLINK_IDENTIFIER);
 
@@ -57,6 +58,7 @@ public class IterableApi {
 //region Constructor
 //---------------------------------------------------------------------------------------
     IterableApi(){
+        config = new IterableConfig.Builder().build();
     }
 
 //---------------------------------------------------------------------------------------
@@ -82,22 +84,6 @@ public class IterableApi {
      */
     public String getPayloadData(String key) {
         return (_payloadData != null) ? _payloadData.getString(key, null): null;
-    }
-
-    /**
-     * Set a custom URL handler to override openUrl actions
-     * @param urlHandler Custom URL handler provided by the app
-     */
-    public void setUrlHandler(IterableUrlHandler urlHandler) {
-        this.urlHandler = urlHandler;
-    }
-
-    /**
-     * Set an action handler for custom actions
-     * @param customActionHandler Custom action handler provided by the app
-     */
-    public void setCustomActionHandler(IterableCustomActionHandler customActionHandler) {
-        this.customActionHandler = customActionHandler;
     }
 
     /**
@@ -157,13 +143,49 @@ public class IterableApi {
 
 //region Public Functions
 //---------------------------------------------------------------------------------------
+
+    /**
+     * Initializes IterableApi
+     * This method must be called from {@link Application#onCreate()}
+     * Note: Make sure you also call {@link #setEmail(String)} or {@link #setUserId(String)} before calling other methods
+     *
+     * @param context Application context
+     * @param apiKey Iterable Mobile API key
+     */
+    public static void initialize(Context context, String apiKey) {
+        initialize(context, apiKey, null);
+    }
+
+    /**
+     * Initializes IterableApi
+     * This method must be called from {@link Application#onCreate()}
+     * Note: Make sure you also call {@link #setEmail(String)} or {@link #setUserId(String)} before calling other methods
+     *
+     * @param context Application context
+     * @param apiKey Iterable Mobile API key
+     * @param config {@link IterableConfig} object holding SDK configuration options
+     */
+    public static void initialize(Context context, String apiKey, IterableConfig config) {
+        sharedInstance._applicationContext = context.getApplicationContext();
+        sharedInstance._apiKey = apiKey;
+        sharedInstance.config = config;
+
+        if (sharedInstance.config == null) {
+            sharedInstance.config = new IterableConfig.Builder().build();
+        }
+        sharedInstance.sdkCompatEnabled = false;
+    }
+
     /**
      * Returns a shared instance of IterableApi. Updates the client data if an instance already exists.
      * Should be called whenever the app is opened.
      * @param currentActivity The current activity
      * @param userId The current userId
      * @return stored instance of IterableApi
+     *
+     * @deprecated Initialize the SDK with {@link #initialize(Context, String, IterableConfig)} instead
      */
+    @Deprecated
     public static IterableApi sharedInstanceWithApiKeyWithUserId(Activity currentActivity, String apiKey,
                                                                  String userId)
     {
@@ -175,9 +197,11 @@ public class IterableApi {
      * Should be called whenever the app is opened.
      * Allows the IterableApi to be intialized with debugging enabled
      * @param currentActivity The current activity
-     * @param userId
-     * The current userId@return stored instance of IterableApi
+     * @param userId The current userId@return stored instance of IterableApi
+     *
+     * @deprecated Initialize the SDK with {@link #initialize(Context, String, IterableConfig)} instead
      */
+    @Deprecated
     public static IterableApi sharedInstanceWithApiKeyWithUserId(Activity currentActivity, String apiKey,
                                                                  String userId, boolean debugMode)
     {
@@ -190,7 +214,10 @@ public class IterableApi {
      * @param currentContext The current context
      * @param userId The current userId
      * @return stored instance of IterableApi
+     *
+     * @deprecated Initialize the SDK with {@link #initialize(Context, String, IterableConfig)} instead
      */
+    @Deprecated
     public static IterableApi sharedInstanceWithApiKeyWithUserId(Context currentContext, String apiKey,
                                                                  String userId)
     {
@@ -203,7 +230,10 @@ public class IterableApi {
      * Allows the IterableApi to be intialized with debugging enabled
      * @param currentContext The current context
      * @return stored instance of IterableApi
+     *
+     * @deprecated Initialize the SDK with {@link #initialize(Context, String, IterableConfig)} instead
      */
+    @Deprecated
     public static IterableApi sharedInstanceWithApiKeyWithUserId(Context currentContext, String apiKey,
                                                                  String userId, boolean debugMode)
     {
@@ -216,7 +246,10 @@ public class IterableApi {
      * @param currentActivity The current activity
      * @param email The current email
      * @return stored instance of IterableApi
+     *
+     * @deprecated Initialize the SDK with {@link #initialize(Context, String, IterableConfig)} instead
      */
+    @Deprecated
     public static IterableApi sharedInstanceWithApiKey(Activity currentActivity, String apiKey,
                                                        String email)
     {
@@ -231,6 +264,7 @@ public class IterableApi {
      * @param email The current email
      * @return stored instance of IterableApi
      */
+    @Deprecated
     public static IterableApi sharedInstanceWithApiKey(Activity currentActivity, String apiKey,
                                                        String email, boolean debugMode)
     {
@@ -243,7 +277,10 @@ public class IterableApi {
      * @param currentContext The current context
      * @param email The current email
      * @return stored instance of IterableApi
+     *
+     * @deprecated Initialize the SDK with {@link #initialize(Context, String, IterableConfig)} instead
      */
+    @Deprecated
     public static IterableApi sharedInstanceWithApiKey(Context currentContext, String apiKey,
                                                        String email)
     {
@@ -257,7 +294,10 @@ public class IterableApi {
      * @param currentContext The current context
      * @param email The current email
      * @return stored instance of IterableApi
+     *
+     * @deprecated Initialize the SDK with {@link #initialize(Context, String, IterableConfig)} instead
      */
+    @Deprecated
     public static IterableApi sharedInstanceWithApiKey(Context currentContext, String apiKey,
                                                        String email, boolean debugMode)
     {
@@ -269,8 +309,56 @@ public class IterableApi {
     {
         sharedInstance.updateData(currentContext.getApplicationContext(), apiKey, email, userId);
         sharedInstance.setDebugMode(debugMode);
+        sharedInstance.sdkCompatEnabled = true;
 
         return sharedInstance;
+    }
+
+    /**
+     * Set user email used for API calls
+     * Calling this or `setUserId:` is required before making any API calls.
+     *
+     * Note: This clears userId and persists the user email so you only need to call this once when the user logs in.
+     * @param email User email
+     */
+    public void setEmail(String email) {
+        _email = email;
+        _userId = null;
+        storeEmailAndUserId();
+    }
+
+    /**
+     * Set user ID used for API calls
+     * Calling this or `setEmail:` is required before making any API calls.
+     *
+     * Note: This clears user email and persists the user ID so you only need to call this once when the user logs in.
+     * @param userId User ID
+     */
+    public void setUserId(String userId) {
+        _email = null;
+        _userId = userId;
+        storeEmailAndUserId();
+    }
+
+    private void storeEmailAndUserId() {
+        try {
+            SharedPreferences.Editor editor = getPreferences().edit();
+            editor.putString(IterableConstants.SHARED_PREFS_EMAIL_KEY, _email);
+            editor.putString(IterableConstants.SHARED_PREFS_USERID_KEY, _userId);
+            editor.commit();
+        } catch (Exception e) {
+            IterableLogger.e(TAG, "Error while persisting email/userId", e);
+        }
+    }
+
+    private void retrieveEmailAndUserId() {
+        try {
+            SharedPreferences prefs = getPreferences();
+            _email = prefs.getString(IterableConstants.SHARED_PREFS_EMAIL_KEY, null);
+            _userId = prefs.getString(IterableConstants.SHARED_PREFS_USERID_KEY, null);
+        } catch (Exception e) {
+            IterableLogger.e(TAG, "Error while retrieving email/userId", e);
+        }
     }
 
     /**
@@ -304,7 +392,7 @@ public class IterableApi {
     /**
      * Call onNewIntent to set the payload data and track pushOpens directly if
      * sharedInstanceWithApiKey was called with a Context rather than an Activity.
-     * DEPRECATED: Push opens are now tracked automatically.
+     * @deprecated Push opens are now tracked automatically.
      */
     @Deprecated
     public void onNewIntent(Intent intent) {
@@ -324,9 +412,20 @@ public class IterableApi {
 
     /**
      * Registers a device token with Iterable.
+     * @param token Push token obtained from GCM or FCM
+     */
+    public void registerDeviceToken(String token) {
+        registerDeviceToken(config.pushIntegrationName, token);
+    }
+
+    /**
+     * Registers a device token with Iterable.
      * @param applicationName
      * @param token
+     * @deprecated Call {@link #registerDeviceToken(String)} instead and specify the push
+     * integration name in {@link IterableConfig#pushIntegrationName}
      */
+    @Deprecated
     public void registerDeviceToken(String applicationName, String token) {
         registerDeviceToken(applicationName, token, null);
     }
@@ -336,7 +435,10 @@ public class IterableApi {
      * @param applicationName
      * @param token
      * @param pushServicePlatform
+     * @deprecated Call {@link #registerDeviceToken(String)} instead and specify the push
+     * integration name in {@link IterableConfig#pushIntegrationName}
      */
+    @Deprecated
     public void registerDeviceToken(final String applicationName, final String token, final String pushServicePlatform) {
         if (token != null) {
             new Thread(new Runnable() {
@@ -382,6 +484,10 @@ public class IterableApi {
      * @param dataFields
      */
     public void track(String eventName, int campaignId, int templateId, JSONObject dataFields) {
+        if (!checkSDKInitialization()) {
+            return;
+        }
+
         JSONObject requestJSON = new JSONObject();
         try {
             addEmailOrUserIdToJson(requestJSON);
@@ -414,6 +520,10 @@ public class IterableApi {
      * @param dataFields a `JSONObject` containing any additional information to save along with the event
      */
     public void trackPurchase(double total, List<CommerceItem> items, JSONObject dataFields) {
+        if (!checkSDKInitialization()) {
+            return;
+        }
+
         JSONObject requestJSON = new JSONObject();
         try {
             JSONArray itemsArray = new JSONArray();
@@ -469,6 +579,10 @@ public class IterableApi {
      *               Format is YYYY-MM-DD HH:MM:SS in UTC
      */
     public void sendPush(String email, int campaignId, Date sendAt, JSONObject dataFields) {
+        if (!checkSDKInitialization()) {
+            return;
+        }
+
         JSONObject requestJSON = new JSONObject();
 
         try {
@@ -513,7 +627,7 @@ public class IterableApi {
             }
         } else {
             IterableLogger.w(TAG, "updateEmail should not be called with a userId. " +
-                "Init SDK with sharedInstanceWithApiKey instead of sharedInstanceWithApiKeyWithUserId");
+                "Make sure you call setEmail(String) before trying to update it");
         }
     }
 
@@ -522,6 +636,10 @@ public class IterableApi {
      * @param dataFields
      */
     public void updateUser(JSONObject dataFields) {
+        if (!checkSDKInitialization()) {
+            return;
+        }
+
         JSONObject requestJSON = new JSONObject();
 
         try {
@@ -583,6 +701,10 @@ public class IterableApi {
      * @param unsubscribedMessageTypeIds
      */
     public void updateSubscriptions(Integer[] emailListIds, Integer[] unsubscribedChannelIds, Integer[] unsubscribedMessageTypeIds) {
+        if (!checkSDKInitialization()) {
+            return;
+        }
+
         JSONObject requestJSON = new JSONObject();
         addEmailOrUserIdToJson(requestJSON);
 
@@ -615,6 +737,10 @@ public class IterableApi {
      * @param clickCallback
      */
     public void spawnInAppNotification(final Context context, final IterableHelper.IterableActionHandler clickCallback) {
+        if (!checkSDKInitialization()) {
+            return;
+        }
+
         getInAppMessages(1, new IterableHelper.IterableActionHandler(){
             @Override
             public void execute(String payload) {
@@ -649,6 +775,10 @@ public class IterableApi {
      * @param onCallback
      */
     public void getInAppMessages(int count, IterableHelper.IterableActionHandler onCallback) {
+        if (!checkSDKInitialization()) {
+            return;
+        }
+
         JSONObject requestJSON = new JSONObject();
         addEmailOrUserIdToJson(requestJSON);
         try {
@@ -669,6 +799,10 @@ public class IterableApi {
      * @param messageId
      */
     public void trackInAppOpen(String messageId) {
+        if (!checkSDKInitialization()) {
+            return;
+        }
+
         JSONObject requestJSON = new JSONObject();
 
         try {
@@ -688,6 +822,10 @@ public class IterableApi {
      * @param urlClick
      */
     public void trackInAppClick(String messageId, String urlClick) {
+        if (!checkSDKInitialization()) {
+            return;
+        }
+
         JSONObject requestJSON = new JSONObject();
 
         try {
@@ -707,6 +845,10 @@ public class IterableApi {
      * @param messageId
      */
     public void inAppConsume(String messageId) {
+        if (!checkSDKInitialization()) {
+            return;
+        }
+
         JSONObject requestJSON = new JSONObject();
 
         try {
@@ -804,6 +946,10 @@ public class IterableApi {
      * @param dataFields
      */
     protected void registerDeviceToken(String applicationName, String token, String pushServicePlatform, JSONObject dataFields) {
+        if (!checkSDKInitialization()) {
+            return;
+        }
+
         String platform = IterableConstants.MESSAGING_PLATFORM_GOOGLE;
 
         JSONObject requestJSON = new JSONObject();
@@ -856,6 +1002,22 @@ public class IterableApi {
         this._apiKey = apiKey;
         this._email = email;
         this._userId = userId;
+    }
+
+    private boolean isInitialized() {
+        return _apiKey != null && (_email != null || _userId != null);
+    }
+
+    private boolean checkSDKInitialization() {
+        if (!isInitialized()) {
+            IterableLogger.e(TAG, "Iterable SDK must be initialized with an API key and user email/userId before calling SDK methods");
+            return false;
+        }
+        return true;
+    }
+
+    private SharedPreferences getPreferences() {
+        return _applicationContext.getSharedPreferences(IterableConstants.SHARED_PREFS_FILE, Context.MODE_PRIVATE);
     }
 
     /**

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableConfig.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableConfig.java
@@ -1,0 +1,65 @@
+package com.iterable.iterableapi;
+
+/**
+ *
+ */
+public class IterableConfig {
+
+    /**
+     * Push integration name – used for token registration.
+     * Make sure the name of this integration matches the one set up in Iterable console.
+     */
+    final String pushIntegrationName;
+
+    /**
+     * Custom URL handler to override openUrl actions
+     */
+    final IterableUrlHandler urlHandler;
+
+    /**
+     * Action handler for custom actions
+     */
+    final IterableCustomActionHandler customActionHandler;
+
+    private IterableConfig(Builder builder) {
+        pushIntegrationName = builder.pushIntegrationName;
+        urlHandler = builder.urlHandler;
+        customActionHandler = builder.customActionHandler;
+    }
+
+    public static class Builder {
+        private String pushIntegrationName;
+        private IterableUrlHandler urlHandler;
+        private IterableCustomActionHandler customActionHandler;
+
+        public Builder() {}
+
+        public Builder setPushIntegrationName(String pushIntegrationName) {
+            this.pushIntegrationName = pushIntegrationName;
+            return this;
+        }
+
+        /**
+         * Set a custom URL handler to override openUrl actions
+         * @param urlHandler Custom URL handler provided by the app
+         */
+        public Builder setUrlHandler(IterableUrlHandler urlHandler) {
+            this.urlHandler = urlHandler;
+            return this;
+        }
+
+        /**
+         * Set an action handler for custom actions
+         * @param customActionHandler Custom action handler provided by the app
+         */
+        public Builder setCustomActionHandler(IterableCustomActionHandler customActionHandler) {
+            this.customActionHandler = customActionHandler;
+            return this;
+        }
+
+        public IterableConfig build() {
+            return new IterableConfig(this);
+        }
+    }
+
+}

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableConstants.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableConstants.java
@@ -72,6 +72,11 @@ public final class IterableConstants {
     public static final String ITERABLE_DATA_ACTION_BUTTONS  = "actionButtons";
     public static final String ITERABLE_DATA_DEFAULT_ACTION  = "defaultAction";
 
+    //SharedPreferences keys
+    public static final String SHARED_PREFS_FILE = "com.iterable.iterableapi";
+    public static final String SHARED_PREFS_EMAIL_KEY = "itbl_email";
+    public static final String SHARED_PREFS_USERID_KEY = "itbl_userid";
+
     //Action buttons
     public static final String ITBL_BUTTON_IDENTIFIER        = "identifier";
     public static final String ITBL_BUTTON_TYPE              = "buttonType";


### PR DESCRIPTION
- Introduce a new method for initialization, decouple setEmail/setUserId from SDK initialization
- Persist email/userId so the app only has to call it when the user logs in or logs out
- Specify push integration name in IterableConfig
- Deprecate old methods
- Make sure we only switch to the new behavior (like opening push links by default) when the SDK is initialized with the new method