### PR TITLE
MOB 706 Improve Logging in Android SDK

### DIFF
--- a/iterableapi-ui/src/main/java/com/iterable/iterableapi/ui/inbox/InboxActivity.java
+++ b/iterableapi-ui/src/main/java/com/iterable/iterableapi/ui/inbox/InboxActivity.java
@@ -4,6 +4,7 @@ import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.v7.app.AppCompatActivity;
 
+import com.iterable.iterableapi.IterableLogger;
 import com.iterable.iterableapi.ui.R;
 
 public class InboxActivity extends AppCompatActivity {
@@ -12,6 +13,7 @@ public class InboxActivity extends AppCompatActivity {
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.inbox_activity);
+        IterableLogger.printInfo();
         if (savedInstanceState == null) {
             getSupportFragmentManager().beginTransaction()
                     .replace(R.id.container, InboxFragment.newInstance())

--- a/iterableapi-ui/src/main/java/com/iterable/iterableapi/ui/inbox/InboxFragment.java
+++ b/iterableapi-ui/src/main/java/com/iterable/iterableapi/ui/inbox/InboxFragment.java
@@ -40,6 +40,7 @@ public class InboxFragment extends Fragment implements IterableInAppManager.List
     @Nullable
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
+        IterableLogger.printInfo();
         RecyclerView view = (RecyclerView) inflater.inflate(R.layout.fragment_inbox_list, container, false);
         view.setLayoutManager(new LinearLayoutManager(getContext()));
         InboxRecyclerViewAdapter adapter = new InboxRecyclerViewAdapter(IterableApi.getInstance().getInAppManager().getInboxMessages(), InboxFragment.this);
@@ -135,6 +136,7 @@ public class InboxFragment extends Fragment implements IterableInAppManager.List
         }
 
         private void onMessageImpressionStarted(IterableInAppMessage message) {
+            IterableLogger.printInfo();
             String messageId = message.getMessageId();
             ImpressionData impressionData = impressions.get(messageId);
             if (impressionData == null) {
@@ -145,6 +147,7 @@ public class InboxFragment extends Fragment implements IterableInAppManager.List
         }
 
         private void onMessageImpressionEnded(IterableInAppMessage message) {
+            IterableLogger.printInfo();
             String messageId = message.getMessageId();
             ImpressionData impressionData = impressions.get(messageId);
             if (impressionData == null) {

--- a/iterableapi-ui/src/main/java/com/iterable/iterableapi/ui/inbox/InboxMessageActivity.java
+++ b/iterableapi-ui/src/main/java/com/iterable/iterableapi/ui/inbox/InboxMessageActivity.java
@@ -4,6 +4,7 @@ import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.v7.app.AppCompatActivity;
 
+import com.iterable.iterableapi.IterableLogger;
 import com.iterable.iterableapi.ui.R;
 
 public class InboxMessageActivity extends AppCompatActivity {
@@ -13,6 +14,7 @@ public class InboxMessageActivity extends AppCompatActivity {
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.inbox_message_activity);
+        IterableLogger.printInfo();
         if (savedInstanceState == null) {
             getSupportFragmentManager().beginTransaction()
                     .replace(R.id.container, InboxMessageFragment.newInstance(getIntent().getStringExtra(ARG_MESSAGE_ID)))

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
@@ -458,6 +458,7 @@ public class IterableApi {
      * @return
      */
     public static boolean handleAppLink(String uri) {
+        IterableLogger.printInfo();
         if (IterableDeeplinkManager.isIterableDeeplink(uri)) {
             IterableDeeplinkManager.getAndTrackDeeplink(uri, new IterableHelper.IterableActionHandler() {
                 @Override
@@ -592,6 +593,7 @@ public class IterableApi {
      * @param dataFields
      */
     public void track(String eventName, int campaignId, int templateId, JSONObject dataFields) {
+        IterableLogger.printInfo();
         if (!checkSDKInitialization()) {
             return;
         }
@@ -985,6 +987,7 @@ public class IterableApi {
      * @param messageId
      */
     public void trackInAppOpen(String messageId) {
+        IterableLogger.printInfo();
         if (!checkSDKInitialization()) {
             return;
         }
@@ -1003,6 +1006,7 @@ public class IterableApi {
     }
 
     void trackInAppOpen(String messageId, IterableInAppLocation location) {
+        IterableLogger.printInfo();
         IterableInAppMessage message = getInAppManager().getMessageById(messageId);
         if (message != null) {
             trackInAppOpen(message, location);
@@ -1040,6 +1044,7 @@ public class IterableApi {
     }
 
     void trackInAppClick(String messageId, String clickedUrl, IterableInAppLocation location) {
+        IterableLogger.printInfo();
         IterableInAppMessage message = getInAppManager().getMessageById(messageId);
         if (message != null) {
             trackInAppClick(message, clickedUrl, location);
@@ -1107,6 +1112,7 @@ public class IterableApi {
         IterableInAppMessage message = getInAppManager().getMessageById(messageId);
         if (message != null) {
             trackInAppClose(message, clickedURL, closeAction, clickLocation);
+            IterableLogger.printInfo();
         } else {
             IterableLogger.w(TAG, "trackInAppClose: could not find an in-app message with ID: " + messageId);
         }
@@ -1181,6 +1187,7 @@ public class IterableApi {
             return;
         }
         inAppConsume(message,null,null);
+        IterableLogger.printInfo();
     }
 
     /**

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableInAppManager.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableInAppManager.java
@@ -133,6 +133,7 @@ public class IterableInAppManager implements IterableActivityMonitor.AppStateCal
      * need to call this method from your app.
      */
     void syncInApp() {
+        IterableLogger.printInfo();
         this.api.getInAppMessages(MESSAGES_TO_FETCH, new IterableHelper.IterableActionHandler() {
             @Override
             public void execute(String payload) {
@@ -205,6 +206,7 @@ public class IterableInAppManager implements IterableActivityMonitor.AppStateCal
     }
 
     public synchronized void removeMessage(IterableInAppMessage message, IterableInAppDeleteActionType source, IterableInAppLocation clickLocation) {
+        IterableLogger.printInfo();
         message.setConsumed(true);
         api.inAppConsume(message, source, clickLocation);
         notifyOnChange();
@@ -212,6 +214,7 @@ public class IterableInAppManager implements IterableActivityMonitor.AppStateCal
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     public void handleInAppClick(IterableInAppMessage message, Uri url) {
+        IterableLogger.printInfo();
         if (url != null && !url.toString().isEmpty()) {
             String urlString = url.toString();
             if (urlString.startsWith(IterableConstants.URL_SCHEME_ACTION)) {
@@ -282,7 +285,7 @@ public class IterableInAppManager implements IterableActivityMonitor.AppStateCal
             return;
         }
 
-        IterableLogger.d(TAG, "processMessages");
+        IterableLogger.printInfo();
 
         List<IterableInAppMessage> messages = getMessages();
         for (IterableInAppMessage message : messages) {
@@ -301,6 +304,7 @@ public class IterableInAppManager implements IterableActivityMonitor.AppStateCal
     }
 
     void scheduleProcessing() {
+        IterableLogger.printInfo();
         if (canShowInAppAfterPrevious()) {
             processMessages();
         } else {

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableLogger.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableLogger.java
@@ -9,37 +9,51 @@ public class IterableLogger {
 
     public static void d(String tag, String msg) {
         if (isLoggableLevel(Log.DEBUG)) {
-            Log.d(tag, msg);
+            Log.d(tag, " 💚 " + msg);
         }
     }
 
     public static void d(String tag, String msg, Throwable tr) {
         if (isLoggableLevel(Log.DEBUG)) {
-            Log.d(tag, msg, tr);
+            Log.d(tag, " 💚 " + msg, tr);
+        }
+    }
+
+    public static void v(String tag, String msg) {
+        if (isLoggableLevel(Log.VERBOSE)) {
+            Log.v(tag, msg);
         }
     }
 
     public static void w(String tag, String msg) {
         if (isLoggableLevel(Log.WARN)) {
-            Log.w(tag, msg);
+            Log.w(tag, " 🧡️ "+ msg);
         }
     }
 
     public static void w(String tag, String msg, Throwable tr) {
         if (isLoggableLevel(Log.WARN)) {
-            Log.w(tag, msg, tr);
+            Log.w(tag, " 🧡 " + msg, tr);
         }
     }
 
     public static void e(String tag, String msg) {
         if (isLoggableLevel(Log.ERROR)) {
-            Log.e(tag, msg);
+            Log.e(tag, " ❤️ "+ msg);
         }
     }
 
     public static void e(String tag, String msg, Throwable tr) {
         if (isLoggableLevel(Log.ERROR)) {
-            Log.e(tag, msg, tr);
+            Log.e(tag, " ❤️ "+ msg, tr);
+        }
+    }
+
+    public static void printInfo() {
+        try {
+            Log.v("Iterable Call", " 💛 " + Thread.currentThread().getStackTrace()[3].getFileName() + " => " + Thread.currentThread().getStackTrace()[3].getClassName() + " => " + Thread.currentThread().getStackTrace()[3].getMethodName() + " => Line #" + Thread.currentThread().getStackTrace()[3].getLineNumber());
+        }catch (Exception e) {
+            Log.e("Iterable Call", "Couldn't print info");
         }
     }
 


### PR DESCRIPTION
Added method in Iterable Logger to have verbose implementation.
Added a generic method to callout from any Iterable class to understand from which class, method and line number the call is made.
Called the generic functions from few of Iterable API's key functionality like trackInAppOpen, trackInAppClose, showMessage, inappClose etc enabling developers to understand the internal flow of SDK
Added IterableLog statements to Log Request and Response with proper indentation for JSON objects.