### PR TITLE
[ITBL-4563] Extract redirect handing code from IterableRequest

### DIFF
--- a/iterableapi/src/androidTest/java/com/iterable/iterableapi/IterableApiDeeplinkTest.java
+++ b/iterableapi/src/androidTest/java/com/iterable/iterableapi/IterableApiDeeplinkTest.java
@@ -1,6 +1,7 @@
 package com.iterable.iterableapi;
 
 import android.app.Application;
+import android.os.Looper;
 import android.test.ApplicationTestCase;
 
 import java.util.concurrent.CountDownLatch;
@@ -13,8 +14,6 @@ public class IterableApiDeeplinkTest extends ApplicationTestCase<Application> {
     public IterableApiDeeplinkTest() {
         super(Application.class);
     }
-
-    public final String ITERABLE_BAD_UUID_REQUEST     = "bad uuid";
 
     @Override
     public void setUp() {
@@ -55,6 +54,7 @@ public class IterableApiDeeplinkTest extends ApplicationTestCase<Application> {
                 public void execute(String result) {
                     assertFalse(result.equalsIgnoreCase(requestString));
                     assertEquals(redirectString, result);
+                    assertTrue("Callback is called on the main thread", Looper.getMainLooper().getThread() == Thread.currentThread());
                     signal.countDown();
                 }
             };
@@ -192,12 +192,10 @@ public class IterableApiDeeplinkTest extends ApplicationTestCase<Application> {
         try {
             final String userId = "xxx";
             final String requestString = "http://links.iterable.com/a/"+userId+"?_e=email&_m=123";
-            final String badUuid = ITERABLE_BAD_UUID_REQUEST + " " + userId;
             IterableHelper.IterableActionHandler clickCallback = new IterableHelper.IterableActionHandler() {
                 @Override
                 public void execute(String result) {
-                    assertFalse(requestString.equalsIgnoreCase(result));
-                    assertEquals(badUuid, result);
+                    assertTrue(requestString.equalsIgnoreCase(result));
                     signal.countDown();
                 }
             };
@@ -216,7 +214,7 @@ public class IterableApiDeeplinkTest extends ApplicationTestCase<Application> {
             IterableHelper.IterableActionHandler clickCallback = new IterableHelper.IterableActionHandler() {
                 @Override
                 public void execute(String result) {
-                    assertFalse(requestString.equalsIgnoreCase(result));
+                    assertTrue(requestString.equalsIgnoreCase(result));
                     signal.countDown();
                 }
             };

--- a/iterableapi/src/androidTest/java/com/iterable/iterableapi/IterableApiResponseTest.java
+++ b/iterableapi/src/androidTest/java/com/iterable/iterableapi/IterableApiResponseTest.java
@@ -235,24 +235,4 @@ public class IterableApiResponseTest {
         server.takeRequest(1, TimeUnit.SECONDS);
         assertTrue("onFailure is called", signal.await(1, TimeUnit.SECONDS));
     }
-
-    @Test
-    public void testRedirectRequest() throws Exception {
-        final CountDownLatch signal = new CountDownLatch(1);
-
-        MockResponse response = new MockResponse().setResponseCode(302).setHeader("Location", "https://www.example.com/testlink");
-        server.enqueue(response);
-
-        IterableApiRequest request = new IterableApiRequest("fake_key", server.url("").toString(), new JSONObject(), IterableApiRequest.REDIRECT, new IterableHelper.IterableActionHandler() {
-            @Override
-            public void execute(String data) {
-                assertEquals("https://www.example.com/testlink", data);
-                signal.countDown();
-            }
-        });
-        new IterableRequest().execute(request);
-
-        server.takeRequest(1, TimeUnit.SECONDS);
-        assertTrue("callback is called", signal.await(1, TimeUnit.SECONDS));
-    }
 }

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
@@ -50,8 +50,6 @@ public class IterableApi {
     private Bundle _payloadData;
     private IterableNotificationData _notificationData;
 
-    private static Pattern deeplinkPattern = Pattern.compile(IterableConstants.ITBL_DEEPLINK_IDENTIFIER);
-
 //---------------------------------------------------------------------------------------
 //endregion
 
@@ -377,17 +375,7 @@ public class IterableApi {
      *                   or the original url if it is not a interable link.
      */
     public static void getAndTrackDeeplink(String uri, IterableHelper.IterableActionHandler onCallback) {
-        if (uri != null) {
-            Matcher m = deeplinkPattern.matcher(uri);
-            if (m.find( )) {
-                IterableApiRequest request = new IterableApiRequest(null, uri, null, IterableApiRequest.REDIRECT, onCallback);
-                new IterableRequest().execute(request);
-            } else {
-                onCallback.execute(uri);
-            }
-        } else {
-            onCallback.execute(null);
-        }
+        IterableDeeplinkManager.getAndTrackDeeplink(uri, onCallback);
     }
 
     /**

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableDeeplinkManager.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableDeeplinkManager.java
@@ -11,6 +11,11 @@ class IterableDeeplinkManager {
 
     private static Pattern deeplinkPattern = Pattern.compile(IterableConstants.ITBL_DEEPLINK_IDENTIFIER);
 
+    /**
+     * Tracks a link click and passes the redirected URL to the callback
+     * @param url The URL that was clicked
+     * @param callback The callback to execute the original URL is retrieved
+     */
     static void getAndTrackDeeplink(String url, IterableHelper.IterableActionHandler callback) {
         if (url != null) {
             Matcher m = deeplinkPattern.matcher(url);

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableDeeplinkManager.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableDeeplinkManager.java
@@ -1,0 +1,76 @@
+package com.iterable.iterableapi;
+
+import android.os.AsyncTask;
+
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+class IterableDeeplinkManager {
+
+    private static Pattern deeplinkPattern = Pattern.compile(IterableConstants.ITBL_DEEPLINK_IDENTIFIER);
+
+    static void getAndTrackDeeplink(String url, IterableHelper.IterableActionHandler callback) {
+        if (url != null) {
+            Matcher m = deeplinkPattern.matcher(url);
+            if (m.find()) {
+                new RedirectTask(callback).execute(url);
+            } else {
+                callback.execute(url);
+            }
+        } else {
+            callback.execute(null);
+        }
+    }
+
+    private static class RedirectTask extends AsyncTask<String, Void, String> {
+        static final String TAG = "RedirectTask";
+        static final int DEFAULT_TIMEOUT_MS = 1000;   //1 seconds
+
+        private IterableHelper.IterableActionHandler callback;
+
+        RedirectTask(IterableHelper.IterableActionHandler callback) {
+            this.callback = callback;
+        }
+
+        @Override
+        protected String doInBackground(String... params) {
+            if (params == null || params.length == 0) {
+                return null;
+            }
+
+            String urlString = params[0];
+            HttpURLConnection urlConnection = null;
+
+            try {
+                URL url = new URL(urlString);
+                urlConnection = (HttpURLConnection) url.openConnection();
+                urlConnection.setReadTimeout(DEFAULT_TIMEOUT_MS);
+                urlConnection.setInstanceFollowRedirects(false);
+
+                int responseCode = urlConnection.getResponseCode();
+
+                if (responseCode >= 400) {
+                    IterableLogger.d(TAG, "Invalid Request for: " + urlString + ", returned code " + responseCode);
+                } else if (responseCode >= 300) {
+                    urlString = urlConnection.getHeaderField(IterableConstants.LOCATION_HEADER_FIELD);
+                }
+            } catch (Exception e) {
+                IterableLogger.e(TAG, e.getMessage());
+            } finally {
+                if (urlConnection != null) {
+                    urlConnection.disconnect();
+                }
+            }
+            return urlString;
+        }
+
+        @Override
+        protected void onPostExecute(String s) {
+            if (callback != null) {
+                callback.execute(s);
+            }
+        }
+    }
+}

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableRequest.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableRequest.java
@@ -71,11 +71,6 @@ class IterableRequest extends AsyncTask<IterableApiRequest, Void, String> {
 
                     url = new URL(builder.build().toString());
                     urlConnection = (HttpURLConnection) url.openConnection();
-                } else if (iterableApiRequest.requestType == IterableApiRequest.REDIRECT) {
-                    url = new URL(iterableApiRequest.resourcePath);
-                    urlConnection = (HttpURLConnection) url.openConnection();
-                    urlConnection.setReadTimeout(DEFAULT_TIMEOUT_MS);
-                    urlConnection.setInstanceFollowRedirects(false);
                 } else {
                     url = new URL(baseUrl + iterableApiRequest.resourcePath);
                     urlConnection = (HttpURLConnection) url.openConnection();
@@ -164,20 +159,6 @@ class IterableRequest extends AsyncTask<IterableApiRequest, Void, String> {
                 } else {
                     handleFailure("Received non-200 response: " + responseCode, jsonResponse);
                 }
-
-                if (iterableApiRequest.requestType == IterableApiRequest.REDIRECT) {
-                    if (responseCode >= 400) {
-                        // Return the response as it is
-                        IterableLogger.d(TAG, "Invalid Request for: " + iterableApiRequest.resourcePath);
-                        IterableLogger.d(TAG, requestResult);
-                    } else if (responseCode >= 300) {
-                        String newUrl = urlConnection.getHeaderField(IterableConstants.LOCATION_HEADER_FIELD);
-                        requestResult = newUrl;
-                    } else {
-                        //pass back original url
-                        requestResult = url.toString();
-                    }
-                }
             } catch (JSONException e) {
                 IterableLogger.e(TAG, e.getMessage());
                 handleFailure(e.getMessage(), null);
@@ -251,7 +232,6 @@ class IterableRequest extends AsyncTask<IterableApiRequest, Void, String> {
 class IterableApiRequest {
     static String GET = "GET";
     static String POST = "POST";
-    static String REDIRECT = "REDIRECT";
 
     String apiKey = "";
     String resourcePath = "";


### PR DESCRIPTION
**Changed:** getAndTrackDeeplink was previously returning the original app link URL (if the response is 302), the URL passed to it (if it's not an Iterable link), or the error message from the response body (if it returned with code >= 400). It only returns a URL now and doesn't return the error text in case of 400 errors, same as on iOS. Is it a desired change?