### PR TITLE
MOB 806 Call consume only if inapplocation is inapp

### DIFF
--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableInAppManager.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableInAppManager.java
@@ -171,7 +171,7 @@ public class IterableInAppManager implements IterableActivityMonitor.AppStateCal
     }
 
     public void showMessage(IterableInAppMessage message, IterableInAppLocation location) {
-        showMessage(message, true, null, location);
+        showMessage(message, location == IterableInAppLocation.IN_APP, null, location);
     }
 
     /**


### PR DESCRIPTION
A check is set where the 'consume' parameter is set to true only if the call is made from InApp location. Else (in case of inbox), the consume flags to false.