### PR TITLE
[MOB-305] Increase timeout in IterableDeeplinkManager to 3 seconds

### DIFF
--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableDeeplinkManager.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableDeeplinkManager.java
@@ -48,7 +48,7 @@ class IterableDeeplinkManager {
 
     private static class RedirectTask extends AsyncTask<String, Void, String> {
         static final String TAG = "RedirectTask";
-        static final int DEFAULT_TIMEOUT_MS = 1000;   //1 seconds
+        static final int DEFAULT_TIMEOUT_MS = 3000;   //3 seconds
 
         private IterableHelper.IterableActionHandler callback;
 


### PR DESCRIPTION
This has been causing a lot of test failures lately.. The emulator is extremely slow on TravisCI.
Also, we’ve previously bumped the other, general timeout for requests to 3 seconds, so we should do the same here.