### PR TITLE
In App Close event tracking

### DIFF
--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
@@ -1101,6 +1101,49 @@ public class IterableApi {
         }
     }
 
+
+    void trackInAppClose(String messageId, String clickedURL, IterableInAppLocation clickLocation ){
+        IterableInAppMessage message = getInAppManager().getMessageById(messageId);
+        if (message != null) {
+            trackInAppClose(message, clickedURL, clickLocation);
+        } else {
+            IterableLogger.w(TAG, "trackInAppClose: could not find an in-app message with ID: " + messageId);
+        }
+    }
+
+    /**
+     *Tracks InApp Close events.
+     * @param message in-app message
+     * @param clickedURL clicked Url if available
+     * @param clickLocation location of the click
+     */
+    void trackInAppClose(IterableInAppMessage message, String clickedURL, IterableInAppLocation clickLocation){
+        if (!checkSDKInitialization()) {
+            return;
+        }
+
+        if (message == null) {
+            IterableLogger.e(TAG, "trackInAppClose: message is null");
+            return;
+        }
+
+        JSONObject requestJSON = new JSONObject();
+
+        try {
+            addEmailOrUserIdToJson(requestJSON);
+            requestJSON.put(IterableConstants.KEY_EMAIL,getEmail());
+            requestJSON.put(IterableConstants.KEY_USER_ID,getUserId());
+            requestJSON.put(IterableConstants.KEY_MESSAGE_ID, message.getMessageId());
+            requestJSON.put(IterableConstants.ITERABLE_IN_APP_CLICKED_URL, clickedURL);
+            requestJSON.put(IterableConstants.KEY_MESSAGE_CONTEXT, getInAppMessageContext(message, clickLocation));
+            sendPostRequest(IterableConstants.ENDPOINT_TRACK_INAPP_CLOSE, requestJSON);
+        }
+        catch (JSONException e) {
+            e.printStackTrace();
+        }
+
+    }
+
     void trackInAppDelivery(IterableInAppMessage message) {
         if (!checkSDKInitialization()) {
             return;

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableConstants.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableConstants.java
@@ -63,6 +63,7 @@ public final class IterableConstants {
     public static final String ENDPOINT_UPDATE_EMAIL            = "users/updateEmail";
     public static final String ENDPOINT_UPDATE_USER_SUBS        = "users/updateSubscriptions";
     public static final String ENDPOINT_DDL_MATCH               = "a/matchFp";
+    public static final String ENDPOINT_TRACK_INAPP_CLOSE       = "events/trackInAppClose";
 
     public static final String PUSH_APP_ID                      = "IterableAppId";
     public static final String PUSH_GCM_PROJECT_NUMBER          = "GCMProjectNumber";

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableInAppHTMLNotification.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableInAppHTMLNotification.java
@@ -124,7 +124,7 @@ public class IterableInAppHTMLNotification extends Dialog {
     @Override
     public void onBackPressed() {
         IterableApi.sharedInstance.trackInAppClick(messageId, BACK_BUTTON);
-
+        IterableApi.sharedInstance.trackInAppClose(messageId, BACK_BUTTON, IterableInAppLocation.IN_APP);
         super.onBackPressed();
     }
 
@@ -314,9 +314,9 @@ class IterableWebViewClient extends WebViewClient {
     @Override
     public boolean shouldOverrideUrlLoading(WebView view, String url) {
         IterableApi.sharedInstance.trackInAppClick(inAppHTMLNotification.messageId, url, IterableInAppLocation.IN_APP);
+        IterableApi.sharedInstance.trackInAppClose(inAppHTMLNotification.messageId,url,IterableInAppLocation.IN_APP);
         inAppHTMLNotification.clickCallback.execute(Uri.parse(url));
         inAppHTMLNotification.dismiss();
-
         return true;
     }
 

--- a/iterableapi/src/test/java/com/iterable/iterableapi/IterableApiTest.java
+++ b/iterableapi/src/test/java/com/iterable/iterableapi/IterableApiTest.java
@@ -393,6 +393,28 @@ public class IterableApiTest extends BaseTest {
     }
 
     @Test
+    public void testInAppClose() throws Exception{
+        server.enqueue(new MockResponse().setResponseCode(200).setBody("{}"));
+
+        IterableInAppMessage message = InAppTestUtils.getTestInAppMessage();
+
+        IterableApi.initialize(RuntimeEnvironment.application, "apiKey", new IterableConfig.Builder().setAutoPushRegistration(false).build());
+        IterableApi.getInstance().setEmail("test@email.com");
+
+        IterableApi.getInstance().trackInAppClose(message,"https://www.google.com", null);
+        Robolectric.flushBackgroundThreadScheduler();
+
+        RecordedRequest trackInAppCloseRequest = server.takeRequest(1, TimeUnit.SECONDS);
+        assertNotNull(trackInAppCloseRequest);
+        Uri uri = Uri.parse(trackInAppCloseRequest.getRequestUrl().toString());
+        assertEquals("/" + IterableConstants.ENDPOINT_TRACK_INAPP_CLOSE, uri.getPath());
+        JSONObject requestJson = new JSONObject(trackInAppCloseRequest.getBody().readUtf8());
+        assertEquals(message.getMessageId(), requestJson.getString(IterableConstants.KEY_MESSAGE_ID));
+        assertEquals("https://www.google.com", requestJson.getString(IterableConstants.ITERABLE_IN_APP_CLICKED_URL));
+
+    }
+
+    @Test
     public void testInAppClickExtended() throws Exception {
         server.enqueue(new MockResponse().setResponseCode(200).setBody("{}"));
 
@@ -444,5 +466,7 @@ public class IterableApiTest extends BaseTest {
         assertEquals(IterableConstants.ITBL_PLATFORM_ANDROID, deviceInfo.getString(IterableConstants.KEY_PLATFORM));
         assertEquals(PACKAGE_NAME, deviceInfo.getString(IterableConstants.DEVICE_APP_PACKAGE_NAME));
     }
+
+
 
 }


### PR DESCRIPTION
New function to call InAppTrack api with required parameters. Called within two places in the app.
1. When user pressed the back button and dismisses the inApp screen.
2. When user clicks on a button on inApp leading execute the uri externally and dismissing the inApp layover screen.

Unit Test function covering happy path us written to test if sent parameters is correctly fetched.