### PR TITLE
[MOB-1124] Don't log an error when notification channel name is not set

### DIFF
--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableNotificationHelper.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableNotificationHelper.java
@@ -270,8 +270,8 @@ class IterableNotificationHelper {
                     channelName = info.metaData.getString(IterableConstants.NOTIFICATION_CHANNEL_NAME);
 
                     // Try to read from a string resource
-                    if (channelName == null) {
-                        int stringId = info.metaData.getInt(IterableConstants.NOTIFICATION_CHANNEL_NAME);
+                    int stringId = info.metaData.getInt(IterableConstants.NOTIFICATION_CHANNEL_NAME);
+                    if (channelName == null && stringId != 0) {
                         channelName = context.getString(stringId);
                     }
                     IterableLogger.d(IterableNotificationBuilder.TAG, "channel name: " + channelName);


### PR DESCRIPTION
It was working but was logging this error message every time: `android.content.res.Resources$NotFoundException: String resource ID #0x0.`
We should not be trying to get resource ID 0.