### PR TITLE
[MOB-991] Travis: fix build compatibility with emulator 29.2.11 by using 29.2.1 instead

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,12 @@ install:
   # Download required emulator tools
   - echo y | sdkmanager --no_https "platforms;android-$API" >/dev/null # We need the API of the emulator we will run
   - echo y | sdkmanager --no_https $EMU_CHANNEL "emulator" >/dev/null
+  - mv ${ANDROID_HOME}/emulator/package.xml package.xml
+  - rm -rf ${ANDROID_HOME}/emulator
+  - wget -q http://dl.google.com/android/repository/emulator-linux-5889189.zip -O android-emulator.zip
+  - unzip -q android-emulator.zip -d ${ANDROID_HOME}
+  - rm android-emulator.zip
+  - mv package.xml ${ANDROID_HOME}/emulator/package.xml
   - echo y | sdkmanager --no_https "system-images;android-$API;$EMU_FLAVOR;$ABI" >/dev/null # install our emulator
 
   # Set up KVM on linux for hardware acceleration.


### PR DESCRIPTION
emulator-headless has been removed in 29.2.11:
https://androidstudio.googleblog.com/2019/12/emulator-29211-and-amd-hypervisor-12-to.html