### PR TITLE
Remove strings.xml from iterableapi.

### DIFF
--- a/iterableapi/src/androidTest/AndroidManifest.xml
+++ b/iterableapi/src/androidTest/AndroidManifest.xml
@@ -4,6 +4,6 @@
     package="iterable.com.iterableapi">
     <uses-sdk tools:overrideLibrary="android_libs.ub_uiautomator"/>
     <application
-        android:label="@string/app_name"
+        android:label="IterableAPI"
         android:supportsRtl="true"/>
 </manifest>

--- a/iterableapi/src/main/res/values/strings.xml
+++ b/iterableapi/src/main/res/values/strings.xml
@@ -1,3 +1,0 @@
-<resources>
-    <string name="app_name">IterableAPI</string>
-</resources>

--- a/iterableapi/src/test/AndroidManifest.xml
+++ b/iterableapi/src/test/AndroidManifest.xml
@@ -2,7 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
 package="com.iterable.iterableapi" android:versionName="1.2.3" android:versionCode="321">
     <application
-        android:label="@string/app_name"
+        android:label="IterableAPI"
         android:supportsRtl="true">
         <activity android:name=".unit.MainActivity">
             <intent-filter>


### PR DESCRIPTION
This avoids consumer apps accidentally
inheriting/overriding IterableAPI app_name.

https://github.com/Iterable/iterable-android-sdk/issues/242