### PR TITLE
[MOB-1223] Add padding at the bottom of the Inbox cell

### DIFF
--- a/iterableapi-ui/src/main/res/layout/iterable_inbox_item.xml
+++ b/iterableapi-ui/src/main/res/layout/iterable_inbox_item.xml
@@ -73,6 +73,7 @@
         android:layout_alignStart="@+id/title"
         android:layout_alignLeft="@+id/title"
         android:layout_marginTop="4dp"
+        android:layout_marginBottom="4dp"
         android:textAppearance="?attr/textAppearanceListItem"
         android:textColor="#AAAAAA"
         android:textSize="10sp"


### PR DESCRIPTION
There is no padding at the bottom of the Inbox cell (after the date text view), which makes it look weird when combined with other kinds of cells. Need to add at least a few px of padding there.