### PR TITLE
[MOB-2270] Support delayed initialization

### DIFF
--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
@@ -297,6 +297,7 @@ private static final String TAG = "IterableApi";
         IterableActivityMonitor.getInstance().registerLifecycleCallbacks(context);
         IterableActivityMonitor.getInstance().addCallback(sharedInstance.activityMonitorListener);
         sharedInstance.inAppManager = new IterableInAppManager(sharedInstance, sharedInstance.config.inAppHandler, sharedInstance.config.inAppDisplayInterval);
+        IterablePushActionReceiver.processPendingAction(context);
     }
 
     /**

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableFirebaseMessagingService.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableFirebaseMessagingService.java
@@ -67,7 +67,7 @@ public class IterableFirebaseMessagingService extends FirebaseMessagingService {
             IterableLogger.d(TAG, "Iterable ghost silent push received");
 
             String notificationType = extras.getString("notificationType");
-            if (notificationType != null) {
+            if (notificationType != null && IterableApi.getInstance().getMainActivityContext() != null) {
                 if (notificationType.equals("InAppUpdate")) {
                     IterableApi.getInstance().getInAppManager().syncInApp();
                 } else if (notificationType.equals("InAppRemove")) {


### PR DESCRIPTION
Currently, we require that `IterableApi.initialize` is always called in `Application#onCreate`. However, there is no easy way to do that in React Native. This adds support for late initialization of the SDK with two changes:
* Push actions: If SDK is not initialized by the time we receive a push action, it is stored in a static variable and executed after SDK init
* Silent push messages are skipped if (we're going to refresh the in-app queue on launch anyway, so skipping these should be fine)