### PR TITLE
[MOB-2075] - Handle 401 jwt error code

### DIFF
--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableAuthManager.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableAuthManager.java
@@ -102,7 +102,7 @@ public class IterableAuthManager {
         return exp;
     }
 
-    private String getJson(String strEncoded) throws UnsupportedEncodingException {
+    private static String getJson(String strEncoded) throws UnsupportedEncodingException {
         byte[] decodedBytes = Base64.decode(strEncoded, Base64.URL_SAFE);
         return new String(decodedBytes, "UTF-8");
     }

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableAuthManager.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableAuthManager.java
@@ -35,6 +35,7 @@ public class IterableAuthManager {
     public void requestNewAuthToken() {
         //What do we do if there's already a pending auth? Ignore since it will eventually fix itself
         if (!pendingAuth) {
+        //I think the pending auth will help since push pushRegistration and getMessages happen sequentially.
             long currentTime = IterableUtil.currentTimeMillis();
             if (currentTime - lastTokenRequestTime >= rateLimitTime) {
                 pendingAuth = true;
@@ -88,7 +89,7 @@ public class IterableAuthManager {
         }, 0, timeDuration);
     }
 
-    public static int decodedExpiration(String encodedJWT) {
+    static int decodedExpiration(String encodedJWT) {
         int exp = 0;
         try {
             String[] split = encodedJWT.split("\\.");

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableAuthManager.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableAuthManager.java
@@ -26,8 +26,7 @@ public class IterableAuthManager {
 
     private int failedSequentialAuthRequestCount;
 
-    IterableAuthManager(IterableApi api)
-    {
+    IterableAuthManager(IterableApi api) {
         timer = new Timer();
         this.api = api;
     }
@@ -73,9 +72,9 @@ public class IterableAuthManager {
         }
     }
 
-    private void queueExpirationRefresh(String JWTEncoded) {
-        int expirationTimeSeconds = decodedExpiration(JWTEncoded);
-        long triggerExpirationRefreshTime = expirationTimeSeconds*1000 - refreshWindowTime - IterableUtil.currentTimeMillis();
+    private void queueExpirationRefresh(String encdodedJWT) {
+        int expirationTimeSeconds = decodedExpiration(encdodedJWT);
+        long triggerExpirationRefreshTime = expirationTimeSeconds * 1000 - refreshWindowTime - IterableUtil.currentTimeMillis();
         scheduleAuthTokenRefresh(triggerExpirationRefreshTime);
     }
 

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableAuthManager.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableAuthManager.java
@@ -34,15 +34,15 @@ public class IterableAuthManager {
 
     public void requestNewAuthToken() {
         //What do we do if there's already a pending auth? Ignore since it will eventually fix itself
-        //I think the pending auth will help since push pushRegistration and getMessages happen sequentially.
-        if (pendingAuth == false) {
+        if (!pendingAuth) {
             long currentTime = IterableUtil.currentTimeMillis();
             if (currentTime - lastTokenRequestTime >= rateLimitTime) {
                 pendingAuth = true;
 
                 failedSequentialAuthRequestCount++;
                 //Blocking call on a separate thread
-                String authToken = "";//onAuthTokenRequested();
+                String authToken = "";
+                //onAuthTokenRequested();
                 updateAuthToken(this.authToken);
             } else {
                 //queue up another requestNewAuthToken at currentTime + rateLimitTime
@@ -88,15 +88,15 @@ public class IterableAuthManager {
         }, 0, timeDuration);
     }
 
-    private int decodedExpiration(String JWTEncoded) {
+    public static int decodedExpiration(String encodedJWT) {
         int exp = 0;
         try {
-            String[] split = JWTEncoded.split("\\.");
+            String[] split = encodedJWT.split("\\.");
             String body = getJson(split[1]);
             JSONObject jObj = new JSONObject(body);
             exp = jObj.getInt(expirationString);
         } catch (Exception e) {
-            IterableLogger.e(TAG, "Error while parsing JWT for the expiration: " + JWTEncoded, e);
+            IterableLogger.e(TAG, "Error while parsing JWT for the expiration: " + encodedJWT, e);
         }
         return exp;
     }

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableRequest.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableRequest.java
@@ -162,9 +162,12 @@ class IterableRequest extends AsyncTask<IterableApiRequest, Void, String> {
 
                 // Handle HTTP status codes
                 if (responseCode == 401) {
-                    // Add a rate limiter here if too many are called. Clear on success
-
-                    handleFailure("Invalid API Key", jsonResponse);
+                    if (jsonResponse.getString("msg") == "JWT Authorization header is not set") {
+                        handleFailure("JWT Authorization header is not set", jsonResponse);
+                        // TODO: Add a rate limiter here if too many are called. Clear on success
+                    } else {
+                        handleFailure("Invalid API Key", jsonResponse);
+                    }
                 } else if (responseCode >= 400) {
                     String errorMessage = "Invalid Request";
 


### PR DESCRIPTION
Code is still 401.
Just an additional check if the message returned is "JWT Authorization header is not set", as currently sent by our backend.
If there are different types of error messages for jwt, I would need to update that here. Or have some different approach.
For e.g, "invalid authKey", "expired authKey" etc