### PR TITLE
[MOB-2234] - Fix for SDK Crash on inapp close

### DIFF
--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableInAppFragmentHTMLNotification.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableInAppFragmentHTMLNotification.java
@@ -258,6 +258,11 @@ public class IterableInAppFragmentHTMLNotification extends DialogFragment implem
 
     private void processMessageRemoval() {
         IterableInAppMessage message = IterableApi.sharedInstance.getInAppManager().getMessageById(messageId);
+        if (message == null) {
+            IterableLogger.e(TAG, "Message with id " + messageId + " does not exist");
+            return;
+        }
+
         if (message.isMarkedForDeletion() && !message.isConsumed()) {
             IterableApi.sharedInstance.getInAppManager().removeMessage(message);
         }


### PR DESCRIPTION
Added a check if message is null in case the message gets deleted in the background and gets synced with the app.