### PR TITLE
[MOB-926] add session id to inbox calls

### DIFF
--- a/iterableapi-ui/src/main/java/com/iterable/iterableapi/ui/inbox/IterableInboxFragment.java
+++ b/iterableapi-ui/src/main/java/com/iterable/iterableapi/ui/inbox/IterableInboxFragment.java
@@ -98,6 +98,7 @@ public class IterableInboxFragment extends Fragment implements IterableInAppMana
     public void onDestroy() {
         super.onDestroy();
         stopSession();
+        IterableInboxSession.sessionId = null;
         IterableActivityMonitor.getInstance().removeCallback(appStateCallback);
     }
 
@@ -214,6 +215,7 @@ public class IterableInboxFragment extends Fragment implements IterableInAppMana
                     IterableApi.getInstance().getInAppManager().getUnreadInboxMessagesCount(),
                     getImpressionList());
             IterableApi.getInstance().trackInboxSession(sessionToTrack);
+            IterableInboxSession.sessionId = null;
             session = new IterableInboxSession();
             impressions = new HashMap<>();
         }

--- a/iterableapi-ui/src/main/java/com/iterable/iterableapi/ui/inbox/IterableInboxFragment.java
+++ b/iterableapi-ui/src/main/java/com/iterable/iterableapi/ui/inbox/IterableInboxFragment.java
@@ -63,7 +63,6 @@ public class IterableInboxFragment extends Fragment implements IterableInAppMana
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
         IterableLogger.printInfo();
-
         Bundle arguments = getArguments();
         if (arguments != null) {
             if (arguments.get(INBOX_MODE) instanceof InboxMode) {
@@ -98,7 +97,6 @@ public class IterableInboxFragment extends Fragment implements IterableInAppMana
     public void onDestroy() {
         super.onDestroy();
         stopSession();
-        IterableInboxSession.sessionId = null;
         IterableActivityMonitor.getInstance().removeCallback(appStateCallback);
     }
 
@@ -198,6 +196,7 @@ public class IterableInboxFragment extends Fragment implements IterableInAppMana
                     0,
                     0,
                     null);
+            IterableApi.getInstance().setInboxSessionId(session.sessionId);
         }
 
         private void onAppDidEnterBackground() {
@@ -215,7 +214,7 @@ public class IterableInboxFragment extends Fragment implements IterableInAppMana
                     IterableApi.getInstance().getInAppManager().getUnreadInboxMessagesCount(),
                     getImpressionList());
             IterableApi.getInstance().trackInboxSession(sessionToTrack);
-            IterableInboxSession.sessionId = null;
+            IterableApi.getInstance().clearInboxSessionId();
             session = new IterableInboxSession();
             impressions = new HashMap<>();
         }

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
@@ -47,6 +47,7 @@ public class IterableApi {
     private String _deviceId;
 
     private IterableInAppManager inAppManager;
+    private String inboxSessionId;
 
 //---------------------------------------------------------------------------------------
 //endregion
@@ -832,8 +833,8 @@ public class IterableApi {
             requestJSON.put(IterableConstants.KEY_MESSAGE_ID, message.getMessageId());
             requestJSON.put(IterableConstants.KEY_MESSAGE_CONTEXT, getInAppMessageContext(message, location));
             requestJSON.put(IterableConstants.KEY_DEVICE_INFO, getDeviceInfoJson());
-            if (IterableInboxSession.sessionId != null) {
-                requestJSON.put(IterableConstants.KEY_INBOX_SESSION_ID,IterableInboxSession.sessionId);
+            if (location == IterableInAppLocation.INBOX) {
+                addInboxSessionID(requestJSON);
             }
             sendPostRequest(IterableConstants.ENDPOINT_TRACK_INAPP_OPEN, requestJSON);
         }
@@ -899,8 +900,8 @@ public class IterableApi {
             requestJSON.put(IterableConstants.ITERABLE_IN_APP_CLICKED_URL, clickedUrl);
             requestJSON.put(IterableConstants.KEY_MESSAGE_CONTEXT, getInAppMessageContext(message, clickLocation));
             requestJSON.put(IterableConstants.KEY_DEVICE_INFO, getDeviceInfoJson());
-            if (IterableInboxSession.sessionId != null) {
-                requestJSON.put(IterableConstants.KEY_INBOX_SESSION_ID,IterableInboxSession.sessionId);
+            if (clickLocation == IterableInAppLocation.INBOX) {
+                addInboxSessionID(requestJSON);
             }
             sendPostRequest(IterableConstants.ENDPOINT_TRACK_INAPP_CLICK, requestJSON);
         }
@@ -947,10 +948,9 @@ public class IterableApi {
             requestJSON.put(IterableConstants.ITERABLE_IN_APP_CLOSE_ACTION, closeAction.toString());
             requestJSON.put(IterableConstants.KEY_MESSAGE_CONTEXT, getInAppMessageContext(message, clickLocation));
             requestJSON.put(IterableConstants.KEY_DEVICE_INFO, getDeviceInfoJson());
-            if (IterableInboxSession.sessionId != null) {
-                requestJSON.put(IterableConstants.KEY_INBOX_SESSION_ID,IterableInboxSession.sessionId);
+            if (clickLocation == IterableInAppLocation.INBOX) {
+                addInboxSessionID(requestJSON);
             }
-
             sendPostRequest(IterableConstants.ENDPOINT_TRACK_INAPP_CLOSE, requestJSON);
         }
         catch (JSONException e) {
@@ -1027,8 +1027,8 @@ public class IterableApi {
                 requestJSON.put(IterableConstants.KEY_DEVICE_INFO, getDeviceInfoJson());
             }
 
-            if (IterableInboxSession.sessionId != null) {
-                requestJSON.put(IterableConstants.KEY_INBOX_SESSION_ID,IterableInboxSession.sessionId);
+            if (clickLocation == IterableInAppLocation.INBOX) {
+                addInboxSessionID(requestJSON);
             }
 
             sendPostRequest(IterableConstants.ENDPOINT_INAPP_CONSUME, requestJSON);
@@ -1081,9 +1081,7 @@ public class IterableApi {
             }
 
             requestJSON.putOpt(IterableConstants.KEY_DEVICE_INFO, getDeviceInfoJson());
-            if (IterableInboxSession.sessionId != null) {
-                requestJSON.put(IterableConstants.KEY_INBOX_SESSION_ID,IterableInboxSession.sessionId);
-            }
+            addInboxSessionID(requestJSON);
 
             sendPostRequest(IterableConstants.ENDPOINT_TRACK_INBOX_SESSION, requestJSON);
         }
@@ -1299,6 +1297,12 @@ public class IterableApi {
         return _applicationContext.getSharedPreferences(IterableConstants.SHARED_PREFS_FILE, Context.MODE_PRIVATE);
     }
 
+    private void addInboxSessionID(JSONObject requestJSON) throws JSONException {
+        if (this.inboxSessionId != null) {
+            requestJSON.put(IterableConstants.KEY_INBOX_SESSION_ID, this.inboxSessionId);
+        }
+    }
+
     /**
      * Sends the POST request to Iterable.
      * Performs network operations on an async thread instead of the main thread.
@@ -1490,6 +1494,16 @@ public class IterableApi {
             IterableLogger.e(TAG, "Could not populate deviceInfo JSON", e);
         }
         return deviceInfo;
+    }
+
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    public void setInboxSessionId (String inboxSessionId) {
+        this.inboxSessionId = inboxSessionId;
+    }
+
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    public void clearInboxSessionId() {
+        this.inboxSessionId = null;
     }
 
 //---------------------------------------------------------------------------------------

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
@@ -18,11 +18,8 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import java.text.SimpleDateFormat;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.List;
-import java.util.TimeZone;
 import java.util.UUID;
 
 /**
@@ -835,7 +832,9 @@ public class IterableApi {
             requestJSON.put(IterableConstants.KEY_MESSAGE_ID, message.getMessageId());
             requestJSON.put(IterableConstants.KEY_MESSAGE_CONTEXT, getInAppMessageContext(message, location));
             requestJSON.put(IterableConstants.KEY_DEVICE_INFO, getDeviceInfoJson());
-
+            if (IterableInboxSession.sessionId != null) {
+                requestJSON.put(IterableConstants.KEY_INBOX_SESSION_ID,IterableInboxSession.sessionId);
+            }
             sendPostRequest(IterableConstants.ENDPOINT_TRACK_INAPP_OPEN, requestJSON);
         }
         catch (JSONException e) {
@@ -900,7 +899,9 @@ public class IterableApi {
             requestJSON.put(IterableConstants.ITERABLE_IN_APP_CLICKED_URL, clickedUrl);
             requestJSON.put(IterableConstants.KEY_MESSAGE_CONTEXT, getInAppMessageContext(message, clickLocation));
             requestJSON.put(IterableConstants.KEY_DEVICE_INFO, getDeviceInfoJson());
-
+            if (IterableInboxSession.sessionId != null) {
+                requestJSON.put(IterableConstants.KEY_INBOX_SESSION_ID,IterableInboxSession.sessionId);
+            }
             sendPostRequest(IterableConstants.ENDPOINT_TRACK_INAPP_CLICK, requestJSON);
         }
         catch (JSONException e) {
@@ -946,6 +947,9 @@ public class IterableApi {
             requestJSON.put(IterableConstants.ITERABLE_IN_APP_CLOSE_ACTION, closeAction.toString());
             requestJSON.put(IterableConstants.KEY_MESSAGE_CONTEXT, getInAppMessageContext(message, clickLocation));
             requestJSON.put(IterableConstants.KEY_DEVICE_INFO, getDeviceInfoJson());
+            if (IterableInboxSession.sessionId != null) {
+                requestJSON.put(IterableConstants.KEY_INBOX_SESSION_ID,IterableInboxSession.sessionId);
+            }
 
             sendPostRequest(IterableConstants.ENDPOINT_TRACK_INAPP_CLOSE, requestJSON);
         }
@@ -1022,6 +1026,11 @@ public class IterableApi {
                 requestJSON.put(IterableConstants.KEY_MESSAGE_CONTEXT, getInAppMessageContext(message, clickLocation));
                 requestJSON.put(IterableConstants.KEY_DEVICE_INFO, getDeviceInfoJson());
             }
+
+            if (IterableInboxSession.sessionId != null) {
+                requestJSON.put(IterableConstants.KEY_INBOX_SESSION_ID,IterableInboxSession.sessionId);
+            }
+
             sendPostRequest(IterableConstants.ENDPOINT_INAPP_CONSUME, requestJSON);
         }
         catch (JSONException e) {
@@ -1072,6 +1081,9 @@ public class IterableApi {
             }
 
             requestJSON.putOpt(IterableConstants.KEY_DEVICE_INFO, getDeviceInfoJson());
+            if (IterableInboxSession.sessionId != null) {
+                requestJSON.put(IterableConstants.KEY_INBOX_SESSION_ID,IterableInboxSession.sessionId);
+            }
 
             sendPostRequest(IterableConstants.ENDPOINT_TRACK_INBOX_SESSION, requestJSON);
         }

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableConstants.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableConstants.java
@@ -45,6 +45,7 @@ public final class IterableConstants {
     public static final String KEY_USER_ID              = "userId";
     public static final String KEY_USER                 = "user";
     public static final String KEY_USER_TEXT            = "userText";
+    public static final String KEY_INBOX_SESSION_ID     = "inboxSessionId";
 
     //API Endpoint Key Constants
     public static final String ENDPOINT_DISABLE_DEVICE          = "users/disableDevice";

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableInboxSession.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableInboxSession.java
@@ -4,6 +4,7 @@ import android.support.annotation.RestrictTo;
 
 import java.util.Date;
 import java.util.List;
+import java.util.UUID;
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 public class IterableInboxSession {
@@ -15,6 +16,8 @@ public class IterableInboxSession {
     public final int endUnreadMessageCount;
     public final List<Impression> impressions;
 
+    public static String sessionId;
+
     public IterableInboxSession(Date sessionStartTime, Date sessionEndTime, int startTotalMessageCount, int startUnreadMessageCount, int endTotalMessageCount, int endUnreadMessageCount, List<Impression> impressions) {
         this.sessionStartTime = sessionStartTime;
         this.sessionEndTime = sessionEndTime;
@@ -23,6 +26,9 @@ public class IterableInboxSession {
         this.endTotalMessageCount = endTotalMessageCount;
         this.endUnreadMessageCount = endUnreadMessageCount;
         this.impressions = impressions;
+        if (this.sessionId == null) {
+            this.sessionId = UUID.randomUUID().toString();
+        }
     }
 
     public IterableInboxSession() {
@@ -33,6 +39,9 @@ public class IterableInboxSession {
         this.endTotalMessageCount = 0;
         this.endUnreadMessageCount = 0;
         this.impressions = null;
+        if (this.sessionId == null) {
+            this.sessionId = UUID.randomUUID().toString();
+        }
     }
 
     public static class Impression {

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableInboxSession.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableInboxSession.java
@@ -15,8 +15,7 @@ public class IterableInboxSession {
     public final int endTotalMessageCount;
     public final int endUnreadMessageCount;
     public final List<Impression> impressions;
-
-    public static String sessionId;
+    public final String sessionId;
 
     public IterableInboxSession(Date sessionStartTime, Date sessionEndTime, int startTotalMessageCount, int startUnreadMessageCount, int endTotalMessageCount, int endUnreadMessageCount, List<Impression> impressions) {
         this.sessionStartTime = sessionStartTime;
@@ -26,9 +25,7 @@ public class IterableInboxSession {
         this.endTotalMessageCount = endTotalMessageCount;
         this.endUnreadMessageCount = endUnreadMessageCount;
         this.impressions = impressions;
-        if (this.sessionId == null) {
-            this.sessionId = UUID.randomUUID().toString();
-        }
+        this.sessionId = UUID.randomUUID().toString();
     }
 
     public IterableInboxSession() {
@@ -39,9 +36,7 @@ public class IterableInboxSession {
         this.endTotalMessageCount = 0;
         this.endUnreadMessageCount = 0;
         this.impressions = null;
-        if (this.sessionId == null) {
-            this.sessionId = UUID.randomUUID().toString();
-        }
+        this.sessionId = UUID.randomUUID().toString();
     }
 
     public static class Impression {


### PR DESCRIPTION
This architecture is good in terms of scaling. Also enabling other developers to play with sessionId if they end up not using the IterableInboxFragment altogether.

I tried minimizing, switching back and forth the inbox fragment, things are working. But in certain combination, the sessionId was not generated which I will have to check properly.
One thing to note is that the bug where we are not sending appropriate inapp location needs to be fixed for sessionIds to be sent during the request. Currently only in-app consume and trackSession are able to send sessionIds