### PR TITLE
[MOB-165] Get application name by using loadLabel

### DIFF
--- a/iterableapi/src/androidTest/AndroidManifest.xml
+++ b/iterableapi/src/androidTest/AndroidManifest.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest
-    xmlns:tools="http://schemas.android.com/tools"
+<manifest xmlns:tools="http://schemas.android.com/tools"
+    xmlns:android="http://schemas.android.com/apk/res/android"
     package="iterable.com.iterableapi">
     <uses-sdk tools:overrideLibrary="android.support.test.uiautomator.v18"/>
+    <application
+        android:label="@string/app_name"
+        android:supportsRtl="true"/>
 </manifest>

--- a/iterableapi/src/main/AndroidManifest.xml
+++ b/iterableapi/src/main/AndroidManifest.xml
@@ -1,9 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.iterable.iterableapi">
 
-    <application
-        android:label="@string/app_name"
-        android:supportsRtl="true">
+    <application>
 
         <!--FCM-->
         <service

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableNotificationBuilder.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableNotificationBuilder.java
@@ -109,8 +109,7 @@ public class IterableNotificationBuilder extends NotificationCompat.Builder {
      * @return Returns null if the intent comes from an Iterable ghostPush or it is not an Iterable notification
      */
     public static IterableNotificationBuilder createNotification(Context context, Bundle extras) {
-        int stringId = context.getApplicationInfo().labelRes;
-        String applicationName = context.getString(stringId);
+        String applicationName = context.getApplicationInfo().loadLabel(context.getPackageManager()).toString();
         String title = null;
         String notificationBody = null;
         String soundName = null;


### PR DESCRIPTION
Get application name by using loadLabel so we can support both resource and plain text application labels
Also, remove `label` from the Manifest because that's not something we want to merge into the app manifest.