### PR TITLE
[MOB-462] Disable Codecov commit status

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,4 @@
+coverage:
+  status:
+    project: off
+    patch: off


### PR DESCRIPTION
This is enabled by default, and causes it to show a red X next to the commit/PR, implying failed tests. A comment from codecov in the PR should be enough.