### PR TITLE
MOB-703 Change trackInAppConsume parameter

### DIFF
--- a/iterableapi-ui/src/main/java/com/iterable/iterableapi/ui/inbox/InboxRecyclerViewTouchHelper.java
+++ b/iterableapi-ui/src/main/java/com/iterable/iterableapi/ui/inbox/InboxRecyclerViewTouchHelper.java
@@ -33,7 +33,7 @@ public class InboxRecyclerViewTouchHelper extends ItemTouchHelper.SimpleCallback
     @Override
     public void onSwiped(RecyclerView.ViewHolder viewHolder, int direction) {
         int position = viewHolder.getAdapterPosition();
-        adapter.deleteItem(position, IterableInAppDeleteActionType.INBOX_SWIPE_LEFT);
+        adapter.deleteItem(position, IterableInAppDeleteActionType.INBOX_SWIPE);
     }
 
     @Override

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableInAppDeleteActionType.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableInAppDeleteActionType.java
@@ -2,10 +2,10 @@ package com.iterable.iterableapi;
 
 public enum IterableInAppDeleteActionType {
 
-    INBOX_SWIPE_LEFT {
+    INBOX_SWIPE {
         @Override
         public String toString() {
-            return "inbox-swipe-left";
+            return "inbox-swipe";
         }
     },
 

--- a/iterableapi/src/test/java/com/iterable/iterableapi/IterableApiTest.java
+++ b/iterableapi/src/test/java/com/iterable/iterableapi/IterableApiTest.java
@@ -13,7 +13,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.robolectric.Robolectric;
 import org.robolectric.RuntimeEnvironment;
-import org.robolectric.shadows.ShadowApplication;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -536,7 +535,7 @@ public class IterableApiTest extends BaseTest {
 
         IterableApi.initialize(RuntimeEnvironment.application, "apiKey", new IterableConfig.Builder().setAutoPushRegistration(false).build());
         IterableApi.getInstance().setEmail("test@email.com");
-        IterableApi.getInstance().inAppConsume(message, IterableInAppDeleteActionType.INBOX_SWIPE_LEFT, null);
+        IterableApi.getInstance().inAppConsume(message, IterableInAppDeleteActionType.INBOX_SWIPE, null);
         Robolectric.flushBackgroundThreadScheduler();
 
         RecordedRequest trackInAppCloseRequest = server.takeRequest(1, TimeUnit.SECONDS);
@@ -545,7 +544,7 @@ public class IterableApiTest extends BaseTest {
         assertEquals("/" + IterableConstants.ENDPOINT_INAPP_CONSUME, uri.getPath());
         JSONObject requestJson = new JSONObject(trackInAppCloseRequest.getBody().readUtf8());
         assertEquals(message.getMessageId(), requestJson.getString(IterableConstants.KEY_MESSAGE_ID));
-        assertEquals("inbox-swipe-left", requestJson.getString(IterableConstants.ITERABLE_IN_APP_DELETE_ACTION));
+        assertEquals("inbox-swipe", requestJson.getString(IterableConstants.ITERABLE_IN_APP_DELETE_ACTION));
 
     }
 


### PR DESCRIPTION
The inbox-Swipe-Left keyword is now changed to inbox-swipe making it more generic for app developers. This will remove the constraints/future confusion in case customer wants to implement deletion of message using different swipe methods.