### PR TITLE
[MOB-580] Fix a possible NullPointerException in getAdvertisingId

### DIFF
--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
@@ -1315,7 +1315,7 @@ public class IterableApi {
             IterableLogger.d(TAG, "ClassNotFoundException: Can't track ADID. " +
                     "Check that play-services-ads is added to the dependencies.", e);
         } catch (Exception e) {
-            IterableLogger.w(TAG, e.getMessage());
+            IterableLogger.w(TAG, "Error while fetching advertising ID", e);
         }
         return advertisingId;
     }


### PR DESCRIPTION
The error message may be null so we pass the exception itself instead
Fixes #126 