### PR TITLE
[MOB-34] Use 'preferUserId' flag to create a user by userId instead of the old API

### DIFF
--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
@@ -534,22 +534,7 @@ public class IterableApi {
                     registerDeviceToken(email, userId, applicationName, token, IterableConstants.MESSAGING_PLATFORM_FIREBASE, null);
                 }
             });
-
-            if (getUserId() != null) {
-                createUserForUserId(new IterableHelper.SuccessHandler() {
-                    @Override
-                    public void onSuccess(JSONObject data) {
-                        registrationThread.start();
-                    }
-                }, new IterableHelper.FailureHandler() {
-                    @Override
-                    public void onFailure(String reason, JSONObject data) {
-                        IterableLogger.e(TAG, "Could not create user: " + reason);
-                    }
-                });
-            } else {
-                registrationThread.start();
-            }
+            registrationThread.start();
         }
     }
 
@@ -1191,6 +1176,11 @@ public class IterableApi {
             device.putOpt(IterableConstants.KEY_DATA_FIELDS, dataFields);
             requestJSON.put(IterableConstants.KEY_DEVICE, device);
 
+            // Create the user by userId if it doesn't exist
+            if (email == null && userId != null) {
+                requestJSON.put(IterableConstants.KEY_PREFER_USER_ID, true);
+            }
+
             sendPostRequest(IterableConstants.ENDPOINT_REGISTER_DEVICE_TOKEN, requestJSON);
         } catch (JSONException e) {
             IterableLogger.e(TAG, "registerDeviceToken: exception", e);
@@ -1400,25 +1390,6 @@ public class IterableApi {
             IterableLogger.e(TAG, "Error while handling deferred deep link", e);
         }
         setDDLChecked(true);
-    }
-
-    /**
-     * Creates a user profile for a userId if it does not yet exist.
-     */
-    private void createUserForUserId(IterableHelper.SuccessHandler onSuccess, IterableHelper.FailureHandler onFailure) {
-        if (!checkSDKInitialization() || _userId == null) {
-            return;
-        }
-
-        JSONObject requestJSON = new JSONObject();
-        try {
-            requestJSON.put(IterableConstants.KEY_USER_ID, _userId);
-
-            sendPostRequest(IterableConstants.ENDPOINT_CREATE_USERID, requestJSON, onSuccess, onFailure);
-        }
-        catch (JSONException e) {
-            e.printStackTrace();
-        }
     }
 
 //---------------------------------------------------------------------------------------

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableConstants.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableConstants.java
@@ -27,6 +27,7 @@ public final class IterableConstants {
     public static final String KEY_ITEMS                = "items";
     public static final String KEY_NEW_EMAIL            = "newEmail";
     public static final String KEY_PLATFORM             = "platform";
+    public static final String KEY_PREFER_USER_ID       = "preferUserId";
     public static final String KEY_RECIPIENT_EMAIL      = "recipientEmail";
     public static final String KEY_SEND_AT              = "sendAt";
     public static final String KEY_TEMPLATE_ID          = "templateId";
@@ -40,7 +41,6 @@ public final class IterableConstants {
     public static final String KEY_USER_TEXT            = "userText";
 
     //API Endpoint Key Constants
-    public static final String ENDPOINT_CREATE_USERID           = "users/createUserForUserId";
     public static final String ENDPOINT_DISABLE_DEVICE          = "users/disableDevice";
     public static final String ENDPOINT_GET_INAPP_MESSAGES      = "inApp/getMessages";
     public static final String ENDPOINT_INAPP_CONSUME           = "events/inAppConsume";

--- a/iterableapi/src/test/java/com/iterable/iterableapi/IterableApiTest.java
+++ b/iterableapi/src/test/java/com/iterable/iterableapi/IterableApiTest.java
@@ -243,20 +243,18 @@ public class IterableApiTest extends BaseTest {
     @Test
     public void testPushRegistrationWithUserId() throws Exception {
         server.enqueue(new MockResponse().setResponseCode(200).setBody("{}"));
-        server.enqueue(new MockResponse().setResponseCode(200).setBody("{}"));
 
         IterableApi.initialize(RuntimeEnvironment.application, "apiKey", new IterableConfig.Builder().setAutoPushRegistration(false).build());
         IterableApi.getInstance().setUserId("testUserId");
         IterableApi.getInstance().registerDeviceToken("pushIntegration", "token", IterableConstants.MESSAGING_PLATFORM_FIREBASE);
         Thread.sleep(1000);  // Since the network request is queued from a background thread, we need to wait
         Robolectric.flushBackgroundThreadScheduler();
-        RecordedRequest createUserRequest = server.takeRequest(1, TimeUnit.SECONDS);
-        assertNotNull(createUserRequest);
-        assertEquals("/" + IterableConstants.ENDPOINT_CREATE_USERID, createUserRequest.getPath());
 
         RecordedRequest registerDeviceRequest = server.takeRequest(1, TimeUnit.SECONDS);
         assertNotNull(registerDeviceRequest);
         assertEquals("/" + IterableConstants.ENDPOINT_REGISTER_DEVICE_TOKEN, registerDeviceRequest.getPath());
+        JSONObject requestJson = new JSONObject(registerDeviceRequest.getBody().readUtf8());
+        assertEquals(requestJson.getBoolean(IterableConstants.KEY_PREFER_USER_ID), true);
     }
 
 }


### PR DESCRIPTION
Use 'preferUserId' flag to create a user by userId instead of the deprecated createUserForUserId API.