### PR TITLE
[MOB-1190] Remove deprecated push registration methods

### DIFF
--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
@@ -341,16 +341,6 @@ public class IterableApi {
     }
 
     /**
-     * Call onNewIntent to set the payload data and track pushOpens directly if
-     * sharedInstanceWithApiKey was called with a Context rather than an Activity.
-     * @deprecated Push opens are now tracked automatically.
-     */
-    @Deprecated
-    public void onNewIntent(Intent intent) {
-
-    }
-
-    /**
      * Returns whether or not the intent was sent from Iterable.
      */
     public boolean isIterableIntent(Intent intent) {
@@ -367,44 +357,14 @@ public class IterableApi {
      * @param token Push token obtained from GCM or FCM
      */
     public void registerDeviceToken(String token) {
-        registerDeviceToken(getPushIntegrationName(), token);
+        registerDeviceToken(_email, _userId, getPushIntegrationName(), token);
     }
 
-    /**
-     * Registers a device token with Iterable.
-     * @param applicationName
-     * @param token
-     * @deprecated Call {@link #registerDeviceToken(String)} instead and specify the push
-     * integration name in {@link IterableConfig#pushIntegrationName}
-     */
-    @Deprecated
-    public void registerDeviceToken(String applicationName, String token) {
-        registerDeviceToken(applicationName, token, IterableConstants.MESSAGING_PLATFORM_FIREBASE);
-    }
-
-    /**
-     * Registers a device token with Iterable.
-     * @param applicationName
-     * @param token
-     * @param pushServicePlatform
-     * @deprecated Call {@link #registerDeviceToken(String)} instead and specify the push
-     * integration name in {@link IterableConfig#pushIntegrationName}
-     */
-    @Deprecated
-    public void registerDeviceToken(final String applicationName, final String token, final String pushServicePlatform) {
-        registerDeviceToken(_email, _userId, applicationName, token, pushServicePlatform);
-    }
-
-    protected void registerDeviceToken(final String email, final String userId, final String applicationName, final String token, final String pushServicePlatform) {
-        if (!IterableConstants.MESSAGING_PLATFORM_FIREBASE.equals(pushServicePlatform)) {
-            IterableLogger.e(TAG, "registerDeviceToken: only MESSAGING_PLATFORM_FIREBASE is supported.");
-            return;
-        }
-
+    protected void registerDeviceToken(final String email, final String userId, final String applicationName, final String token) {
         if (token != null) {
             final Thread registrationThread = new Thread(new Runnable() {
                 public void run() {
-                    registerDeviceToken(email, userId, applicationName, token, IterableConstants.MESSAGING_PLATFORM_FIREBASE, null);
+                    registerDeviceToken(email, userId, applicationName, token, null);
                 }
             });
             registrationThread.start();
@@ -621,84 +581,10 @@ public class IterableApi {
     }
 
     /**
-     * Registers for push notifications.
-     * @param pushIntegrationName
-     * @param gcmProjectNumber
-     * @deprecated Call {@link #registerForPush()} instead and specify the push
-     * integration name in {@link IterableConfig#pushIntegrationName}
-     */
-    @Deprecated
-    public void registerForPush(String pushIntegrationName, String gcmProjectNumber) {
-        registerForPush(pushIntegrationName, gcmProjectNumber, IterableConstants.MESSAGING_PLATFORM_FIREBASE);
-    }
-
-    /**
-     * Registers for push notifications.
-     * @param pushIntegrationName
-     * @param projectNumber
-     * @param pushServicePlatform
-     * @deprecated Call {@link #registerForPush()} instead and specify the push
-     * integration name in {@link IterableConfig#pushIntegrationName}
-     */
-    @Deprecated
-    public void registerForPush(String pushIntegrationName, String projectNumber, String pushServicePlatform) {
-        if (!IterableConstants.MESSAGING_PLATFORM_FIREBASE.equals(pushServicePlatform)) {
-            IterableLogger.e(TAG, "registerDeviceToken: only MESSAGING_PLATFORM_FIREBASE is supported.");
-            return;
-        }
-
-        IterablePushRegistrationData data = new IterablePushRegistrationData(_email, _userId, pushIntegrationName, projectNumber, pushServicePlatform, IterablePushRegistrationData.PushRegistrationAction.ENABLE);
-        new IterablePushRegistration().execute(data);
-    }
-
-    /**
-     * Registers for push notifications.
-     * @param pushIntegrationName
-     * @deprecated Call {@link #registerForPush()} instead and specify the push
-     * integration name in {@link IterableConfig#pushIntegrationName}
-     */
-    @Deprecated
-    public void registerForPush(String pushIntegrationName) {
-        IterablePushRegistrationData data = new IterablePushRegistrationData(_email, _userId, pushIntegrationName, IterablePushRegistrationData.PushRegistrationAction.ENABLE);
-        new IterablePushRegistration().execute(data);
-    }
-
-    /**
      * Disables the device from push notifications
      */
     public void disablePush() {
         IterablePushRegistrationData data = new IterablePushRegistrationData(_email, _userId, getPushIntegrationName(), IterablePushRegistrationData.PushRegistrationAction.DISABLE);
-        new IterablePushRegistration().execute(data);
-    }
-
-    /**
-     * Disables the device from push notifications
-     * @param iterableAppId
-     * @param gcmProjectNumber
-     * @deprecated Call {@link #disablePush()} instead and specify the push
-     * integration name in {@link IterableConfig#pushIntegrationName}
-     */
-    @Deprecated
-    public void disablePush(String iterableAppId, String gcmProjectNumber) {
-        disablePush(iterableAppId, gcmProjectNumber, IterableConstants.MESSAGING_PLATFORM_FIREBASE);
-    }
-
-    /**
-     * Disables the device from push notifications
-     * @param iterableAppId
-     * @param projectNumber
-     * @param pushServicePlatform
-     * @deprecated Call {@link #disablePush()} instead and specify the push
-     * integration name in {@link IterableConfig#pushIntegrationName}
-     */
-    @Deprecated
-    public void disablePush(String iterableAppId, String projectNumber, String pushServicePlatform) {
-        if (!IterableConstants.MESSAGING_PLATFORM_FIREBASE.equals(pushServicePlatform)) {
-            IterableLogger.e(TAG, "registerDeviceToken: only MESSAGING_PLATFORM_FIREBASE is supported.");
-            return;
-        }
-
-        IterablePushRegistrationData data = new IterablePushRegistrationData(_email, _userId, iterableAppId, projectNumber, pushServicePlatform, IterablePushRegistrationData.PushRegistrationAction.DISABLE);
         new IterablePushRegistration().execute(data);
     }
 
@@ -1201,10 +1087,9 @@ public class IterableApi {
      * Registers the GCM registration ID with Iterable.
      * @param applicationName
      * @param token
-     * @param pushServicePlatform
      * @param dataFields
      */
-    protected void registerDeviceToken(String email, String userId, String applicationName, String token, String pushServicePlatform, JSONObject dataFields) {
+    protected void registerDeviceToken(String email, String userId, String applicationName, String token, JSONObject dataFields) {
         if (!checkSDKInitialization()) {
             return;
         }

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterablePushRegistration.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterablePushRegistration.java
@@ -32,8 +32,7 @@ class IterablePushRegistration extends AsyncTask<IterablePushRegistrationData, V
                             iterablePushRegistrationData.email,
                             iterablePushRegistrationData.userId,
                             iterablePushRegistrationData.pushIntegrationName,
-                            pushRegistrationObject.token,
-                            IterableConstants.MESSAGING_PLATFORM_FIREBASE);
+                            pushRegistrationObject.token);
 
                 } else if (iterablePushRegistrationData.pushRegistrationAction == IterablePushRegistrationData.PushRegistrationAction.DISABLE) {
                     IterableApi.sharedInstance.disableToken(

--- a/iterableapi/src/test/java/com/iterable/iterableapi/IterableApiTest.java
+++ b/iterableapi/src/test/java/com/iterable/iterableapi/IterableApiTest.java
@@ -81,7 +81,7 @@ public class IterableApiTest extends BaseTest {
         IterableApi.getInstance().inAppConsume("12345");
         IterableApi.getInstance().trackInAppClick("12345", "");
         IterableApi.getInstance().registerDeviceToken("12345");
-        IterableApi.getInstance().disablePush("12345", "12345");
+        IterableApi.getInstance().disablePush();
         IterableApi.getInstance().updateUser(new JSONObject());
         IterableApi.getInstance().updateEmail("");
         IterableApi.getInstance().trackPurchase(10.0, new ArrayList<CommerceItem>());
@@ -264,7 +264,7 @@ public class IterableApiTest extends BaseTest {
         server.enqueue(new MockResponse().setResponseCode(200).setBody("{}"));
         IterableApi.initialize(RuntimeEnvironment.application, "apiKey", new IterableConfig.Builder().setAutoPushRegistration(false).build());
         IterableApi.getInstance().setEmail("test@email.com");
-        IterableApi.getInstance().registerDeviceToken("pushIntegration", "token", IterableConstants.MESSAGING_PLATFORM_FIREBASE);
+        IterableApi.getInstance().registerDeviceToken("token");
         Thread.sleep(100);  // Since the network request is queued from a background thread, we need to wait
         Robolectric.flushBackgroundThreadScheduler();
         RecordedRequest request = server.takeRequest(1, TimeUnit.SECONDS);
@@ -287,7 +287,7 @@ public class IterableApiTest extends BaseTest {
 
         IterableApi.initialize(RuntimeEnvironment.application, "apiKey", new IterableConfig.Builder().setAutoPushRegistration(false).build());
         IterableApi.getInstance().setUserId("testUserId");
-        IterableApi.getInstance().registerDeviceToken("pushIntegration", "token", IterableConstants.MESSAGING_PLATFORM_FIREBASE);
+        IterableApi.getInstance().registerDeviceToken("token");
         Thread.sleep(1000);  // Since the network request is queued from a background thread, we need to wait
         Robolectric.flushBackgroundThreadScheduler();
 

--- a/iterableapi/src/test/java/com/iterable/iterableapi/IterablePushRegistrationTest.java
+++ b/iterableapi/src/test/java/com/iterable/iterableapi/IterablePushRegistrationTest.java
@@ -74,7 +74,7 @@ public class IterablePushRegistrationTest extends BaseTest {
         IterablePushRegistrationData data = new IterablePushRegistrationData(IterableTestUtils.userEmail, null, INTEGRATION_NAME, IterablePushRegistrationData.PushRegistrationAction.ENABLE);
         new IterablePushRegistration().execute(data);
 
-        verify(apiMock, timeout(100)).registerDeviceToken(eq(IterableTestUtils.userEmail), nullable(String.class), eq(INTEGRATION_NAME), eq(TEST_TOKEN), eq(IterableConstants.MESSAGING_PLATFORM_FIREBASE));
+        verify(apiMock, timeout(100)).registerDeviceToken(eq(IterableTestUtils.userEmail), nullable(String.class), eq(INTEGRATION_NAME), eq(TEST_TOKEN));
         verify(apiMock, never()).disableToken(eq(IterableTestUtils.userEmail), nullable(String.class), any(String.class), nullable(IterableHelper.SuccessHandler.class), nullable(IterableHelper.FailureHandler.class));
     }
 
@@ -102,7 +102,7 @@ public class IterablePushRegistrationTest extends BaseTest {
         new IterablePushRegistration().execute(data);
 
         ArgumentCaptor<IterableHelper.SuccessHandler> successHandlerCaptor = ArgumentCaptor.forClass(IterableHelper.SuccessHandler.class);
-        verify(apiMock).registerDeviceToken(eq(IterableTestUtils.userEmail), isNull(String.class), eq(INTEGRATION_NAME), eq(NEW_TOKEN), eq(IterableConstants.MESSAGING_PLATFORM_FIREBASE));
+        verify(apiMock).registerDeviceToken(eq(IterableTestUtils.userEmail), isNull(String.class), eq(INTEGRATION_NAME), eq(NEW_TOKEN));
         verify(apiMock, times(1)).disableToken(eq(IterableTestUtils.userEmail), isNull(String.class), eq(OLD_TOKEN), successHandlerCaptor.capture(), nullable(IterableHelper.FailureHandler.class));
         successHandlerCaptor.getValue().onSuccess(new JSONObject());
 
@@ -110,7 +110,7 @@ public class IterablePushRegistrationTest extends BaseTest {
 
         new IterablePushRegistration().execute(data);
 
-        verify(apiMock).registerDeviceToken(eq(IterableTestUtils.userEmail), isNull(String.class), eq(INTEGRATION_NAME), eq(NEW_TOKEN), eq(IterableConstants.MESSAGING_PLATFORM_FIREBASE));
+        verify(apiMock).registerDeviceToken(eq(IterableTestUtils.userEmail), isNull(String.class), eq(INTEGRATION_NAME), eq(NEW_TOKEN));
         verify(apiMock, never()).disableToken(eq(IterableTestUtils.userEmail), isNull(String.class), any(String.class), nullable(IterableHelper.SuccessHandler.class), nullable(IterableHelper.FailureHandler.class));
     }
 


### PR DESCRIPTION
These methods have been deprecated since 3.0.0, it's time to remove them.