### PR TITLE
Close streams after reading file

### DIFF
--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableUtil.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableUtil.java
@@ -8,7 +8,7 @@ import android.content.pm.PackageManager;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 
-import com.google.android.gms.common.util.IOUtils;
+import com.iterable.iterableapi.util.IOUtils;
 
 import org.json.JSONObject;
 

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableUtil.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableUtil.java
@@ -8,6 +8,8 @@ import android.content.pm.PackageManager;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 
+import com.google.android.gms.common.util.IOUtils;
+
 import org.json.JSONObject;
 
 import java.io.BufferedReader;
@@ -185,10 +187,13 @@ class IterableUtil {
 
         @Nullable
         String readFile(File file) {
+            FileInputStream inputStream = null;
+            InputStreamReader streamReader = null;
+            BufferedReader bufferedReader = null;
             try {
-                FileInputStream inputStream = new FileInputStream(file);
-                InputStreamReader streamReader = new InputStreamReader(inputStream);
-                BufferedReader bufferedReader = new BufferedReader(streamReader);
+                inputStream = new FileInputStream(file);
+                streamReader = new InputStreamReader(inputStream);
+                bufferedReader = new BufferedReader(streamReader);
                 StringBuilder stringBuilder = new StringBuilder();
                 String line;
                 while ((line = bufferedReader.readLine()) != null) {
@@ -197,6 +202,10 @@ class IterableUtil {
                 return stringBuilder.toString();
             } catch (Exception e) {
                 IterableLogger.e(TAG, "Error while reading file: " + file.toString(), e);
+            } finally {
+                IOUtils.closeQuietly(inputStream);
+                IOUtils.closeQuietly(streamReader);
+                IOUtils.closeQuietly(bufferedReader);
             }
             return null;
         }

--- a/iterableapi/src/main/java/com/iterable/iterableapi/util/IOUtils.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/util/IOUtils.java
@@ -1,0 +1,20 @@
+package com.iterable.iterableapi.util;
+
+import androidx.annotation.Nullable;
+
+import java.io.Closeable;
+import java.io.IOException;
+
+public final class IOUtils {
+    private IOUtils() {
+    }
+
+    public static void closeQuietly(@Nullable Closeable closeable) {
+        if (closeable != null) {
+            try {
+                closeable.close();
+            } catch (IOException ignored) {
+            }
+        }
+    }
+}


### PR DESCRIPTION
Hi!

While using the SDK, we noticed when using StrictMode that these streams weren't being closed. So I thought that we should patch it.