### PR TITLE
[MOB-526] Move new token handling to FirebaseMessagingService

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ See [Bintray](https://bintray.com/davidtruong/maven/Iterable-SDK) for the latest
 
 ### Handling Firebase push messages and tokens
 
-The SDK adds a `FirebaseMessagingService` and `FirebaseInstanceIdService` to the app manifest automatically, so you don't have to do any extra setup to handle incoming push messages.
+The SDK adds a `FirebaseMessagingService` to the app manifest automatically, so you don't have to do any extra setup to handle incoming push messages.
 
-If your application implements its own FirebaseMessagingService, make sure you forward `onMessageReceived` and `onNewToken` calls to `IterableFirebaseMessagingService.handleMessageReceived` and `IterableFirebaseInstanceIDService.handleTokenRefresh`, respectively:
+If your application implements its own FirebaseMessagingService, make sure you forward `onMessageReceived` and `onNewToken` calls to `IterableFirebaseMessagingService.handleMessageReceived` and `IterableFirebaseMessagingService.handleTokenRefresh`, respectively:
 
 ```java
 public class MyFirebaseMessagingService extends FirebaseMessagingService {
@@ -52,7 +52,7 @@ public class MyFirebaseMessagingService extends FirebaseMessagingService {
 
     @Override
     public void onNewToken(String s) {
-        IterableFirebaseInstanceIDService.handleTokenRefresh();
+        IterableFirebaseMessagingService.handleTokenRefresh();
     }
 }
 ```

--- a/iterableapi/build.gradle
+++ b/iterableapi/build.gradle
@@ -30,7 +30,7 @@ dependencies {
     api 'com.android.support:support-v4:28.0.0'
     api 'com.android.support:appcompat-v7:28.0.0'
     api 'com.android.support:support-annotations:28.0.0'
-    api 'com.google.firebase:firebase-messaging:15.0.2'
+    api 'com.google.firebase:firebase-messaging:17.4.0'
 
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.mockito:mockito-core:2.27.0'

--- a/iterableapi/src/main/AndroidManifest.xml
+++ b/iterableapi/src/main/AndroidManifest.xml
@@ -12,14 +12,6 @@
             </intent-filter>
         </service>
 
-        <service
-            android:name="com.iterable.iterableapi.IterableFirebaseInstanceIDService"
-            android:exported="false">
-            <intent-filter android:priority="-1">
-                <action android:name="com.google.firebase.INSTANCE_ID_EVENT"/>
-            </intent-filter>
-        </service>
-
         <!-- Action receiver for push interactions -->
         <receiver
             android:name="com.iterable.iterableapi.IterablePushActionReceiver"

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
@@ -10,7 +10,6 @@ import android.os.Bundle;
 import android.support.annotation.VisibleForTesting;
 import android.support.v4.app.NotificationManagerCompat;
 
-import com.google.android.gms.ads.identifier.AdvertisingIdClient;
 import com.iterable.iterableapi.ddl.DeviceInfo;
 import com.iterable.iterableapi.ddl.MatchFpResponse;
 
@@ -1307,9 +1306,9 @@ public class IterableApi {
         try {
             Class adClass = Class.forName("com.google.android.gms.ads.identifier.AdvertisingIdClient");
             if (adClass != null) {
-                AdvertisingIdClient.Info advertisingIdInfo = AdvertisingIdClient.getAdvertisingIdInfo(_applicationContext);
+                Object advertisingIdInfo = adClass.getMethod("getAdvertisingIdInfo", Context.class).invoke(null, _applicationContext);
                 if (advertisingIdInfo != null) {
-                    advertisingId = advertisingIdInfo.getId();
+                    advertisingId = (String) advertisingIdInfo.getClass().getMethod("getId").invoke(advertisingIdInfo);
                 }
             }
         } catch (ClassNotFoundException e) {

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableFirebaseInstanceIDService.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableFirebaseInstanceIDService.java
@@ -1,33 +1,14 @@
 package com.iterable.iterableapi;
 
-import android.content.Context;
-import android.content.SharedPreferences;
-
-import com.google.firebase.iid.FirebaseInstanceId;
-import com.google.firebase.iid.FirebaseInstanceIdService;
-
-import org.json.JSONException;
-import org.json.JSONObject;
-
 /**
- * Created by David Truong dt@iterable.com.
+ * Deprecated. Please use {@link IterableFirebaseMessagingService} instead.
  */
-public class IterableFirebaseInstanceIDService extends FirebaseInstanceIdService {
-
-    static final String TAG = "itblFCMInstanceService";
-
-    @Override
-    public void onTokenRefresh() {
-        handleTokenRefresh();
-    }
-
+@Deprecated
+public class IterableFirebaseInstanceIDService {
     /**
-     * Handles token refresh
-     * Call this from a custom {@link FirebaseInstanceIdService} to register the new token with Iterable
+     * Deprecated. Use {@link IterableFirebaseMessagingService#handleTokenRefresh()} instead.
      */
     public static void handleTokenRefresh() {
-        String registrationToken = FirebaseInstanceId.getInstance().getToken();
-        IterableLogger.d(TAG, "New Firebase Token generated: " + registrationToken);
-        IterableApi.getInstance().registerForPush();
+        IterableFirebaseMessagingService.handleTokenRefresh();
     }
 }

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableFirebaseMessagingService.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableFirebaseMessagingService.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.os.AsyncTask;
 import android.os.Bundle;
 
+import com.google.firebase.iid.FirebaseInstanceId;
 import com.google.firebase.messaging.FirebaseMessagingService;
 import com.google.firebase.messaging.RemoteMessage;
 
@@ -16,6 +17,11 @@ public class IterableFirebaseMessagingService extends FirebaseMessagingService {
     @Override
     public void onMessageReceived(RemoteMessage remoteMessage) {
         handleMessageReceived(this, remoteMessage);
+    }
+
+    @Override
+    public void onNewToken(String s) {
+        handleTokenRefresh();
     }
 
     /**
@@ -75,6 +81,16 @@ public class IterableFirebaseMessagingService extends FirebaseMessagingService {
             }
         }
         return true;
+    }
+
+    /**
+     * Handles token refresh
+     * Call this from a custom {@link FirebaseMessagingService} to register the new token with Iterable
+     */
+    public static void handleTokenRefresh() {
+        String registrationToken = FirebaseInstanceId.getInstance().getToken();
+        IterableLogger.d(TAG, "New Firebase Token generated: " + registrationToken);
+        IterableApi.getInstance().registerForPush();
     }
 }
 


### PR DESCRIPTION
Google has recently removed FirebaseInstanceIdService class from the Firebase Messaging library. We need to remove it in our SDK to ensure compatibility with the newer version of the Firebase library.
Keeping `IterableFirebaseInstanceIDService` with one static method for backwards compatibility.
Fixes #118.