### PR TITLE
[MOB-914] Read Write in-app json on persistent file directory

### DIFF
--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableInAppFileStorage.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableInAppFileStorage.java
@@ -99,6 +99,10 @@ public class IterableInAppFileStorage implements IterableInAppStorage, IterableI
     }
 
     private File getInAppStorageFile() {
+        return new File(getInAppContentFolder(), "itbl_inapp.json");
+    }
+
+    private File getInAppCacheStorageFile() {
         return new File(IterableUtil.getSdkCacheDir(context), "itbl_inapp.json");
     }
 
@@ -107,6 +111,9 @@ public class IterableInAppFileStorage implements IterableInAppStorage, IterableI
             File inAppStorageFile = getInAppStorageFile();
             if (inAppStorageFile.exists()) {
                 JSONObject jsonData = new JSONObject(IterableUtil.readFile(inAppStorageFile));
+                loadMessagesFromJson(jsonData);
+            } else if (getInAppCacheStorageFile().exists()) {
+                JSONObject jsonData = new JSONObject(IterableUtil.readFile(getInAppCacheStorageFile()));
                 loadMessagesFromJson(jsonData);
             }
         } catch (Exception e) {

--- a/iterableapi/src/test/java/com/iterable/iterableapi/IterableInAppFileStorageTest.java
+++ b/iterableapi/src/test/java/com/iterable/iterableapi/IterableInAppFileStorageTest.java
@@ -94,4 +94,40 @@ public class IterableInAppFileStorageTest {
         assertEquals(message.getContent().html,storage.getHTML(messageID1));
         assertNotNull(storage.getHTML(messageID2));
     }
+
+    @Test
+    public void loadMessagesWithNoJson() {
+        IterableInAppFileStorage storage = new IterableInAppFileStorage(RuntimeEnvironment.application);
+        assertEquals(0, storage.getMessages().size());
+    }
+
+    @Test
+    public void loadMessagesWithJsonInCache() throws Exception {
+        File folder = IterableUtil.getSdkCacheDir(RuntimeEnvironment.application);
+        File oldJsonStorageFile = new File(folder, "itbl_inapp.json");
+        Boolean fileWriteResult = IterableUtil.writeFile(oldJsonStorageFile, IterableTestUtils.getResourceString("inapp_payload_multiple.json"));
+        assertTrue(fileWriteResult);
+        IterableInAppFileStorage storage = new IterableInAppFileStorage(RuntimeEnvironment.application);
+        assertTrue(storage.getMessages().size() > 1);
+
+        // Simulate message update and check if new json file is created in SDK directory
+        storage.onInAppMessageChanged(storage.getMessages().get(0));
+        File sdkFilesDirectory = IterableUtil.getSDKFilesDirectory(RuntimeEnvironment.application);
+        File inAppDirectory = IterableUtil.getDirectory(sdkFilesDirectory, "IterableInAppFileStorage");
+        File inAppJsonFile = new File(inAppDirectory, "itbl_inapp.json");
+        assertTrue(inAppJsonFile.exists());
+    }
+
+    @Test
+    public void loadMessagesWithJsonInFilesDirectory() throws Exception {
+        File sdkFilesDirectory = IterableUtil.getSDKFilesDirectory(RuntimeEnvironment.application);
+        File inAppDirectory = IterableUtil.getDirectory(sdkFilesDirectory, "IterableInAppFileStorage");
+        File inAppJsonFile = new File(inAppDirectory, "itbl_inapp.json");
+        Boolean fileWriteResult = IterableUtil.writeFile(inAppJsonFile, IterableTestUtils.getResourceString("inapp_payload_single.json"));
+        assertTrue(fileWriteResult);
+
+        IterableInAppFileStorage storage = new IterableInAppFileStorage(RuntimeEnvironment.application);
+        assertEquals(1, storage.getMessages().size());
+    }
+
 }


### PR DESCRIPTION
The in app load will now look for file directory. If it does not exist (which will occur during the first launch after new SDK migration), the inapp json will be loaded from cache directory and subsequent metadata changes will be saved in file directory.