### PR TITLE
[MOB-689] Fix read/unread state update

### DIFF
--- a/iterableapi-ui/src/main/java/com/iterable/iterableapi/ui/inbox/InboxFragment.java
+++ b/iterableapi-ui/src/main/java/com/iterable/iterableapi/ui/inbox/InboxFragment.java
@@ -67,7 +67,7 @@ public class InboxFragment extends Fragment implements IterableInAppManager.List
     private void updateList() {
         RecyclerView recyclerView = (RecyclerView) getView();
         InboxRecyclerViewAdapter adapter = (InboxRecyclerViewAdapter) recyclerView.getAdapter();
-        adapter.setValues(IterableApi.getInstance().getInAppManager().getInboxMessages());
+        adapter.setInboxItems(IterableApi.getInstance().getInAppManager().getInboxMessages());
     }
 
     @Override

--- a/iterableapi-ui/src/main/java/com/iterable/iterableapi/ui/inbox/InboxRecyclerViewAdapter.java
+++ b/iterableapi-ui/src/main/java/com/iterable/iterableapi/ui/inbox/InboxRecyclerViewAdapter.java
@@ -13,7 +13,6 @@ import android.widget.TextView;
 
 import com.iterable.iterableapi.IterableInAppDeleteActionType;
 import com.iterable.iterableapi.IterableInAppMessage;
-import com.iterable.iterableapi.IterableLogger;
 import com.iterable.iterableapi.ui.BitmapLoader;
 import com.iterable.iterableapi.ui.R;
 
@@ -26,11 +25,11 @@ public class InboxRecyclerViewAdapter extends RecyclerView.Adapter<InboxRecycler
 
     private static final String TAG = "InboxRecyclerViewAdapter";
 
-    private List<InboxRow> values;
+    private List<InboxRow> inboxItems;
     private OnListInteractionListener listener;
 
     public InboxRecyclerViewAdapter(List<IterableInAppMessage> values, OnListInteractionListener listener) {
-        this.values = inboxRowListFromInboxMessages(values);
+        this.inboxItems = inboxRowListFromInboxMessages(values);
         this.listener = listener;
     }
 
@@ -51,7 +50,7 @@ public class InboxRecyclerViewAdapter extends RecyclerView.Adapter<InboxRecycler
 
     @Override
     public void onBindViewHolder(@NonNull ViewHolder holder, int position) {
-        InboxRow inboxRow = values.get(position);
+        InboxRow inboxRow = inboxItems.get(position);
         IterableInAppMessage.InboxMetadata inboxMetadata = inboxRow.inboxMetadata;
         holder.title.setText(inboxMetadata.title);
         holder.subtitle.setText(inboxMetadata.subtitle);
@@ -68,7 +67,7 @@ public class InboxRecyclerViewAdapter extends RecyclerView.Adapter<InboxRecycler
 
     @Override
     public int getItemCount() {
-        return values.size();
+        return inboxItems.size();
     }
 
     @Override
@@ -85,18 +84,18 @@ public class InboxRecyclerViewAdapter extends RecyclerView.Adapter<InboxRecycler
         listener.onListItemImpressionEnded(message);
     }
 
-    public void setValues(List<IterableInAppMessage> newValues) {
+    public void setInboxItems(List<IterableInAppMessage> newValues) {
         List<InboxRow> newRowValues = inboxRowListFromInboxMessages(newValues);
-        InAppMessageDiffCallback diffCallback = new InAppMessageDiffCallback(values, newRowValues);
+        InAppMessageDiffCallback diffCallback = new InAppMessageDiffCallback(inboxItems, newRowValues);
         DiffUtil.DiffResult diffResult = DiffUtil.calculateDiff(diffCallback);
-        values.clear();
-        values.addAll(newRowValues);
+        inboxItems.clear();
+        inboxItems.addAll(newRowValues);
         diffResult.dispatchUpdatesTo(this);
     }
 
     public void deleteItem(int position, IterableInAppDeleteActionType source) {
-        IterableInAppMessage deletedItem = values.get(position).message;
-        values.remove(position);
+        IterableInAppMessage deletedItem = inboxItems.get(position).message;
+        inboxItems.remove(position);
         listener.onListItemDeleted(deletedItem, source);
         notifyItemRemoved(position);
     }

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableInAppMessage.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableInAppMessage.java
@@ -423,28 +423,4 @@ public class IterableInAppMessage {
         }
         return returnObject;
     }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (obj == this) {
-            return true;
-        }
-        if (!(obj instanceof IterableInAppMessage)) {
-            return false;
-        }
-        IterableInAppMessage message = (IterableInAppMessage) obj;
-        return ObjectsCompat.equals(messageId, message.messageId) &&
-                ObjectsCompat.equals(content, message.content) &&
-                ObjectsCompat.equals(customPayload, message.customPayload) &&
-                ObjectsCompat.equals(createdAt, message.createdAt) &&
-                ObjectsCompat.equals(expiresAt, message.expiresAt) &&
-                ObjectsCompat.equals(trigger, message.trigger) &&
-                ObjectsCompat.equals(saveToInbox, message.saveToInbox) &&
-                ObjectsCompat.equals(inboxMetadata, message.inboxMetadata);
-    }
-
-    @Override
-    public int hashCode() {
-        return ObjectsCompat.hash(messageId, content, customPayload, createdAt, expiresAt, trigger, saveToInbox, inboxMetadata);
-    }
 }


### PR DESCRIPTION
`DiffUtil` is comparing objects within arrays, but since the in-app messages themselves are mutable, we were effectively comparing the updated `IterableInAppMessages` to themselves. This PR changes `InboxRecyclerViewAdapter` to use an immutable `InboxRow` class instead.