### PR TITLE
[MOB-155] Increase connection timeout to 3 seconds

### DIFF
--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableRequest.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableRequest.java
@@ -28,7 +28,7 @@ class IterableRequest extends AsyncTask<IterableApiRequest, Void, String> {
 
     static String overrideUrl;
 
-    static final int DEFAULT_TIMEOUT_MS = 1000;   //1 seconds
+    static final int DEFAULT_TIMEOUT_MS = 3000;   //3 seconds
     static final long RETRY_DELAY_MS = 2000;      //2 seconds
     static final int MAX_RETRY_COUNT = 5;
 


### PR DESCRIPTION
The default connection timeout is 1 second.
Since we only have servers in one region (US-EAST), pings from countries in Asia may reach 400-500 ms.
TLS handshake takes 2-3 requests, and that may be pushing it over the limit. We should bump the timeout to 3 seconds.