### PR TITLE
[MOB-1228]- Quick Fix for inapp notification

### DIFF
--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableInAppHTMLNotification.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableInAppHTMLNotification.java
@@ -249,6 +249,7 @@ public class IterableInAppHTMLNotification extends Dialog implements IterableWeb
                     }
                 } catch (IllegalArgumentException e) {
                     IterableLogger.e(TAG, "Exception while trying to resize an in-app message", e);
+                    notification = null;
                 }
             }
         });


### PR DESCRIPTION
In App tries to resize but leads to failure throwing an exception. Assigning notification to null so that next launches can detect null and initialize it properly.