### PR TITLE
[MOB-1277] Switch the sample app to the release version of the SDK

### DIFF
--- a/sample-apps/inbox-customization/app/build.gradle
+++ b/sample-apps/inbox-customization/app/build.gradle
@@ -33,8 +33,8 @@ dependencies {
     implementation 'androidx.navigation:navigation-ui-ktx:2.1.0'
     implementation 'com.google.android.material:material:1.1.0'
 
-    implementation 'com.github.Iterable.iterable-android-sdk:iterableapi:1ee579df9'
-    implementation 'com.github.Iterable.iterable-android-sdk:iterableapi-ui:1ee579df9'
+    implementation 'com.iterable:iterableapi:3.2.0'
+    implementation 'com.iterable:iterableapi-ui:3.2.0'
     implementation 'com.squareup.okhttp3:mockwebserver:4.2.2'
 
     testImplementation 'junit:junit:4.12'

--- a/sample-apps/inbox-customization/build.gradle
+++ b/sample-apps/inbox-customization/build.gradle
@@ -19,7 +19,6 @@ allprojects {
     repositories {
         google()
         jcenter()
-        maven { url 'https://jitpack.io' }
     }
 }
 


### PR DESCRIPTION
It's pulling the SDK from Jitpack, no need for that anymore.