### PR TITLE
[MOB-48] Pass email & userId to registerDeviceToken/disableToken calls to avoid concurrency issues

### DIFF
--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
@@ -519,6 +519,10 @@ public class IterableApi {
      */
     @Deprecated
     public void registerDeviceToken(final String applicationName, final String token, final String pushServicePlatform) {
+        registerDeviceToken(_email, _userId, applicationName, token, pushServicePlatform);
+    }
+
+    protected void registerDeviceToken(final String email, final String userId, final String applicationName, final String token, final String pushServicePlatform) {
         if (!IterableConstants.MESSAGING_PLATFORM_FIREBASE.equals(pushServicePlatform)) {
             IterableLogger.e(TAG, "registerDeviceToken: only MESSAGING_PLATFORM_FIREBASE is supported.");
             return;
@@ -527,7 +531,7 @@ public class IterableApi {
         if (token != null) {
             final Thread registrationThread = new Thread(new Runnable() {
                 public void run() {
-                    registerDeviceToken(applicationName, token, IterableConstants.MESSAGING_PLATFORM_FIREBASE, null);
+                    registerDeviceToken(email, userId, applicationName, token, IterableConstants.MESSAGING_PLATFORM_FIREBASE, null);
                 }
             });
 
@@ -770,7 +774,7 @@ public class IterableApi {
             return;
         }
 
-        IterablePushRegistrationData data = new IterablePushRegistrationData(config.pushIntegrationName, IterablePushRegistrationData.PushRegistrationAction.ENABLE);
+        IterablePushRegistrationData data = new IterablePushRegistrationData(_email, _userId, config.pushIntegrationName, IterablePushRegistrationData.PushRegistrationAction.ENABLE);
         new IterablePushRegistration().execute(data);
     }
 
@@ -801,7 +805,7 @@ public class IterableApi {
             return;
         }
 
-        IterablePushRegistrationData data = new IterablePushRegistrationData(pushIntegrationName, projectNumber, pushServicePlatform, IterablePushRegistrationData.PushRegistrationAction.ENABLE);
+        IterablePushRegistrationData data = new IterablePushRegistrationData(_email, _userId, pushIntegrationName, projectNumber, pushServicePlatform, IterablePushRegistrationData.PushRegistrationAction.ENABLE);
         new IterablePushRegistration().execute(data);
     }
 
@@ -813,7 +817,7 @@ public class IterableApi {
      */
     @Deprecated
     public void registerForPush(String pushIntegrationName) {
-        IterablePushRegistrationData data = new IterablePushRegistrationData(pushIntegrationName, IterablePushRegistrationData.PushRegistrationAction.ENABLE);
+        IterablePushRegistrationData data = new IterablePushRegistrationData(_email, _userId, pushIntegrationName, IterablePushRegistrationData.PushRegistrationAction.ENABLE);
         new IterablePushRegistration().execute(data);
     }
 
@@ -826,7 +830,7 @@ public class IterableApi {
             return;
         }
 
-        IterablePushRegistrationData data = new IterablePushRegistrationData(config.pushIntegrationName, IterablePushRegistrationData.PushRegistrationAction.DISABLE);
+        IterablePushRegistrationData data = new IterablePushRegistrationData(_email, _userId, config.pushIntegrationName, IterablePushRegistrationData.PushRegistrationAction.DISABLE);
         new IterablePushRegistration().execute(data);
     }
 
@@ -857,7 +861,7 @@ public class IterableApi {
             return;
         }
 
-        IterablePushRegistrationData data = new IterablePushRegistrationData(iterableAppId, projectNumber, pushServicePlatform, IterablePushRegistrationData.PushRegistrationAction.DISABLE);
+        IterablePushRegistrationData data = new IterablePushRegistrationData(_email, _userId, iterableAppId, projectNumber, pushServicePlatform, IterablePushRegistrationData.PushRegistrationAction.DISABLE);
         new IterablePushRegistration().execute(data);
     }
 
@@ -1111,19 +1115,23 @@ public class IterableApi {
         }
     }
 
-    protected void disableToken(String token) {
-        disableToken(token, null, null);
+    protected void disableToken(String email, String userId, String token) {
+        disableToken(email, userId, token, null, null);
     }
 
     /**
      * Internal api call made from IterablePushRegistration after a registrationToken is obtained.
      * @param token
      */
-    protected void disableToken(String token, IterableHelper.SuccessHandler onSuccess, IterableHelper.FailureHandler onFailure) {
+    protected void disableToken(String email, String userId, String token, IterableHelper.SuccessHandler onSuccess, IterableHelper.FailureHandler onFailure) {
         JSONObject requestJSON = new JSONObject();
         try {
             requestJSON.put(IterableConstants.KEY_TOKEN, token);
-            addEmailOrUserIdToJson(requestJSON);
+            if (email != null) {
+                requestJSON.put(IterableConstants.KEY_EMAIL, email);
+            } else {
+                requestJSON.put(IterableConstants.KEY_USER_ID, userId);
+            }
 
             sendPostRequest(IterableConstants.ENDPOINT_DISABLE_DEVICE, requestJSON, onSuccess, onFailure);
         }
@@ -1139,7 +1147,7 @@ public class IterableApi {
      * @param pushServicePlatform
      * @param dataFields
      */
-    protected void registerDeviceToken(String applicationName, String token, String pushServicePlatform, JSONObject dataFields) {
+    protected void registerDeviceToken(String email, String userId, String applicationName, String token, String pushServicePlatform, JSONObject dataFields) {
         if (!checkSDKInitialization()) {
             return;
         }

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterablePushRegistration.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterablePushRegistration.java
@@ -13,6 +13,7 @@ import org.json.JSONObject;
  */
 class IterablePushRegistration extends AsyncTask<IterablePushRegistrationData, Void, Void> {
     static final String TAG = "IterablePushRegistration";
+    IterablePushRegistrationData iterablePushRegistrationData;
 
     /**
      * Registers or disables the device
@@ -20,14 +21,23 @@ class IterablePushRegistration extends AsyncTask<IterablePushRegistrationData, V
      * @param params Push registration request data
      */
     protected Void doInBackground(IterablePushRegistrationData... params) {
-        IterablePushRegistrationData iterablePushRegistrationData = params[0];
+        iterablePushRegistrationData = params[0];
         if (iterablePushRegistrationData.pushIntegrationName != null) {
             PushRegistrationObject pushRegistrationObject = getDeviceToken();
             if (pushRegistrationObject != null) {
                 if (iterablePushRegistrationData.pushRegistrationAction == IterablePushRegistrationData.PushRegistrationAction.ENABLE) {
-                    IterableApi.sharedInstance.registerDeviceToken(iterablePushRegistrationData.pushIntegrationName, pushRegistrationObject.token);
+                    IterableApi.sharedInstance.registerDeviceToken(
+                            iterablePushRegistrationData.email,
+                            iterablePushRegistrationData.userId,
+                            iterablePushRegistrationData.pushIntegrationName,
+                            pushRegistrationObject.token,
+                            IterableConstants.MESSAGING_PLATFORM_FIREBASE);
+
                 } else if (iterablePushRegistrationData.pushRegistrationAction == IterablePushRegistrationData.PushRegistrationAction.DISABLE) {
-                    IterableApi.sharedInstance.disableToken(pushRegistrationObject.token);
+                    IterableApi.sharedInstance.disableToken(
+                            iterablePushRegistrationData.email,
+                            iterablePushRegistrationData.userId,
+                            pushRegistrationObject.token);
                 }
                 disableOldDeviceIfNeeded();
             }
@@ -79,7 +89,7 @@ class IterablePushRegistration extends AsyncTask<IterablePushRegistrationData, V
 
                     // We disable the device on Iterable but keep the token
                     if (oldToken != null) {
-                        IterableApi.sharedInstance.disableToken(oldToken, new IterableHelper.SuccessHandler() {
+                        IterableApi.sharedInstance.disableToken(iterablePushRegistrationData.email, iterablePushRegistrationData.userId, oldToken, new IterableHelper.SuccessHandler() {
                             @Override
                             public void onSuccess(JSONObject data) {
                                 sharedPref.edit().putBoolean(IterableConstants.SHARED_PREFS_FCM_MIGRATION_DONE_KEY, true).apply();

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterablePushRegistrationData.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterablePushRegistrationData.java
@@ -10,20 +10,26 @@ class IterablePushRegistrationData {
         DISABLE
     }
 
+    String email;
+    String userId;
     String pushIntegrationName;
     String projectNumber = "";
     String messagingPlatform = IterableConstants.MESSAGING_PLATFORM_FIREBASE;
     PushRegistrationAction pushRegistrationAction;
 
 
-    public IterablePushRegistrationData(String pushIntegrationName, String projectNumber, String messagingPlatform, PushRegistrationAction pushRegistrationAction){
+    public IterablePushRegistrationData(String email, String userId, String pushIntegrationName, String projectNumber, String messagingPlatform, PushRegistrationAction pushRegistrationAction){
+        this.email = email;
+        this.userId = userId;
         this.pushIntegrationName = pushIntegrationName;
         this.projectNumber = projectNumber;
         this.messagingPlatform = messagingPlatform;
         this.pushRegistrationAction = pushRegistrationAction;
     }
 
-    public IterablePushRegistrationData(String pushIntegrationName, PushRegistrationAction pushRegistrationAction) {
+    public IterablePushRegistrationData(String email, String userId, String pushIntegrationName, PushRegistrationAction pushRegistrationAction) {
+        this.email = email;
+        this.userId = userId;
         this.pushIntegrationName = pushIntegrationName;
         this.pushRegistrationAction = pushRegistrationAction;
     }

--- a/iterableapi/src/test/java/com/iterable/iterableapi/IterablePushRegistrationTest.java
+++ b/iterableapi/src/test/java/com/iterable/iterableapi/IterablePushRegistrationTest.java
@@ -19,6 +19,7 @@ import okhttp3.mockwebserver.MockWebServer;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -72,21 +73,22 @@ public class IterablePushRegistrationTest extends BaseTest {
     public void testEnableDevice() throws Exception {
         when(mockInstanceId.getToken()).thenReturn(TEST_TOKEN);
 
-        IterablePushRegistrationData data = new IterablePushRegistrationData(INTEGRATION_NAME, IterablePushRegistrationData.PushRegistrationAction.ENABLE);
+        IterablePushRegistrationData data = new IterablePushRegistrationData(IterableTestUtils.userEmail, null, INTEGRATION_NAME, IterablePushRegistrationData.PushRegistrationAction.ENABLE);
         new IterablePushRegistration().execute(data);
 
-        verify(apiMock, timeout(100)).registerDeviceToken(eq(INTEGRATION_NAME), eq(TEST_TOKEN));
-        verify(apiMock, never()).disableToken(any(String.class), nullable(IterableHelper.SuccessHandler.class), nullable(IterableHelper.FailureHandler.class));
+        verify(apiMock, timeout(100)).registerDeviceToken(eq(IterableTestUtils.userEmail), nullable(String.class), eq(INTEGRATION_NAME), eq(TEST_TOKEN), eq(IterableConstants.MESSAGING_PLATFORM_FIREBASE));
+        verify(apiMock, never()).disableToken(eq(IterableTestUtils.userEmail), nullable(String.class), any(String.class), nullable(IterableHelper.SuccessHandler.class), nullable(IterableHelper.FailureHandler.class));
     }
 
     @Test
     public void testDisableDevice() throws Exception {
         when(mockInstanceId.getToken()).thenReturn("testToken");
 
-        IterablePushRegistrationData data = new IterablePushRegistrationData(INTEGRATION_NAME, IterablePushRegistrationData.PushRegistrationAction.DISABLE);
+        IterablePushRegistrationData data = new IterablePushRegistrationData(IterableTestUtils.userEmail, null, INTEGRATION_NAME, IterablePushRegistrationData.PushRegistrationAction.DISABLE);
         new IterablePushRegistration().execute(data);
+        ShadowApplication.runBackgroundTasks();
 
-        verify(apiMock, timeout(100)).disableToken(eq(TEST_TOKEN));
+        verify(apiMock, timeout(100)).disableToken(eq(IterableTestUtils.userEmail), isNull(String.class), eq(TEST_TOKEN));
     }
 
     @Test
@@ -96,20 +98,20 @@ public class IterablePushRegistrationTest extends BaseTest {
         when(mockInstanceId.getToken()).thenReturn(NEW_TOKEN);
         when(mockInstanceId.getToken(eq(GCM_SENDER_ID), eq(IterableConstants.MESSAGING_PLATFORM_GOOGLE))).thenReturn(OLD_TOKEN);
 
-        IterablePushRegistrationData data = new IterablePushRegistrationData(INTEGRATION_NAME, IterablePushRegistrationData.PushRegistrationAction.ENABLE);
+        IterablePushRegistrationData data = new IterablePushRegistrationData(IterableTestUtils.userEmail, null, INTEGRATION_NAME, IterablePushRegistrationData.PushRegistrationAction.ENABLE);
         new IterablePushRegistration().execute(data);
         ShadowApplication.runBackgroundTasks();
 
         ArgumentCaptor<IterableHelper.SuccessHandler> successHandlerCaptor = ArgumentCaptor.forClass(IterableHelper.SuccessHandler.class);
-        verify(apiMock).registerDeviceToken(eq(INTEGRATION_NAME), eq(NEW_TOKEN));
-        verify(apiMock, times(1)).disableToken(eq(OLD_TOKEN), successHandlerCaptor.capture(), nullable(IterableHelper.FailureHandler.class));
+        verify(apiMock).registerDeviceToken(eq(IterableTestUtils.userEmail), isNull(String.class), eq(INTEGRATION_NAME), eq(NEW_TOKEN), eq(IterableConstants.MESSAGING_PLATFORM_FIREBASE));
+        verify(apiMock, times(1)).disableToken(eq(IterableTestUtils.userEmail), isNull(String.class), eq(OLD_TOKEN), successHandlerCaptor.capture(), nullable(IterableHelper.FailureHandler.class));
         successHandlerCaptor.getValue().onSuccess(new JSONObject());
 
         reset(apiMock);
 
         new IterablePushRegistration().execute(data);
-        verify(apiMock).registerDeviceToken(eq(INTEGRATION_NAME), eq(NEW_TOKEN));
-        verify(apiMock, never()).disableToken(any(String.class), nullable(IterableHelper.SuccessHandler.class), nullable(IterableHelper.FailureHandler.class));
+        verify(apiMock).registerDeviceToken(eq(IterableTestUtils.userEmail), isNull(String.class), eq(INTEGRATION_NAME), eq(NEW_TOKEN), eq(IterableConstants.MESSAGING_PLATFORM_FIREBASE));
+        verify(apiMock, never()).disableToken(eq(IterableTestUtils.userEmail), isNull(String.class), any(String.class), nullable(IterableHelper.SuccessHandler.class), nullable(IterableHelper.FailureHandler.class));
     }
 
 }

--- a/iterableapi/src/test/java/com/iterable/iterableapi/unit/IterableTestUtils.java
+++ b/iterableapi/src/test/java/com/iterable/iterableapi/unit/IterableTestUtils.java
@@ -17,8 +17,12 @@ import java.util.Iterator;
 import java.util.Map;
 
 public class IterableTestUtils {
+    public static final String apiKey = "fake_key";
+    public static final String userEmail = "test_email";
+
+
     public static void createIterableApi() {
-        IterableApi.sharedInstanceWithApiKey(RuntimeEnvironment.application, "fake_key", "test_email");
+        IterableApi.sharedInstanceWithApiKey(RuntimeEnvironment.application, apiKey, userEmail);
     }
 
     public static String getResourceString(String fileName) throws IOException {


### PR DESCRIPTION
Due to the asynchronous nature of device registration in the Android SDK, disableDevice actually gets handled after the new userId/email is already set. To make sure it is called with the correct email/userId, we should pass that directly.