### PR TITLE
Use the proper screen height value when resizing an in-app message

### DIFF
--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableInAppHTMLNotification.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableInAppHTMLNotification.java
@@ -203,13 +203,8 @@ public class IterableInAppHTMLNotification extends Dialog {
                     Display display = wm.getDefaultDisplay();
                     Point size = new Point();
 
-                    // Get the correct screen size based on api level
-                    // https://stackoverflow.com/questions/35780980/getting-the-actual-screen-height-android
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
-                        display.getRealSize(size);
-                    } else {
-                        display.getSize(size);
-                    }
+                    // getSize gives us the screen size minus the navigation bar, which is what we want
+                    display.getSize(size);
                     int webViewWidth = size.x;
                     int webViewHeight = size.y;
 


### PR DESCRIPTION
getSize returns the screen size minus the navigation bar, which is what we want