### PR TITLE
[MOB-1363] Catch all exceptions in IterableRequest

### DIFF
--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableRequest.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableRequest.java
@@ -189,6 +189,13 @@ class IterableRequest extends AsyncTask<IterableApiRequest, Void, String> {
             } catch (IOException e) {
                 logError(baseUrl, e);
                 handleFailure(e.getMessage(), null);
+            } catch (ArrayIndexOutOfBoundsException e) {
+                // This exception is sometimes thrown from the inside of HttpUrlConnection/OkHttp
+                logError(baseUrl, e);
+                handleFailure(e.getMessage(), null);
+            } catch (Exception e) {
+                logError(baseUrl, e);
+                handleFailure(e.getMessage(), null);
             } finally {
                 if (urlConnection != null) {
                     urlConnection.disconnect();


### PR DESCRIPTION
OkHttp bundled with some Android versions has bugs that result in exceptions. We need to catch these so they can't crash the app.