### PR TITLE
[MOB-1713] - Update IterableLogger

### DIFF
--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableLogger.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableLogger.java
@@ -51,9 +51,9 @@ public class IterableLogger {
 
     public static void printInfo() {
         try {
-            Log.v("Iterable Call", " 💛 " + Thread.currentThread().getStackTrace()[3].getFileName() + " => " + Thread.currentThread().getStackTrace()[3].getClassName() + " => " + Thread.currentThread().getStackTrace()[3].getMethodName() + " => Line #" + Thread.currentThread().getStackTrace()[3].getLineNumber());
+            IterableLogger.v("Iterable Call", " 💛 " + Thread.currentThread().getStackTrace()[3].getFileName() + " => " + Thread.currentThread().getStackTrace()[3].getClassName() + " => " + Thread.currentThread().getStackTrace()[3].getMethodName() + " => Line #" + Thread.currentThread().getStackTrace()[3].getLineNumber());
         } catch (Exception e) {
-            Log.e("Iterable Call", "Couldn't print info");
+            IterableLogger.e("Iterable Call", "Couldn't print info");
         }
     }
 


### PR DESCRIPTION
PrintInfo method internally uses system level log instead of using IterableLogger. This bypasses the Iterable's config value.
The fix:  use IterableLogger. It will print only when VERBOSE is set in config.
Closes #235 