### PR TITLE
[MOB-284] Pass the correct parameter for inAppClick - clickedUrl

### DIFF
--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
@@ -1003,9 +1003,9 @@ public class IterableApi {
     /**
      * Tracks an InApp click.
      * @param messageId
-     * @param urlClick
+     * @param clickedUrl
      */
-    public void trackInAppClick(String messageId, String urlClick) {
+    public void trackInAppClick(String messageId, String clickedUrl) {
         if (!checkSDKInitialization()) {
             return;
         }
@@ -1015,7 +1015,7 @@ public class IterableApi {
         try {
             addEmailOrUserIdToJson(requestJSON);
             requestJSON.put(IterableConstants.KEY_MESSAGE_ID, messageId);
-            requestJSON.put(IterableConstants.ITERABLE_IN_APP_URL_CLICK, urlClick);
+            requestJSON.put(IterableConstants.ITERABLE_IN_APP_CLICKED_URL, clickedUrl);
 
             sendPostRequest(IterableConstants.ENDPOINT_TRACK_INAPP_CLICK, requestJSON);
         }

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableConstants.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableConstants.java
@@ -159,7 +159,7 @@ public final class IterableConstants {
     public static final String ITERABLE_IN_APP_TEXT             = "text";
     public static final String ITERABLE_IN_APP_TITLE            = "title";
     public static final String ITERABLE_IN_APP_TYPE             = "displayType";
-    public static final String ITERABLE_IN_APP_URL_CLICK        = "urlClick";
+    public static final String ITERABLE_IN_APP_CLICKED_URL      = "clickedUrl";
 
     public static final String ITERABLE_IN_APP_TYPE_BOTTOM  = "BOTTOM";
     public static final String ITERABLE_IN_APP_TYPE_CENTER  = "MIDDLE";


### PR DESCRIPTION
Send `clickedUrl` instead of `urlClick` to match the API spec.