### PR TITLE
[MOB-974] Bug fix. Send inbox as an inapp location for trackInAppClose

### DIFF
--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableInAppHTMLNotification.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableInAppHTMLNotification.java
@@ -130,7 +130,7 @@ public class IterableInAppHTMLNotification extends Dialog {
     @Override
     public void onBackPressed() {
         IterableApi.sharedInstance.trackInAppClick(messageId, BACK_BUTTON);
-        IterableApi.sharedInstance.trackInAppClose(messageId, BACK_BUTTON, IterableInAppCloseAction.BACK, IterableInAppLocation.IN_APP);
+        IterableApi.sharedInstance.trackInAppClose(messageId, BACK_BUTTON, IterableInAppCloseAction.BACK, location);
         super.onBackPressed();
     }
 

--- a/iterableapi/src/test/java/com/iterable/iterableapi/IterableApiTest.java
+++ b/iterableapi/src/test/java/com/iterable/iterableapi/IterableApiTest.java
@@ -406,7 +406,7 @@ public class IterableApiTest extends BaseTest {
         IterableApi.getInstance().setEmail("test@email.com");
 
         IterableApi.getInstance().setInboxSessionId("SomeRandomSessionID");
-        IterableApi.getInstance().trackInAppClose(message, "https://www.google.com", IterableInAppCloseAction.BACK, null);
+        IterableApi.getInstance().trackInAppClose(message, "https://www.google.com", IterableInAppCloseAction.BACK, IterableInAppLocation.IN_APP);
         Robolectric.flushBackgroundThreadScheduler();
 
         RecordedRequest trackInAppCloseRequest = server.takeRequest(1, TimeUnit.SECONDS);
@@ -418,8 +418,17 @@ public class IterableApiTest extends BaseTest {
         assertEquals("https://www.google.com", requestJson.getString(IterableConstants.ITERABLE_IN_APP_CLICKED_URL));
         assertEquals("back", requestJson.getString(IterableConstants.ITERABLE_IN_APP_CLOSE_ACTION));
         assertNull(requestJson.optString(IterableConstants.KEY_INBOX_SESSION_ID, null));
+        assertEquals(IterableInAppLocation.IN_APP.toString(), requestJson.optJSONObject(IterableConstants.KEY_MESSAGE_CONTEXT).optString(IterableConstants.ITERABLE_IN_APP_LOCATION));
+
         verifyMessageContext(requestJson);
         verifyDeviceInfo(requestJson);
+
+        //Making another request to check if inbox location is tracked
+        IterableApi.getInstance().trackInAppClose(message, "https://www.google.com", IterableInAppCloseAction.BACK, IterableInAppLocation.INBOX);
+        Robolectric.flushBackgroundThreadScheduler();
+        trackInAppCloseRequest = server.takeRequest(1, TimeUnit.SECONDS);
+        requestJson = new JSONObject(trackInAppCloseRequest.getBody().readUtf8());
+        assertEquals(IterableInAppLocation.INBOX.toString(), requestJson.optJSONObject(IterableConstants.KEY_MESSAGE_CONTEXT).optString(IterableConstants.ITERABLE_IN_APP_LOCATION));
     }
 
     @Test


### PR DESCRIPTION
The location variable was introduced in this class as a fix to previous bug MOB 965. Using the same variable to send the current location while inApp is getting closed.