### PR TITLE
[MOB-1823] Fix NullPointerExceptions in IterableInAppFragmentHTMLNotification

### DIFF
--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableInAppDisplayer.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableInAppDisplayer.java
@@ -43,7 +43,7 @@ class IterableInAppDisplayer {
      * @param backgroundAlpha
      * @param padding
      */
-    static boolean showIterableFragmentNotificationHTML(Context context, String htmlString, String messageId, final IterableHelper.IterableUrlCallback clickCallback, double backgroundAlpha, Rect padding, boolean callbackOnCancel, IterableInAppLocation location) {
+    static boolean showIterableFragmentNotificationHTML(@NonNull Context context, @NonNull String htmlString, @NonNull String messageId,  @NonNull final IterableHelper.IterableUrlCallback clickCallback, double backgroundAlpha, @NonNull Rect padding, boolean callbackOnCancel, @NonNull IterableInAppLocation location) {
         if (context instanceof FragmentActivity) {
             FragmentActivity currentActivity = (FragmentActivity) context;
             if (htmlString != null) {
@@ -57,7 +57,7 @@ class IterableInAppDisplayer {
                 return true;
             }
         } else {
-            IterableLogger.w(IterableInAppManager.TAG, "To display in-app notifications, the context must be of an instance of: Activity");
+            IterableLogger.w(IterableInAppManager.TAG, "To display in-app notifications, the context must be of an instance of: FragmentActivity");
         }
         return false;
     }

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableInAppFragmentHTMLNotification.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableInAppFragmentHTMLNotification.java
@@ -43,9 +43,9 @@ public class IterableInAppFragmentHTMLNotification extends DialogFragment implem
 
     private static final int DELAY_THRESHOLD_MS = 500;
 
-    static IterableInAppFragmentHTMLNotification notification;
-    static IterableHelper.IterableUrlCallback clickCallback;
-    static IterableInAppLocation location;
+    @Nullable static IterableInAppFragmentHTMLNotification notification;
+    @Nullable static IterableHelper.IterableUrlCallback clickCallback;
+    @Nullable static IterableInAppLocation location;
 
     private IterableWebView webView;
     private boolean loaded;
@@ -61,7 +61,7 @@ public class IterableInAppFragmentHTMLNotification extends DialogFragment implem
      * @param htmlString
      * @return
      */
-    public static IterableInAppFragmentHTMLNotification createInstance(String htmlString, boolean callbackOnCancel, IterableHelper.IterableUrlCallback clickCallback, IterableInAppLocation location, String messageId, Double backgroundAlpha, Rect padding) {
+    public static IterableInAppFragmentHTMLNotification createInstance(@NonNull String htmlString, boolean callbackOnCancel, @NonNull IterableHelper.IterableUrlCallback clickCallback, @NonNull IterableInAppLocation location, @NonNull String messageId, @NonNull Double backgroundAlpha, @NonNull Rect padding) {
 
         notification = new IterableInAppFragmentHTMLNotification();
         Bundle args = new Bundle();
@@ -142,7 +142,7 @@ public class IterableInAppFragmentHTMLNotification extends DialogFragment implem
         };
         dialog.setOnCancelListener(new DialogInterface.OnCancelListener() {
             @Override public void onCancel(DialogInterface dialog) {
-                if (callbackOnCancel) {
+                if (callbackOnCancel && clickCallback != null) {
                     clickCallback.execute(null);
                 }
             }
@@ -239,7 +239,9 @@ public class IterableInAppFragmentHTMLNotification extends DialogFragment implem
     public void onUrlClicked(String url) {
         IterableApi.sharedInstance.trackInAppClick(messageId, url, location);
         IterableApi.sharedInstance.trackInAppClose(messageId, url, IterableInAppCloseAction.LINK, location);
-        clickCallback.execute(Uri.parse(url));
+        if (clickCallback != null) {
+            clickCallback.execute(Uri.parse(url));
+        }
         dismiss();
     }
 
@@ -267,7 +269,8 @@ public class IterableInAppFragmentHTMLNotification extends DialogFragment implem
             public void run() {
                 try {
                     // Since this is run asynchronously, notification might've been dismissed already
-                    if (notification == null || notification.getDialog() == null || notification.getDialog().getWindow() == null || !notification.getDialog().isShowing()) {
+                    if (getContext() == null || notification == null || notification.getDialog() == null ||
+                            notification.getDialog().getWindow() == null || !notification.getDialog().isShowing()) {
                         return;
                     }
 


### PR DESCRIPTION
These must happen under weird circumstances, since I'm not sure how it can get to that state.
This is just an immediate fix. In the future we should look at how to make it more resilient (how to keep the callback).
Fixes #241.