### PR TITLE
[MOB-1894] - In App Locks

### DIFF
--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableInAppManager.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableInAppManager.java
@@ -140,8 +140,8 @@ public class IterableInAppManager implements IterableActivityMonitor.AppStateCal
     }
 
     /**
-     * Set a pause to prevent showing an in-app automatically. By default the value is set to false.
-     * @param paused Whether to pause showing an in-app.
+     * Set a pause to prevent showing in-app messages automatically. By default the value is set to false.
+     * @param paused Whether to pause showing in-app messages.
      */
     public void setAutoDisplayPaused(boolean paused) {
         this.autoDisplayPaused = paused;

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableInAppManager.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableInAppManager.java
@@ -46,6 +46,7 @@ public class IterableInAppManager implements IterableActivityMonitor.AppStateCal
     private final List<Listener> listeners = new ArrayList<>();
     private long lastSyncTime = 0;
     private long lastInAppShown = 0;
+    private boolean autoDisplayPaused = false;
 
     IterableInAppManager(IterableApi iterableApi, IterableInAppHandler handler, double inAppDisplayInterval) {
         this(iterableApi,
@@ -131,6 +132,22 @@ public class IterableInAppManager implements IterableActivityMonitor.AppStateCal
     public synchronized void setRead(@NonNull IterableInAppMessage message, boolean read) {
         message.setRead(read);
         notifyOnChange();
+    }
+
+
+    boolean isAutoDisplayPaused() {
+        return autoDisplayPaused;
+    }
+
+    /**
+     * Set a pause to prevent showing an in-app automatically. By default the value is set to false.
+     * @param paused Whether to pause showing an in-app.
+     */
+    public void setAutoDisplayPaused(boolean paused) {
+        this.autoDisplayPaused = paused;
+        if (!paused) {
+            scheduleProcessing();
+        }
     }
 
     /**
@@ -310,7 +327,7 @@ public class IterableInAppManager implements IterableActivityMonitor.AppStateCal
     }
 
     private void processMessages() {
-        if (!activityMonitor.isInForeground() || isShowingInApp() || !canShowInAppAfterPrevious()) {
+        if (!activityMonitor.isInForeground() || isShowingInApp() || !canShowInAppAfterPrevious() || isAutoDisplayPaused()) {
             return;
         }
 

--- a/iterableapi/src/test/java/com/iterable/iterableapi/IterableInAppManagerTest.java
+++ b/iterableapi/src/test/java/com/iterable/iterableapi/IterableInAppManagerTest.java
@@ -43,6 +43,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.robolectric.Shadows.shadowOf;
 
@@ -368,6 +369,27 @@ public class IterableInAppManagerTest extends BaseTest {
         verify(inAppDisplayerMock).showMessage(any(IterableInAppMessage.class), eq(IterableInAppLocation.INBOX), callbackCaptor.capture());
         callbackCaptor.getValue().execute(Uri.parse("iterable://delete"));
         assertTrue(message.isConsumed());
+    }
+
+    @Test
+    public void testInAppAutoDisplayPause() throws Exception {
+        dispatcher.enqueueResponse("/inApp/getMessages", new MockResponse().setBody(IterableTestUtils.getResourceString("inapp_payload_single.json")));
+        IterableInAppManager inAppManager = IterableApi.getInstance().getInAppManager();
+        assertEquals(0, inAppManager.getMessages().size());
+
+        inAppManager.syncInApp();
+        Robolectric.flushBackgroundThreadScheduler();
+        Robolectric.flushForegroundThreadScheduler();
+        assertEquals(1, inAppManager.getMessages().size());
+
+        inAppManager.setAutoDisplayPaused(true);
+        ActivityController<Activity> activityController = Robolectric.buildActivity(Activity.class).create().start().resume();
+        Robolectric.flushForegroundThreadScheduler();
+        ArgumentCaptor<IterableInAppMessage> inAppMessageCaptor = ArgumentCaptor.forClass(IterableInAppMessage.class);
+        verify(inAppHandler, times(0)).onNewInApp(inAppMessageCaptor.capture());
+
+        inAppManager.setAutoDisplayPaused(false);
+        verify(inAppHandler, times(1)).onNewInApp(inAppMessageCaptor.capture());
     }
 
     private static class IterableSkipInAppHandler implements IterableInAppHandler {


### PR DESCRIPTION
A lock on processing and showing messages which will be checked along with other checks when processing the messages. The lock when set to false will trigger scheduleProcessing.