### PR TITLE
Add method to get all payload data

### DIFF
--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
@@ -24,6 +24,7 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.TimeZone;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -84,6 +85,27 @@ public class IterableApi {
      */
     public String getPayloadData(String key) {
         return (_payloadData != null) ? _payloadData.getString(key, null): null;
+    }
+
+    /**
+     * Retrieves all of the payload as a single JSON Object
+     * @return JSONObject
+     */
+
+    public JSONObject getPayloadData() {
+        JSONObject json = new JSONObject();
+        if (_payloadData == null) {
+            return json;
+        }
+        Set<String> keys = _payloadData.keySet();
+        try {
+            for (String key : keys) {
+                 json.put(key, _payloadData.get(key));
+            }
+        } catch(JSONException e) {
+            e.printStackTrace();
+        }
+        return json;
     }
 
     /**

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
@@ -24,7 +24,6 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.TimeZone;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -88,24 +87,12 @@ public class IterableApi {
     }
 
     /**
-     * Retrieves all of the payload as a single JSON Object
-     * @return JSONObject
+     * Retrieves all of the payload as a single Bundle Object
+     * @return Bundle
      */
 
-    public JSONObject getPayloadData() {
-        JSONObject json = new JSONObject();
-        if (_payloadData == null) {
-            return json;
-        }
-        Set<String> keys = _payloadData.keySet();
-        try {
-            for (String key : keys) {
-                 json.put(key, _payloadData.get(key));
-            }
-        } catch(JSONException e) {
-            e.printStackTrace();
-        }
-        return json;
+    public Bundle getPayloadData() {
+        return _payloadData;
     }
 
     /**


### PR DESCRIPTION
Adds a new method that returns all of payload as a JSONObject. It handles JSON errors the same way other methods do in this file.

Context: https://github.com/Iterable/iterable-android-sdk/pull/50#issuecomment-408253595