### PR TITLE
[MOB-1255] - Dialog fragment losing constraints

### DIFF
--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableInAppFragmentHTMLNotification.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableInAppFragmentHTMLNotification.java
@@ -194,15 +194,6 @@ public class IterableInAppFragmentHTMLNotification extends DialogFragment implem
     }
 
     /**
-     * Sets up the webview and the dialog layout
-     */
-    @Override
-    public void onStart() {
-        super.onStart();
-        getDialog().getWindow().setLayout(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT);
-    }
-
-    /**
      * On Stop of the dialog
      */
     @Override


### PR DESCRIPTION
onStart method gets invoked as the app comes to foreground and we set layout to take window size. I dont know how it did perform without any issue in Dialog previously but removing that code seems to resolve the issue.