### PR TITLE
[MOB-1006] Add support for 'read' flag from getMessages API

### DIFF
--- a/iterableapi/src/test/java/com/iterable/iterableapi/IterableInboxTest.java
+++ b/iterableapi/src/test/java/com/iterable/iterableapi/IterableInboxTest.java
@@ -92,17 +92,27 @@ public class IterableInboxTest extends BaseTest {
         IterableInAppManager inAppManager = IterableApi.getInstance().getInAppManager();
         inAppManager.syncInApp();
         List<IterableInAppMessage> inboxMessages = inAppManager.getInboxMessages();
-        assertEquals(2, inAppManager.getUnreadInboxMessagesCount());
+        assertEquals(1, inAppManager.getUnreadInboxMessagesCount());
         assertEquals(2, inboxMessages.size());
         assertFalse(inboxMessages.get(0).isRead());
-        assertFalse(inboxMessages.get(1).isRead());
-
-        inAppManager.setRead(inboxMessages.get(1), true);
-
-        assertEquals(1, inAppManager.getUnreadInboxMessagesCount());
-        assertEquals(2, inAppManager.getInboxMessages().size());
-        assertFalse(inboxMessages.get(0).isRead());
         assertTrue(inboxMessages.get(1).isRead());
+        inAppManager.setRead(inboxMessages.get(0), true);
+        assertEquals(0, inAppManager.getUnreadInboxMessagesCount());
+        assertEquals(2, inAppManager.getInboxMessages().size());
+        assertTrue(inboxMessages.get(0).isRead());
+        assertTrue(inboxMessages.get(1).isRead());
+    }
+
+    @Test
+    public void testMessageReadStatusFromServer() throws Exception {
+        dispatcher.enqueueResponse("/inApp/getMessages", new MockResponse().setBody(IterableTestUtils.getResourceString("inapp_payload_inbox_multiple.json")));
+        IterableInAppManager inAppManager = IterableApi.getInstance().getInAppManager();
+        inAppManager.syncInApp();
+        List<IterableInAppMessage> inboxMessages = inAppManager.getInboxMessages();
+        assertEquals(1, inAppManager.getUnreadInboxMessagesCount());
+        assertEquals(2, inboxMessages.size());
+        assertTrue(inboxMessages.get(1).isRead());
+        assertFalse(inboxMessages.get(0).isRead());
     }
 
     @Test

--- a/iterableapi/src/test/resources/inapp_payload_inbox_multiple.json
+++ b/iterableapi/src/test/resources/inapp_payload_inbox_multiple.json
@@ -69,6 +69,7 @@
       }
     },{
       "messageId": "message4",
+      "read": true,
       "content": {
         "html": "<html><head></head><body>Test</body></html>",
         "inAppDisplaySettings": {


### PR DESCRIPTION
Added inbox parameter to constructor. Default read status will be false unless specified in json obtained from server.
One message in json file used for testing updated to have read status as true.
One Test method updated and one test method added to verify the functionality.