### PR TITLE
[MOB-489] Fix a NullPointerException that may occur in IterableActivityMonitor if it's initialized after the application is started

### DIFF
--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableActivityMonitor.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableActivityMonitor.java
@@ -65,7 +65,7 @@ public class IterableActivityMonitor {
 
         @Override
         public void onActivityPaused(Activity activity) {
-            if (currentActivity.get() == activity) {
+            if (getCurrentActivity() == activity) {
                 currentActivity = null;
             }
         }


### PR DESCRIPTION
Fixes #115