### PR TITLE
[ITBL-6259] Deferred deep linking support

### DIFF
--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
@@ -1367,8 +1367,11 @@ public class IterableApi {
         IterableLogger.d(TAG, "handleDDL: " + response);
         try {
             MatchFpResponse matchFpResponse = MatchFpResponse.fromJSONObject(response);
-            IterableAction action = IterableAction.actionOpenUrl(matchFpResponse.destinationUrl);
-            IterableActionRunner.executeAction(getMainActivityContext(), action, IterableActionSource.APP_LINK);
+
+            if (matchFpResponse.isMatch) {
+                IterableAction action = IterableAction.actionOpenUrl(matchFpResponse.destinationUrl);
+                IterableActionRunner.executeAction(getMainActivityContext(), action, IterableActionSource.APP_LINK);
+            }
         } catch (JSONException e) {
             IterableLogger.e(TAG, "Error while handling deferred deep link", e);
         }

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableConfig.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableConfig.java
@@ -34,12 +34,19 @@ public class IterableConfig {
      */
     final String legacyGCMSenderId;
 
+    /**
+     * When set to true, it will check for deferred deep links on first time app launch
+     * after installation.
+     */
+    final boolean checkForDeferredDeeplink;
+
     private IterableConfig(Builder builder) {
         pushIntegrationName = builder.pushIntegrationName;
         urlHandler = builder.urlHandler;
         customActionHandler = builder.customActionHandler;
         autoPushRegistration = builder.autoPushRegistration;
         legacyGCMSenderId = builder.legacyGCMSenderId;
+        checkForDeferredDeeplink = builder.checkForDeferredDeeplink;
     }
 
     public static class Builder {
@@ -48,6 +55,7 @@ public class IterableConfig {
         private IterableCustomActionHandler customActionHandler;
         private boolean autoPushRegistration = true;
         private String legacyGCMSenderId;
+        private boolean checkForDeferredDeeplink;
 
         public Builder() {}
 
@@ -98,6 +106,16 @@ public class IterableConfig {
          */
         public Builder setLegacyGCMSenderId(String legacyGCMSenderId) {
             this.legacyGCMSenderId = legacyGCMSenderId;
+            return this;
+        }
+
+        /**
+         * When set to true, it will check for deferred deep links on first time app launch
+         * after installation.
+         * @param checkForDeferredDeeplink Enable deferred deep link checks on first launch
+         */
+        public Builder setCheckForDeferredDeeplink(boolean checkForDeferredDeeplink) {
+            this.checkForDeferredDeeplink = checkForDeferredDeeplink;
             return this;
         }
 

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableConstants.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableConstants.java
@@ -10,6 +10,10 @@ public final class IterableConstants {
     public static final String ACTION_PUSH_ACTION = "com.iterable.push.ACTION_PUSH_ACTION";
     public static final String ACTION_PUSH_REGISTRATION = "com.iterable.push.ACTION_PUSH_REGISTRATION";
 
+    //Hosts
+    public static final String BASE_URL_API = "https://api.iterable.com/api/";
+    public static final String BASE_URL_LINKS = "https://links.iterable.com/";
+
     //API Fields
     public static final String KEY_API_KEY              = "api_key";
     public static final String KEY_APPLICATION_NAME     = "applicationName";
@@ -49,6 +53,7 @@ public final class IterableConstants {
     public static final String ENDPOINT_UPDATE_USER             = "users/update";
     public static final String ENDPOINT_UPDATE_EMAIL            = "users/updateEmail";
     public static final String ENDPOINT_UPDATE_USER_SUBS        = "users/updateSubscriptions";
+    public static final String ENDPOINT_DDL_MATCH               = "a/matchFp";
 
     public static final String PUSH_APP_ID                      = "IterableAppId";
     public static final String PUSH_GCM_PROJECT_NUMBER          = "GCMProjectNumber";
@@ -77,6 +82,7 @@ public final class IterableConstants {
     public static final String SHARED_PREFS_EMAIL_KEY = "itbl_email";
     public static final String SHARED_PREFS_USERID_KEY = "itbl_userid";
     public static final String SHARED_PREFS_DEVICEID_KEY = "itbl_deviceid";
+    public static final String SHARED_PREFS_DDL_CHECKED_KEY = "itbl_ddl_checked";
     public static final String SHARED_PREFS_EXPIRATION_SUFFIX = "_expiration";
     public static final String SHARED_PREFS_OBJECT_SUFFIX = "_object";
     public static final String SHARED_PREFS_PAYLOAD_KEY = "itbl_payload";

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableRequest.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableRequest.java
@@ -58,10 +58,11 @@ class IterableRequest extends AsyncTask<IterableApiRequest, Void, String> {
             HttpURLConnection urlConnection = null;
 
             try {
-                String baseUrl = (overrideUrl != null && !overrideUrl.isEmpty()) ? overrideUrl : iterableBaseUrl;
-                if (iterableApiRequest.baseUrl != null) {
-                    baseUrl = iterableApiRequest.baseUrl;
+                String baseUrl = (iterableApiRequest.baseUrl != null && !iterableApiRequest.baseUrl.isEmpty()) ? iterableApiRequest.baseUrl : iterableBaseUrl;
+                if (overrideUrl != null && !overrideUrl.isEmpty()) {
+                    baseUrl = overrideUrl;
                 }
+
                 if (iterableApiRequest.requestType == IterableApiRequest.GET) {
                     Uri.Builder builder = Uri.parse(baseUrl+iterableApiRequest.resourcePath).buildUpon();
                     builder.appendQueryParameter(IterableConstants.KEY_API_KEY, iterableApiRequest.apiKey);

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableRequest.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableRequest.java
@@ -59,6 +59,9 @@ class IterableRequest extends AsyncTask<IterableApiRequest, Void, String> {
 
             try {
                 String baseUrl = (overrideUrl != null && !overrideUrl.isEmpty()) ? overrideUrl : iterableBaseUrl;
+                if (iterableApiRequest.baseUrl != null) {
+                    baseUrl = iterableApiRequest.baseUrl;
+                }
                 if (iterableApiRequest.requestType == IterableApiRequest.GET) {
                     Uri.Builder builder = Uri.parse(baseUrl+iterableApiRequest.resourcePath).buildUpon();
                     builder.appendQueryParameter(IterableConstants.KEY_API_KEY, iterableApiRequest.apiKey);
@@ -234,6 +237,7 @@ class IterableApiRequest {
     static String POST = "POST";
 
     String apiKey = "";
+    String baseUrl = null;
     String resourcePath = "";
     JSONObject json;
     String requestType = "";
@@ -241,6 +245,16 @@ class IterableApiRequest {
     IterableHelper.IterableActionHandler legacyCallback;
     IterableHelper.SuccessHandler successCallback;
     IterableHelper.FailureHandler failureCallback;
+
+    public IterableApiRequest(String apiKey, String baseUrl, String resourcePath, JSONObject json, String requestType, IterableHelper.SuccessHandler onSuccess, IterableHelper.FailureHandler onFailure) {
+        this.apiKey = apiKey;
+        this.baseUrl = baseUrl;
+        this.resourcePath = resourcePath;
+        this.json = json;
+        this.requestType = requestType;
+        this.successCallback = onSuccess;
+        this.failureCallback = onFailure;
+    }
 
     public IterableApiRequest(String apiKey, String resourcePath, JSONObject json, String requestType, IterableHelper.SuccessHandler onSuccess, IterableHelper.FailureHandler onFailure) {
         this.apiKey = apiKey;

--- a/iterableapi/src/main/java/com/iterable/iterableapi/ddl/DeviceInfo.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/ddl/DeviceInfo.java
@@ -1,0 +1,86 @@
+package com.iterable.iterableapi.ddl;
+
+import android.content.Context;
+import android.os.Build;
+import android.util.DisplayMetrics;
+import android.view.Display;
+import android.view.WindowManager;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.Date;
+import java.util.Locale;
+import java.util.TimeZone;
+
+public class DeviceInfo {
+    String mobileDeviceType = "Android";
+    DeviceFp deviceFp;
+
+    private DeviceInfo(DeviceFp deviceFp) {
+        this.deviceFp = deviceFp;
+    }
+
+    static class DeviceFp {
+        String screenWidth;
+        String screenHeight;
+        String screenScale;
+        String version;
+        String timezoneOffsetMinutes;
+        String language;
+
+        JSONObject toJSONObject() throws JSONException {
+            JSONObject json = new JSONObject();
+            json.putOpt("screenWidth", screenWidth);
+            json.putOpt("screenHeight", screenHeight);
+            json.putOpt("screenScale", screenScale);
+            json.putOpt("version", version);
+            json.putOpt("timezoneOffsetMinutes", timezoneOffsetMinutes);
+            json.putOpt("language", language);
+            return json;
+        }
+    }
+
+    public static DeviceInfo createDeviceInfo(Context context) {
+        return new DeviceInfo(createDeviceFp(context));
+    }
+
+    private static DeviceFp createDeviceFp(Context context) {
+        DeviceFp fp = new DeviceFp();
+
+        WindowManager wm = (WindowManager) context.getSystemService(Context.WINDOW_SERVICE);
+        Display display = wm.getDefaultDisplay();
+        DisplayMetrics displayMetrics = new DisplayMetrics();
+        if (Build.VERSION.SDK_INT >= 17) {
+            display.getRealMetrics(displayMetrics);
+        } else {
+            display.getMetrics(displayMetrics);
+        }
+        fp.screenWidth = Long.toString(Math.round(Math.ceil(displayMetrics.widthPixels / displayMetrics.density)));
+        fp.screenHeight = Long.toString(Math.round(Math.ceil(displayMetrics.heightPixels / displayMetrics.density)));
+        fp.screenScale = Float.toString(displayMetrics.density);
+
+        fp.version = Build.VERSION.RELEASE;
+
+        // We're comparing with Javascript timezone offset, which is the difference between the
+        // local time and UTC, so we need to flip the sign
+        TimeZone timezone = TimeZone.getDefault();
+        int seconds = -1 * timezone.getOffset(new Date().getTime()) / 1000;
+        int offsetMinutes = seconds / 60;
+        fp.timezoneOffsetMinutes = Integer.toString(offsetMinutes);
+
+        String countryCode = Locale.getDefault().getCountry();
+        String languageCode = Locale.getDefault().getLanguage();
+        fp.language = languageCode + "_" + countryCode;
+
+        return fp;
+    }
+
+    public JSONObject toJSONObject() throws JSONException {
+        JSONObject json = new JSONObject();
+        json.put("mobileDeviceType", mobileDeviceType);
+        json.put("deviceFp", deviceFp.toJSONObject());
+        return json;
+    }
+
+}

--- a/iterableapi/src/main/java/com/iterable/iterableapi/ddl/MatchFpResponse.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/ddl/MatchFpResponse.java
@@ -1,0 +1,30 @@
+package com.iterable.iterableapi.ddl;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+public class MatchFpResponse {
+    public final boolean isMatch;
+    public final String destinationUrl;
+    public final int campaignId;
+    public final int templateId;
+    public final String messageId;
+
+    public MatchFpResponse(boolean isMatch, String destinationUrl, int campaignId, int templateId, String messageId) {
+        this.isMatch = isMatch;
+        this.destinationUrl = destinationUrl;
+        this.campaignId = campaignId;
+        this.templateId = templateId;
+        this.messageId = messageId;
+    }
+
+    public static MatchFpResponse fromJSONObject(JSONObject json) throws JSONException {
+        return new MatchFpResponse(
+                json.getBoolean("isMatch"),
+                json.getString("destinationUrl"),
+                json.getInt("campaignId"),
+                json.getInt("templateId"),
+                json.getString("messageId")
+        );
+    }
+}

--- a/iterableapi/src/test/java/com/iterable/iterableapi/DeferredDeepLinkTest.java
+++ b/iterableapi/src/test/java/com/iterable/iterableapi/DeferredDeepLinkTest.java
@@ -1,0 +1,110 @@
+package com.iterable.iterableapi;
+
+import android.net.Uri;
+
+import com.iterable.iterableapi.unit.BaseTest;
+import com.iterable.iterableapi.unit.IterableTestUtils;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.robolectric.RuntimeEnvironment;
+
+import java.io.IOException;
+
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.after;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class DeferredDeepLinkTest extends BaseTest {
+
+    private MockWebServer server;
+
+    @Before
+    public void setUp() {
+        server = new MockWebServer();
+        IterableApi.overrideURLEndpointPath(server.url("").toString());
+        IterableApi.sharedInstance = new IterableApi();
+    }
+
+    @After
+    public void tearDown() throws IOException {
+        server.shutdown();
+        server = null;
+    }
+
+    @Test
+    public void testDDLCheckEnabled() throws Exception {
+        server.enqueue(new MockResponse().setBody(IterableTestUtils.getResourceString("fp_match_success.json")));
+
+        IterableUrlHandler urlHandlerMock = mock(IterableUrlHandler.class);
+        when(urlHandlerMock.handleIterableURL(any(Uri.class), any(IterableActionContext.class))).thenReturn(true);
+
+        IterableConfig config = new IterableConfig.Builder()
+                .setUrlHandler(urlHandlerMock)
+                .setCheckForDeferredDeeplink(true)
+                .build();
+        IterableApi.initialize(RuntimeEnvironment.application, "apiKey", config);
+
+        // Verify that IterableActionRunner was called with openUrl action
+        ArgumentCaptor<Uri> capturedUri = ArgumentCaptor.forClass(Uri.class);
+        ArgumentCaptor<IterableActionContext> capturedActionContext = ArgumentCaptor.forClass(IterableActionContext.class);
+        verify(urlHandlerMock, timeout(5000)).handleIterableURL(capturedUri.capture(), capturedActionContext.capture());
+        assertEquals("https://iterable.com", capturedUri.getValue().toString());
+        assertEquals(IterableActionSource.APP_LINK, capturedActionContext.getValue().source);
+        assertTrue(capturedActionContext.getValue().action.isOfType(IterableAction.ACTION_TYPE_OPEN_URL));
+
+        // Verify that the deferred deep link is only handled once per app install
+        server.enqueue(new MockResponse().setBody(IterableTestUtils.getResourceString("fp_match_success.json")));
+        reset(urlHandlerMock);
+        IterableApi.sharedInstance = new IterableApi();
+        IterableApi.initialize(RuntimeEnvironment.application, "apiKey", config);
+        verify(urlHandlerMock, after(100).never()).handleIterableURL(any(Uri.class), any(IterableActionContext.class));
+    }
+
+    @Test
+    public void testDDLCheckDisabled() throws Exception {
+        server.enqueue(new MockResponse().setBody(IterableTestUtils.getResourceString("fp_match_success.json")));
+
+        IterableUrlHandler urlHandlerMock = mock(IterableUrlHandler.class);
+        when(urlHandlerMock.handleIterableURL(any(Uri.class), any(IterableActionContext.class))).thenReturn(true);
+
+        IterableConfig config = new IterableConfig.Builder()
+                .setUrlHandler(urlHandlerMock)
+                .setCheckForDeferredDeeplink(false)
+                .build();
+        IterableApi.initialize(RuntimeEnvironment.application, "apiKey", config);
+
+        // Verify that the deferred deep link is never handled since it is disabled
+        verify(urlHandlerMock, after(100).never()).handleIterableURL(any(Uri.class), any(IterableActionContext.class));
+    }
+
+    @Test
+    public void testDDLCheckFailed() throws Exception {
+        server.enqueue(new MockResponse().setBody(IterableTestUtils.getResourceString("fp_match_fail.json")));
+
+        IterableUrlHandler urlHandlerMock = mock(IterableUrlHandler.class);
+        when(urlHandlerMock.handleIterableURL(any(Uri.class), any(IterableActionContext.class))).thenReturn(true);
+
+        IterableConfig config = new IterableConfig.Builder()
+                .setUrlHandler(urlHandlerMock)
+                .setCheckForDeferredDeeplink(true)
+                .build();
+        IterableApi.initialize(RuntimeEnvironment.application, "apiKey", config);
+
+        // Verify that the URL handler wasn't called because fingerprint matcher returned no result
+        verify(urlHandlerMock, after(100).never()).handleIterableURL(any(Uri.class), any(IterableActionContext.class));
+    }
+
+}

--- a/iterableapi/src/test/resources/fp_match_fail.json
+++ b/iterableapi/src/test/resources/fp_match_fail.json
@@ -1,0 +1,3 @@
+{
+  "isMatch": false
+}

--- a/iterableapi/src/test/resources/fp_match_success.json
+++ b/iterableapi/src/test/resources/fp_match_success.json
@@ -1,0 +1,7 @@
+{
+  "isMatch": true,
+  "destinationUrl": "https://iterable.com",
+  "campaignId": 1234,
+  "templateId": 4321,
+  "messageId": "abcd"
+}


### PR DESCRIPTION
- Added a new config option: `checkForDeferredDeeplink` to enable DDL
- Send a device fingerprint on first launch
- If matched, call the URL handler with the original link