### PR TITLE
Set payload data onReceive

### DIFF
--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterablePushActionReceiver.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterablePushActionReceiver.java
@@ -80,6 +80,7 @@ public class IterablePushActionReceiver extends BroadcastReceiver {
         }
 
         // Automatic tracking
+        IterableApi.sharedInstance.setPayloadData(intent);
         IterableApi.sharedInstance.setNotificationData(notificationData);
         IterableApi.sharedInstance.trackPushOpen(notificationData.getCampaignId(), notificationData.getTemplateId(), notificationData.getMessageId(), dataFields);
 


### PR DESCRIPTION
`setPayloadData` was defined but wasn't being used. This makes sure to set the payload data on GCM messages