### PR TITLE
[MOB-2341] Refactor tests to not depend on partial mocks

### DIFF
--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
@@ -296,7 +296,10 @@ private static final String TAG = "IterableApi";
         sharedInstance.checkForDeferredDeeplink();
         IterableActivityMonitor.getInstance().registerLifecycleCallbacks(context);
         IterableActivityMonitor.getInstance().addCallback(sharedInstance.activityMonitorListener);
-        sharedInstance.inAppManager = new IterableInAppManager(sharedInstance, sharedInstance.config.inAppHandler, sharedInstance.config.inAppDisplayInterval);
+        if (sharedInstance.inAppManager == null) {
+            sharedInstance.inAppManager = new IterableInAppManager(sharedInstance, sharedInstance.config.inAppHandler,
+                    sharedInstance.config.inAppDisplayInterval);
+        }
         IterablePushActionReceiver.processPendingAction(context);
     }
 

--- a/iterableapi/src/test/java/com/iterable/iterableapi/BasePowerMockTest.java
+++ b/iterableapi/src/test/java/com/iterable/iterableapi/BasePowerMockTest.java
@@ -1,5 +1,9 @@
 package com.iterable.iterableapi;
 
+import android.content.Context;
+
+import androidx.test.core.app.ApplicationProvider;
+
 import com.iterable.iterableapi.unit.TestRunner;
 
 import org.junit.Rule;
@@ -25,5 +29,9 @@ public abstract class BasePowerMockTest {
 
     @Rule
     public PowerMockRule rule = new PowerMockRule();
+
+    public Context getContext() {
+        return ApplicationProvider.getApplicationContext();
+    }
 
 }

--- a/iterableapi/src/test/java/com/iterable/iterableapi/BaseTest.java
+++ b/iterableapi/src/test/java/com/iterable/iterableapi/BaseTest.java
@@ -2,13 +2,14 @@ package com.iterable.iterableapi;
 
 import android.content.Context;
 
+import androidx.test.core.app.ApplicationProvider;
+
 import com.iterable.iterableapi.unit.TestRunner;
 
 import org.junit.Rule;
 import org.junit.rules.TestWatcher;
 import org.junit.runner.Description;
 import org.junit.runner.RunWith;
-import org.robolectric.RuntimeEnvironment;
 import org.robolectric.android.util.concurrent.InlineExecutorService;
 import org.robolectric.shadows.ShadowPausedAsyncTask;
 
@@ -26,7 +27,7 @@ public abstract class BaseTest {
     }
 
     protected Context getContext() {
-        return RuntimeEnvironment.application;
+        return ApplicationProvider.getApplicationContext();
     }
 
     private static class AsyncTaskRule extends TestWatcher {

--- a/iterableapi/src/test/java/com/iterable/iterableapi/DeferredDeepLinkTest.java
+++ b/iterableapi/src/test/java/com/iterable/iterableapi/DeferredDeepLinkTest.java
@@ -6,7 +6,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
-import org.robolectric.RuntimeEnvironment;
 
 import java.io.IOException;
 
@@ -53,7 +52,7 @@ public class DeferredDeepLinkTest extends BaseTest {
                 .setUrlHandler(urlHandlerMock)
                 .setCheckForDeferredDeeplink(true)
                 .build();
-        IterableApi.initialize(RuntimeEnvironment.application, "apiKey", config);
+        IterableApi.initialize(getContext(), "apiKey", config);
         shadowOf(getMainLooper()).idle();
 
         // Verify that IterableActionRunner was called with openUrl action
@@ -68,7 +67,7 @@ public class DeferredDeepLinkTest extends BaseTest {
         server.enqueue(new MockResponse().setBody(IterableTestUtils.getResourceString("fp_match_success.json")));
         reset(urlHandlerMock);
         IterableTestUtils.resetIterableApi();
-        IterableApi.initialize(RuntimeEnvironment.application, "apiKey", config);
+        IterableApi.initialize(getContext(), "apiKey", config);
         verify(urlHandlerMock, after(100).never()).handleIterableURL(any(Uri.class), any(IterableActionContext.class));
     }
 
@@ -83,7 +82,7 @@ public class DeferredDeepLinkTest extends BaseTest {
                 .setUrlHandler(urlHandlerMock)
                 .setCheckForDeferredDeeplink(false)
                 .build();
-        IterableApi.initialize(RuntimeEnvironment.application, "apiKey", config);
+        IterableApi.initialize(getContext(), "apiKey", config);
 
         // Verify that the deferred deep link is never handled since it is disabled
         verify(urlHandlerMock, after(100).never()).handleIterableURL(any(Uri.class), any(IterableActionContext.class));
@@ -100,7 +99,7 @@ public class DeferredDeepLinkTest extends BaseTest {
                 .setUrlHandler(urlHandlerMock)
                 .setCheckForDeferredDeeplink(true)
                 .build();
-        IterableApi.initialize(RuntimeEnvironment.application, "apiKey", config);
+        IterableApi.initialize(getContext(), "apiKey", config);
 
         // Verify that the URL handler wasn't called because fingerprint matcher returned no result
         verify(urlHandlerMock, after(100).never()).handleIterableURL(any(Uri.class), any(IterableActionContext.class));

--- a/iterableapi/src/test/java/com/iterable/iterableapi/IterableActivityMonitorTest.java
+++ b/iterableapi/src/test/java/com/iterable/iterableapi/IterableActivityMonitorTest.java
@@ -6,7 +6,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.robolectric.Robolectric;
-import org.robolectric.RuntimeEnvironment;
 import org.robolectric.android.controller.ActivityController;
 
 import static org.junit.Assert.assertFalse;
@@ -20,12 +19,12 @@ public class IterableActivityMonitorTest extends BaseTest {
 
     @Before
     public void setUp() {
-        IterableActivityMonitor.getInstance().registerLifecycleCallbacks(RuntimeEnvironment.application);
+        IterableActivityMonitor.getInstance().registerLifecycleCallbacks(getContext());
     }
 
     @After
     public void tearDown() {
-        IterableActivityMonitor.getInstance().unregisterLifecycleCallbacks(RuntimeEnvironment.application);
+        IterableActivityMonitor.getInstance().unregisterLifecycleCallbacks(getContext());
         IterableActivityMonitor.instance = new IterableActivityMonitor();
     }
 

--- a/iterableapi/src/test/java/com/iterable/iterableapi/IterableApiAuthTests.java
+++ b/iterableapi/src/test/java/com/iterable/iterableapi/IterableApiAuthTests.java
@@ -33,8 +33,6 @@ import static org.robolectric.annotation.LooperMode.Mode.PAUSED;
 @LooperMode(PAUSED)
 public class IterableApiAuthTests extends BaseTest {
 
-    private IterableUtil.IterableUtilImpl originalIterableUtil;
-    private IterableUtil.IterableUtilImpl iterableUtilSpy;
     private MockWebServer server;
     private IterableAuthHandler authHandler;
     private PathBasedQueueDispatcher dispatcher;
@@ -52,10 +50,6 @@ public class IterableApiAuthTests extends BaseTest {
         IterableApi.overrideURLEndpointPath(server.url("").toString());
         reInitIterableApi();
 
-        originalIterableUtil = IterableUtil.instance;
-        iterableUtilSpy = spy(originalIterableUtil);
-        IterableUtil.instance = iterableUtilSpy;
-
         IterableTestUtils.createIterableApiNew(new IterableTestUtils.ConfigBuilderExtender() {
             @Override
             public IterableConfig.Builder run(IterableConfig.Builder builder) {
@@ -66,8 +60,6 @@ public class IterableApiAuthTests extends BaseTest {
 
     @After
     public void tearDown() throws IOException {
-        IterableUtil.instance = originalIterableUtil;
-        iterableUtilSpy = null;
         server.shutdown();
         server = null;
     }

--- a/iterableapi/src/test/java/com/iterable/iterableapi/IterableApiAuthTests.java
+++ b/iterableapi/src/test/java/com/iterable/iterableapi/IterableApiAuthTests.java
@@ -7,7 +7,6 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.robolectric.Robolectric;
-import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.LooperMode;
 
 import java.io.IOException;
@@ -74,7 +73,7 @@ public class IterableApiAuthTests extends BaseTest {
     @Ignore ("Ignoring the JWT Tests")
     @Test
     public void testRefreshToken() throws Exception {
-        IterableApi.initialize(RuntimeEnvironment.application, "apiKey");
+        IterableApi.initialize(getContext(), "apiKey");
         Timer timer = IterableApi.getInstance().getAuthManager().timer;
 
         IterableApi api = IterableApi.getInstance();
@@ -102,7 +101,7 @@ public class IterableApiAuthTests extends BaseTest {
     @Ignore ("Ignoring the JWT Tests")
     @Test
     public void testSetEmailWithToken() throws Exception {
-        IterableApi.initialize(RuntimeEnvironment.application, "apiKey");
+        IterableApi.initialize(getContext(), "apiKey");
 
         String email = "test@example.com";
         IterableApi.getInstance().setEmail(email);
@@ -126,7 +125,7 @@ public class IterableApiAuthTests extends BaseTest {
     @Ignore ("Ignoring the JWT Tests")
     @Test
     public void testSetEmailWithTokenExpired() throws Exception {
-        IterableApi.initialize(RuntimeEnvironment.application, "apiKey");
+        IterableApi.initialize(getContext(), "apiKey");
 
         String email = "test@example.com";
         doReturn(expiredJWT).when(authHandler).onAuthTokenRequested();
@@ -140,7 +139,7 @@ public class IterableApiAuthTests extends BaseTest {
     @Ignore ("Ignoring the JWT Tests")
     @Test
     public void testSetUserIdWithToken() throws Exception {
-        IterableApi.initialize(RuntimeEnvironment.application, "apiKey");
+        IterableApi.initialize(getContext(), "apiKey");
 
         String userId = "testUserId";
         IterableApi.getInstance().setUserId(userId);
@@ -164,7 +163,7 @@ public class IterableApiAuthTests extends BaseTest {
     @Ignore ("Ignoring the JWT Tests")
     @Test
     public void testSameEmailWithNewToken() throws Exception {
-        IterableApi.initialize(RuntimeEnvironment.application, "apiKey");
+        IterableApi.initialize(getContext(), "apiKey");
 
         String email = "test@example.com";
         IterableApi.getInstance().setEmail(email);
@@ -188,7 +187,7 @@ public class IterableApiAuthTests extends BaseTest {
     @Ignore ("Ignoring the JWT Tests")
     @Test
     public void testSameUserIdWithNewToken() throws Exception {
-        IterableApi.initialize(RuntimeEnvironment.application, "apiKey");
+        IterableApi.initialize(getContext(), "apiKey");
 
         String userId = "testUserId";
         doReturn(validJWT).when(authHandler).onAuthTokenRequested();
@@ -207,7 +206,7 @@ public class IterableApiAuthTests extends BaseTest {
     @Ignore ("Ignoring the JWT Tests")
     @Test
     public void testSetSameEmailAndRemoveToken() throws Exception {
-        IterableApi.initialize(RuntimeEnvironment.application, "apiKey");
+        IterableApi.initialize(getContext(), "apiKey");
         String email = "test@example.com";
 
         doReturn(validJWT).when(authHandler).onAuthTokenRequested();
@@ -226,7 +225,7 @@ public class IterableApiAuthTests extends BaseTest {
     @Ignore ("Ignoring the JWT Tests")
     @Test
     public void testSetSameUserIdAndRemoveToken() throws Exception {
-        IterableApi.initialize(RuntimeEnvironment.application, "apiKey");
+        IterableApi.initialize(getContext(), "apiKey");
 
         String userId = "testUserId";
         doReturn(validJWT).when(authHandler).onAuthTokenRequested();
@@ -245,7 +244,7 @@ public class IterableApiAuthTests extends BaseTest {
 
     @Test
     public void testSetSameEmail() throws Exception {
-        IterableApi.initialize(RuntimeEnvironment.application, "apiKey");
+        IterableApi.initialize(getContext(), "apiKey");
 
         String email = "test@example.com";
 
@@ -264,7 +263,7 @@ public class IterableApiAuthTests extends BaseTest {
 
     @Test
     public void testSetSameUserId() throws Exception {
-        IterableApi.initialize(RuntimeEnvironment.application, "apiKey");
+        IterableApi.initialize(getContext(), "apiKey");
 
         String userId = "testUserId";
 
@@ -284,7 +283,7 @@ public class IterableApiAuthTests extends BaseTest {
     @Ignore ("Ignoring the JWT Tests")
     @Test
     public void testSetSameEmailWithSameToken() throws Exception {
-        IterableApi.initialize(RuntimeEnvironment.application, "apiKey");
+        IterableApi.initialize(getContext(), "apiKey");
 
         String email = "test@example.com";
         String token = validJWT;
@@ -304,7 +303,7 @@ public class IterableApiAuthTests extends BaseTest {
     @Ignore ("Ignoring the JWT Tests")
     @Test
     public void testSetSameUserIdWithSameToken() throws Exception {
-        IterableApi.initialize(RuntimeEnvironment.application, "apiKey");
+        IterableApi.initialize(getContext(), "apiKey");
 
         String userId = "testUserId";
         String token = validJWT;
@@ -323,7 +322,7 @@ public class IterableApiAuthTests extends BaseTest {
 
     @Test
     public void testEmailLogOut() throws Exception {
-        IterableApi.initialize(RuntimeEnvironment.application, "apiKey");
+        IterableApi.initialize(getContext(), "apiKey");
 
         String email = "test@example.com";
         doReturn(validJWT).when(authHandler).onAuthTokenRequested();
@@ -340,7 +339,7 @@ public class IterableApiAuthTests extends BaseTest {
 
     @Test
     public void testUserIdLogOut() throws Exception {
-        IterableApi.initialize(RuntimeEnvironment.application, "apiKey");
+        IterableApi.initialize(getContext(), "apiKey");
 
         String userId = "testUserId";
 
@@ -362,7 +361,7 @@ public class IterableApiAuthTests extends BaseTest {
 //        server.enqueue(new MockResponse().setResponseCode(200).setBody("{}"));
         dispatcher.enqueueResponse(ENDPOINT_UPDATE_EMAIL, new MockResponse().setResponseCode(200).setBody("{}"));
         shadowOf(getMainLooper()).runToEndOfTasks();
-        IterableApi.initialize(RuntimeEnvironment.application, "apiKey", new IterableConfig.Builder().setAutoPushRegistration(false).build());
+        IterableApi.initialize(getContext(), "apiKey", new IterableConfig.Builder().setAutoPushRegistration(false).build());
         RecordedRequest getMessagesRequest = server.takeRequest(1, TimeUnit.SECONDS);
         assertNull(getMessagesRequest.getHeader("Authorization"));
 

--- a/iterableapi/src/test/java/com/iterable/iterableapi/IterableApiTest.java
+++ b/iterableapi/src/test/java/com/iterable/iterableapi/IterableApiTest.java
@@ -12,7 +12,6 @@ import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.robolectric.Robolectric;
-import org.robolectric.RuntimeEnvironment;
 import org.robolectric.android.controller.ActivityController;
 
 import java.io.IOException;
@@ -69,7 +68,7 @@ public class IterableApiTest extends BaseTest {
 
     @Test
     public void testSdkInitializedWithoutEmailOrUserId() throws Exception {
-        IterableApi.initialize(RuntimeEnvironment.application, "apiKey");
+        IterableApi.initialize(getContext(), "apiKey");
         IterableApi.getInstance().setEmail(null);
 
         // Verify that none of the calls to the API result in a request
@@ -89,24 +88,24 @@ public class IterableApiTest extends BaseTest {
 
     @Test
     public void testEmailUserIdPersistence() throws Exception {
-        IterableApi.initialize(RuntimeEnvironment.application, "apiKey");
+        IterableApi.initialize(getContext(), "apiKey");
         IterableApi.getInstance().setEmail("test@email.com");
 
         reInitIterableApi();
-        IterableApi.initialize(RuntimeEnvironment.application, "apiKey");
+        IterableApi.initialize(getContext(), "apiKey");
         assertEquals("test@email.com", IterableApi.getInstance().getEmail());
         assertNull(IterableApi.getInstance().getUserId());
 
         IterableApi.getInstance().setUserId("testUserId");
         reInitIterableApi();
-        IterableApi.initialize(RuntimeEnvironment.application, "apiKey");
+        IterableApi.initialize(getContext(), "apiKey");
         assertEquals("testUserId", IterableApi.getInstance().getUserId());
         assertNull(IterableApi.getInstance().getEmail());
     }
 
     @Test
     public void testAttributionInfoPersistence() throws Exception {
-        IterableApi.initialize(RuntimeEnvironment.application, "apiKey");
+        IterableApi.initialize(getContext(), "apiKey");
 
         IterableAttributionInfo attributionInfo = new IterableAttributionInfo(1234, 4321, "message");
         IterableApi.getInstance().setAttributionInfo(attributionInfo);
@@ -128,7 +127,7 @@ public class IterableApiTest extends BaseTest {
     @Test
     public void testUpdateEmailPersistence() throws Exception {
         server.enqueue(new MockResponse().setResponseCode(200).setBody("{}"));
-        IterableApi.initialize(RuntimeEnvironment.application, "apiKey");
+        IterableApi.initialize(getContext(), "apiKey");
         IterableApi.getInstance().setEmail("test@email.com");
         assertEquals("test@email.com", IterableApi.getInstance().getEmail());
 
@@ -138,14 +137,14 @@ public class IterableApiTest extends BaseTest {
         assertEquals("new@email.com", IterableApi.getInstance().getEmail());
 
         reInitIterableApi();
-        IterableApi.initialize(RuntimeEnvironment.application, "apiKey");
+        IterableApi.initialize(getContext(), "apiKey");
         assertEquals("new@email.com", IterableApi.getInstance().getEmail());
     }
 
     @Test
     public void testUpdateEmailWithOldEmail() throws Exception {
         server.enqueue(new MockResponse().setResponseCode(200).setBody("{}"));
-        IterableApi.initialize(RuntimeEnvironment.application, "apiKey");
+        IterableApi.initialize(getContext(), "apiKey");
         IterableApi.getInstance().setEmail("test@email.com");
         IterableApi.getInstance().updateEmail("new@email.com");
 
@@ -160,7 +159,7 @@ public class IterableApiTest extends BaseTest {
     @Test
     public void testUpdateEmailWithUserId() throws Exception {
         server.enqueue(new MockResponse().setResponseCode(200).setBody("{}"));
-        IterableApi.initialize(RuntimeEnvironment.application, "apiKey");
+        IterableApi.initialize(getContext(), "apiKey");
         IterableApi.getInstance().setUserId("testUserId");
         IterableApi.getInstance().updateEmail("new@email.com");
 
@@ -178,8 +177,7 @@ public class IterableApiTest extends BaseTest {
     public void testHandleUniversalLinkRewrite() throws Exception {
         IterableUrlHandler urlHandlerMock = mock(IterableUrlHandler.class);
         when(urlHandlerMock.handleIterableURL(any(Uri.class), any(IterableActionContext.class))).thenReturn(true);
-        IterableApi.initialize(RuntimeEnvironment.application, "fake_key",
-                new IterableConfig.Builder().setUrlHandler(urlHandlerMock).build());
+        IterableApi.initialize(getContext(), "fake_key", new IterableConfig.Builder().setUrlHandler(urlHandlerMock).build());
 
         String url = "https://links.iterable.com/api/docs#!/email";
         IterableApi.handleAppLink(
@@ -197,7 +195,7 @@ public class IterableApiTest extends BaseTest {
 
     @Test
     public void testSetEmailWithAutomaticPushRegistration() throws Exception {
-        IterableApi.initialize(RuntimeEnvironment.application, "fake_key", new IterableConfig.Builder().setPushIntegrationName("pushIntegration").setAutoPushRegistration(true).build());
+        IterableApi.initialize(getContext(), "fake_key", new IterableConfig.Builder().setPushIntegrationName("pushIntegration").setAutoPushRegistration(true).build());
 
         // Check that setEmail calls registerForPush
         IterableApi.getInstance().setEmail("test@email.com");
@@ -212,7 +210,7 @@ public class IterableApiTest extends BaseTest {
 
     @Test
     public void testSetEmailWithoutAutomaticPushRegistration() throws Exception {
-        IterableApi.initialize(RuntimeEnvironment.application, "fake_key", new IterableConfig.Builder().setPushIntegrationName("pushIntegration").setAutoPushRegistration(false).build());
+        IterableApi.initialize(getContext(), "fake_key", new IterableConfig.Builder().setPushIntegrationName("pushIntegration").setAutoPushRegistration(false).build());
 
         // Check that setEmail doesn't call registerForPush or disablePush
         IterableApi.getInstance().setEmail("test@email.com");
@@ -224,7 +222,7 @@ public class IterableApiTest extends BaseTest {
 
     @Test
     public void testSetUserIdWithAutomaticPushRegistration() throws Exception {
-        IterableApi.initialize(RuntimeEnvironment.application, "fake_key", new IterableConfig.Builder().setPushIntegrationName("pushIntegration").setAutoPushRegistration(true).build());
+        IterableApi.initialize(getContext(), "fake_key", new IterableConfig.Builder().setPushIntegrationName("pushIntegration").setAutoPushRegistration(true).build());
 
         // Check that setUserId calls registerForPush
         IterableApi.getInstance().setUserId("userId");
@@ -239,7 +237,7 @@ public class IterableApiTest extends BaseTest {
 
     @Test
     public void testSetUserIdWithoutAutomaticPushRegistration() throws Exception {
-        IterableApi.initialize(RuntimeEnvironment.application, "fake_key", new IterableConfig.Builder().setPushIntegrationName("pushIntegration").setAutoPushRegistration(false).build());
+        IterableApi.initialize(getContext(), "fake_key", new IterableConfig.Builder().setPushIntegrationName("pushIntegration").setAutoPushRegistration(false).build());
 
         // Check that setEmail calls registerForPush
         IterableApi.getInstance().setUserId("userId");
@@ -251,35 +249,35 @@ public class IterableApiTest extends BaseTest {
 
     @Test
     public void testNoAutomaticPushRegistrationOnInit() throws Exception {
-        IterableApi.initialize(RuntimeEnvironment.application, "fake_key", new IterableConfig.Builder().setPushIntegrationName("pushIntegration").setAutoPushRegistration(true).build());
+        IterableApi.initialize(getContext(), "fake_key", new IterableConfig.Builder().setPushIntegrationName("pushIntegration").setAutoPushRegistration(true).build());
         IterableApi.getInstance().setEmail("test@email.com");
 
         reInitIterableApi();
-        IterableApi.initialize(RuntimeEnvironment.application, "fake_key", new IterableConfig.Builder().setPushIntegrationName("pushIntegration").setAutoPushRegistration(true).build());
+        IterableApi.initialize(getContext(), "fake_key", new IterableConfig.Builder().setPushIntegrationName("pushIntegration").setAutoPushRegistration(true).build());
         verify(IterableApi.sharedInstance, never()).registerForPush();
         Mockito.reset(IterableApi.sharedInstance);
     }
 
     @Test
     public void testAutomaticPushRegistrationOnInitAndForeground() throws Exception {
-        IterableApi.initialize(RuntimeEnvironment.application, "fake_key", new IterableConfig.Builder().setPushIntegrationName("pushIntegration").setAutoPushRegistration(true).build());
+        IterableApi.initialize(getContext(), "fake_key", new IterableConfig.Builder().setPushIntegrationName("pushIntegration").setAutoPushRegistration(true).build());
         IterableApi.getInstance().setEmail("test@email.com");
 
         reInitIterableApi();
-        IterableActivityMonitor.getInstance().unregisterLifecycleCallbacks(RuntimeEnvironment.application);
+        IterableActivityMonitor.getInstance().unregisterLifecycleCallbacks(getContext());
         IterableActivityMonitor.instance = new IterableActivityMonitor();
-        IterableApi.initialize(RuntimeEnvironment.application, "fake_key", new IterableConfig.Builder().setPushIntegrationName("pushIntegration").setAutoPushRegistration(true).build());
+        IterableApi.initialize(getContext(), "fake_key", new IterableConfig.Builder().setPushIntegrationName("pushIntegration").setAutoPushRegistration(true).build());
         ActivityController<Activity> activityController = Robolectric.buildActivity(Activity.class).create().start().resume();
         verify(IterableApi.sharedInstance).registerForPush();
         Mockito.reset(IterableApi.sharedInstance);
         activityController.pause().stop().destroy();
-        IterableActivityMonitor.getInstance().unregisterLifecycleCallbacks(RuntimeEnvironment.application);
+        IterableActivityMonitor.getInstance().unregisterLifecycleCallbacks(getContext());
     }
 
     @Test
     public void testPushRegistrationDeviceFields() throws Exception {
         server.enqueue(new MockResponse().setResponseCode(200).setBody("{}"));
-        IterableApi.initialize(RuntimeEnvironment.application, "apiKey", new IterableConfig.Builder().setAutoPushRegistration(false).build());
+        IterableApi.initialize(getContext(), "apiKey", new IterableConfig.Builder().setAutoPushRegistration(false).build());
         IterableApi.getInstance().setEmail("test@email.com");
         IterableApi.getInstance().registerDeviceToken("token");
         Thread.sleep(100);  // Since the network request is queued from a background thread, we need to wait
@@ -302,7 +300,7 @@ public class IterableApiTest extends BaseTest {
     public void testPushRegistrationWithUserId() throws Exception {
         server.enqueue(new MockResponse().setResponseCode(200).setBody("{}"));
 
-        IterableApi.initialize(RuntimeEnvironment.application, "apiKey", new IterableConfig.Builder().setAutoPushRegistration(false).build());
+        IterableApi.initialize(getContext(), "apiKey", new IterableConfig.Builder().setAutoPushRegistration(false).build());
         IterableApi.getInstance().setUserId("testUserId");
         IterableApi.getInstance().registerDeviceToken("token");
         Thread.sleep(1000);  // Since the network request is queued from a background thread, we need to wait
@@ -317,7 +315,7 @@ public class IterableApiTest extends BaseTest {
 
     @Test
     public void testInAppResetOnLogout() throws Exception {
-        IterableApi.initialize(RuntimeEnvironment.application, "fake_key", new IterableConfig.Builder().setPushIntegrationName("pushIntegration").setAutoPushRegistration(true).build());
+        IterableApi.initialize(getContext(), "fake_key", new IterableConfig.Builder().setPushIntegrationName("pushIntegration").setAutoPushRegistration(true).build());
 
         IterableApi.getInstance().setEmail("test@email.com");
         IterableApi.getInstance().setEmail(null);
@@ -328,7 +326,7 @@ public class IterableApiTest extends BaseTest {
     public void testUpdateUserWithUserId() throws Exception {
         server.enqueue(new MockResponse().setResponseCode(200).setBody("{}"));
 
-        IterableApi.initialize(RuntimeEnvironment.application, "apiKey", new IterableConfig.Builder().setAutoPushRegistration(false).build());
+        IterableApi.initialize(getContext(), "apiKey", new IterableConfig.Builder().setAutoPushRegistration(false).build());
         IterableApi.getInstance().setUserId("testUserId");
         IterableApi.getInstance().updateUser(new JSONObject("{\"key\": \"value\"}"));
         shadowOf(getMainLooper()).idle();
@@ -348,7 +346,7 @@ public class IterableApiTest extends BaseTest {
 
         IterableHelper.IterableActionHandler handlerMock = mock(IterableHelper.IterableActionHandler.class);
 
-        IterableApi.initialize(RuntimeEnvironment.application, "apiKey", new IterableConfig.Builder().setAutoPushRegistration(false).build());
+        IterableApi.initialize(getContext(), "apiKey", new IterableConfig.Builder().setAutoPushRegistration(false).build());
         IterableApi.getInstance().setEmail("test@email.com");
         IterableApi.getInstance().getInAppMessages(10, handlerMock);
         shadowOf(getMainLooper()).idle();
@@ -362,14 +360,14 @@ public class IterableApiTest extends BaseTest {
         assertEquals("10", uri.getQueryParameter(IterableConstants.ITERABLE_IN_APP_COUNT));
         assertEquals(IterableConstants.ITBL_PLATFORM_ANDROID, uri.getQueryParameter(IterableConstants.KEY_PLATFORM));
         assertEquals(IterableConstants.ITBL_KEY_SDK_VERSION_NUMBER, uri.getQueryParameter(IterableConstants.ITBL_KEY_SDK_VERSION));
-        assertEquals(RuntimeEnvironment.application.getPackageName(), uri.getQueryParameter(IterableConstants.KEY_PACKAGE_NAME));
+        assertEquals(getContext().getPackageName(), uri.getQueryParameter(IterableConstants.KEY_PACKAGE_NAME));
     }
 
     @Test
     public void testInAppOpen() throws Exception {
         server.enqueue(new MockResponse().setResponseCode(200).setBody("{}"));
 
-        IterableApi.initialize(RuntimeEnvironment.application, "apiKey", new IterableConfig.Builder().setAutoPushRegistration(false).build());
+        IterableApi.initialize(getContext(), "apiKey", new IterableConfig.Builder().setAutoPushRegistration(false).build());
         IterableApi.getInstance().setEmail("test@email.com");
         IterableApi.getInstance().trackInAppOpen("testMessageId");
         shadowOf(getMainLooper()).idle();
@@ -388,7 +386,7 @@ public class IterableApiTest extends BaseTest {
 
         IterableInAppMessage message = InAppTestUtils.getTestInAppMessage();
 
-        IterableApi.initialize(RuntimeEnvironment.application, "apiKey", new IterableConfig.Builder().setAutoPushRegistration(false).build());
+        IterableApi.initialize(getContext(), "apiKey", new IterableConfig.Builder().setAutoPushRegistration(false).build());
         IterableApi.getInstance().setEmail("test@email.com");
         IterableApi.getInstance().setInboxSessionId("SomeRandomSessionID");
         IterableApi.getInstance().trackInAppOpen(message, IterableInAppLocation.IN_APP);
@@ -409,7 +407,7 @@ public class IterableApiTest extends BaseTest {
     public void testInAppClick() throws Exception {
         server.enqueue(new MockResponse().setResponseCode(200).setBody("{}"));
 
-        IterableApi.initialize(RuntimeEnvironment.application, "apiKey", new IterableConfig.Builder().setAutoPushRegistration(false).build());
+        IterableApi.initialize(getContext(), "apiKey", new IterableConfig.Builder().setAutoPushRegistration(false).build());
         IterableApi.getInstance().setEmail("test@email.com");
         IterableApi.getInstance().trackInAppClick("testMessageId", "https://www.google.com");
         shadowOf(getMainLooper()).idle();
@@ -429,7 +427,7 @@ public class IterableApiTest extends BaseTest {
 
         IterableInAppMessage message = InAppTestUtils.getTestInAppMessage();
 
-        IterableApi.initialize(RuntimeEnvironment.application, "apiKey",
+        IterableApi.initialize(getContext(), "apiKey",
                 new IterableConfig.Builder().setAutoPushRegistration(false).build());
         IterableApi.getInstance().setEmail("test@email.com");
 
@@ -469,7 +467,7 @@ public class IterableApiTest extends BaseTest {
 
         IterableInAppMessage message = InAppTestUtils.getTestInAppMessage();
 
-        IterableApi.initialize(RuntimeEnvironment.application, "apiKey", new IterableConfig.Builder().setAutoPushRegistration(false).build());
+        IterableApi.initialize(getContext(), "apiKey", new IterableConfig.Builder().setAutoPushRegistration(false).build());
         IterableApi.getInstance().setEmail("test@email.com");
 
         IterableApi.getInstance().setInboxSessionId("SomeRandomSessionID");
@@ -494,7 +492,7 @@ public class IterableApiTest extends BaseTest {
 
         IterableInAppMessage message = InAppTestUtils.getTestInAppMessage();
 
-        IterableApi.initialize(RuntimeEnvironment.application, "apiKey", new IterableConfig.Builder().setAutoPushRegistration(false).build());
+        IterableApi.initialize(getContext(), "apiKey", new IterableConfig.Builder().setAutoPushRegistration(false).build());
         IterableApi.getInstance().setEmail("test@email.com");
         IterableApi.getInstance().trackInAppDelivery(message);
         shadowOf(getMainLooper()).idle();
@@ -515,7 +513,7 @@ public class IterableApiTest extends BaseTest {
 
         IterableInAppMessage message = InAppTestUtils.getTestInAppMessage();
 
-        IterableApi.initialize(RuntimeEnvironment.application, "apiKey", new IterableConfig.Builder().setAutoPushRegistration(false).build());
+        IterableApi.initialize(getContext(), "apiKey", new IterableConfig.Builder().setAutoPushRegistration(false).build());
         IterableApi.getInstance().setEmail("test@email.com");
 
         // Set up test data
@@ -592,7 +590,7 @@ public class IterableApiTest extends BaseTest {
 
         IterableInAppMessage message = InAppTestUtils.getTestInAppMessage();
 
-        IterableApi.initialize(RuntimeEnvironment.application, "apiKey", new IterableConfig.Builder().setAutoPushRegistration(false).build());
+        IterableApi.initialize(getContext(), "apiKey", new IterableConfig.Builder().setAutoPushRegistration(false).build());
         IterableApi.getInstance().setEmail("test@email.com");
 
         //Explicitly updating sessionId in IterableAPI as it is done when IterableInboxFragment initializes session manager
@@ -618,7 +616,7 @@ public class IterableApiTest extends BaseTest {
         server.enqueue(new MockResponse().setResponseCode(200).setBody("{}"));
 
         IterableInAppMessage message = InAppTestUtils.getTestInAppMessage();
-        IterableApi.initialize(RuntimeEnvironment.application, "apiKey", new IterableConfig.Builder().setAutoPushRegistration(false).build());
+        IterableApi.initialize(getContext(), "apiKey", new IterableConfig.Builder().setAutoPushRegistration(false).build());
         IterableApi.getInstance().setEmail("test@email.com");
         IterableApi.getInstance().setInboxSessionId("SomeRandomSessionID");
         IterableApi.getInstance().inAppConsume(message, null, null);

--- a/iterableapi/src/test/java/com/iterable/iterableapi/IterableApiTest.java
+++ b/iterableapi/src/test/java/com/iterable/iterableapi/IterableApiTest.java
@@ -47,24 +47,16 @@ public class IterableApiTest extends BaseTest {
 
     public static final String PACKAGE_NAME = "com.iterable.iterableapi.test";
     private MockWebServer server;
-    private IterableUtil.IterableUtilImpl originalIterableUtil;
-    private IterableUtil.IterableUtilImpl iterableUtilSpy;
 
     @Before
     public void setUp() {
         server = new MockWebServer();
         IterableApi.overrideURLEndpointPath(server.url("").toString());
         reInitIterableApi();
-
-        originalIterableUtil = IterableUtil.instance;
-        iterableUtilSpy = spy(originalIterableUtil);
-        IterableUtil.instance = iterableUtilSpy;
     }
 
     @After
     public void tearDown() throws IOException {
-        IterableUtil.instance = originalIterableUtil;
-        iterableUtilSpy = null;
         server.shutdown();
         server = null;
     }
@@ -120,7 +112,7 @@ public class IterableApiTest extends BaseTest {
         IterableApi.getInstance().setAttributionInfo(attributionInfo);
 
         // 23 hours, not expired, still present
-        doReturn(System.currentTimeMillis() + 3600 * 23 * 1000).when(iterableUtilSpy).currentTimeMillis();
+        doReturn(System.currentTimeMillis() + 3600 * 23 * 1000).when(utilsRule.iterableUtilSpy).currentTimeMillis();
         IterableAttributionInfo storedAttributionInfo = IterableApi.getInstance().getAttributionInfo();
         assertNotNull(storedAttributionInfo);
         assertEquals(attributionInfo.campaignId, storedAttributionInfo.campaignId);
@@ -128,7 +120,7 @@ public class IterableApiTest extends BaseTest {
         assertEquals(attributionInfo.messageId, storedAttributionInfo.messageId);
 
         // 24 hours, expired, attributionInfo should be null
-        doReturn(System.currentTimeMillis() + 3600 * 24 * 1000).when(iterableUtilSpy).currentTimeMillis();
+        doReturn(System.currentTimeMillis() + 3600 * 24 * 1000).when(utilsRule.iterableUtilSpy).currentTimeMillis();
         storedAttributionInfo = IterableApi.getInstance().getAttributionInfo();
         assertNull(storedAttributionInfo);
     }

--- a/iterableapi/src/test/java/com/iterable/iterableapi/IterableApiTest.java
+++ b/iterableapi/src/test/java/com/iterable/iterableapi/IterableApiTest.java
@@ -70,8 +70,8 @@ public class IterableApiTest extends BaseTest {
     }
 
     private void reInitIterableApi() {
-        IterableApi.sharedInstance = spy(new IterableApi());
         IterableInAppManager inAppManagerMock = mock(IterableInAppManager.class);
+        IterableApi.sharedInstance = spy(new IterableApi(inAppManagerMock));
         doReturn(inAppManagerMock).when(IterableApi.sharedInstance).getInAppManager();
     }
 

--- a/iterableapi/src/test/java/com/iterable/iterableapi/IterableFirebaseMessagingServiceTest.java
+++ b/iterableapi/src/test/java/com/iterable/iterableapi/IterableFirebaseMessagingServiceTest.java
@@ -10,7 +10,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.robolectric.Robolectric;
-import org.robolectric.RuntimeEnvironment;
 import org.robolectric.android.controller.ServiceController;
 
 import java.util.HashMap;
@@ -47,7 +46,7 @@ public class IterableFirebaseMessagingServiceTest extends BaseTest {
         IterableApi.overrideURLEndpointPath(server.url("").toString());
 
         controller = Robolectric.buildService(IterableFirebaseMessagingService.class);
-        Intent intent = new Intent(RuntimeEnvironment.application, IterableFirebaseMessagingService.class);
+        Intent intent = new Intent(getContext(), IterableFirebaseMessagingService.class);
         controller.withIntent(intent).startCommand(0, 0);
 
         originalApi = IterableApi.sharedInstance;
@@ -81,7 +80,7 @@ public class IterableFirebaseMessagingServiceTest extends BaseTest {
         controller.get().onMessageReceived(builder.build());
 
         ArgumentCaptor<Bundle> bundleCaptor = ArgumentCaptor.forClass(Bundle.class);
-        verify(notificationHelperSpy).createNotification(eq(RuntimeEnvironment.application), bundleCaptor.capture());
+        verify(notificationHelperSpy).createNotification(eq(getContext()), bundleCaptor.capture());
         Map<String, String> expectedPayload = new HashMap<>();
         expectedPayload.put(IterableConstants.ITERABLE_DATA_BODY, "Message body");
         expectedPayload.put(IterableConstants.ITERABLE_DATA_KEY, IterableTestUtils.getResourceString("push_payload_custom_action.json"));

--- a/iterableapi/src/test/java/com/iterable/iterableapi/IterableInAppManagerSyncTest.java
+++ b/iterableapi/src/test/java/com/iterable/iterableapi/IterableInAppManagerSyncTest.java
@@ -75,11 +75,9 @@ public class IterableInAppManagerSyncTest extends BaseTest {
     @Test
     public void testSyncOnLogin() throws Exception {
         IterableInAppManager inAppManagerMock = mock(IterableInAppManager.class);
-        IterableApi apiSpy = spy(new IterableApi());
-        IterableApi.sharedInstance = apiSpy;
+        IterableApi.sharedInstance = new IterableApi(inAppManagerMock);
         IterableApi.initialize(getApplicationContext(), "apiKey");
-        doReturn(inAppManagerMock).when(apiSpy).getInAppManager();
-        apiSpy.setEmail("test@email.com");
+        IterableApi.getInstance().setEmail("test@email.com");
         verify(inAppManagerMock).syncInApp();
     }
 

--- a/iterableapi/src/test/java/com/iterable/iterableapi/IterableInAppManagerTest.java
+++ b/iterableapi/src/test/java/com/iterable/iterableapi/IterableInAppManagerTest.java
@@ -19,7 +19,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.robolectric.Robolectric;
-import org.robolectric.RuntimeEnvironment;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.android.util.concurrent.PausedExecutorService;
 import org.robolectric.shadows.ShadowDialog;
@@ -84,7 +83,7 @@ public class IterableInAppManagerTest extends BaseTest {
     public void tearDown() throws IOException {
         server.shutdown();
         server = null;
-        IterableActivityMonitor.getInstance().unregisterLifecycleCallbacks(RuntimeEnvironment.application);
+        IterableActivityMonitor.getInstance().unregisterLifecycleCallbacks(getContext());
         IterableActivityMonitor.instance = new IterableActivityMonitor();
     }
 
@@ -260,7 +259,7 @@ public class IterableInAppManagerTest extends BaseTest {
         dispatcher.enqueueResponse("/inApp/getMessages", new MockResponse().setBody(IterableTestUtils.getResourceString("inapp_payload_single.json")));
 
         // Reset the existing IterableApi
-        IterableActivityMonitor.getInstance().unregisterLifecycleCallbacks(RuntimeEnvironment.application);
+        IterableActivityMonitor.getInstance().unregisterLifecycleCallbacks(getContext());
         IterableActivityMonitor.instance = new IterableActivityMonitor();
         IterableApi.sharedInstance = spy(new IterableApi());
 
@@ -325,7 +324,7 @@ public class IterableInAppManagerTest extends BaseTest {
         dispatcher.enqueueResponse("/inApp/getMessages", new MockResponse().setBody(IterableTestUtils.getResourceString("inapp_payload_single.json")));
 
         // Reset the existing IterableApi
-        IterableActivityMonitor.getInstance().unregisterLifecycleCallbacks(RuntimeEnvironment.application);
+        IterableActivityMonitor.getInstance().unregisterLifecycleCallbacks(getContext());
         IterableActivityMonitor.instance = new IterableActivityMonitor();
         IterableApi.sharedInstance = spy(new IterableApi());
 

--- a/iterableapi/src/test/java/com/iterable/iterableapi/IterableInboxTest.java
+++ b/iterableapi/src/test/java/com/iterable/iterableapi/IterableInboxTest.java
@@ -8,7 +8,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.robolectric.Robolectric;
-import org.robolectric.RuntimeEnvironment;
 
 import java.io.IOException;
 import java.util.List;
@@ -64,7 +63,7 @@ public class IterableInboxTest extends BaseTest {
     public void tearDown() throws IOException {
         server.shutdown();
         server = null;
-        IterableActivityMonitor.getInstance().unregisterLifecycleCallbacks(RuntimeEnvironment.application);
+        IterableActivityMonitor.getInstance().unregisterLifecycleCallbacks(getContext());
         IterableActivityMonitor.instance = new IterableActivityMonitor();
     }
 
@@ -116,7 +115,7 @@ public class IterableInboxTest extends BaseTest {
         dispatcher.enqueueResponse("/inApp/getMessages", new MockResponse().setBody(IterableTestUtils.getResourceString("inapp_payload_inbox_show.json")));
 
         // Reset the existing IterableApi
-        IterableActivityMonitor.getInstance().unregisterLifecycleCallbacks(RuntimeEnvironment.application);
+        IterableActivityMonitor.getInstance().unregisterLifecycleCallbacks(getContext());
         IterableActivityMonitor.instance = new IterableActivityMonitor();
         IterableApi.sharedInstance = spy(new IterableApi());
 

--- a/iterableapi/src/test/java/com/iterable/iterableapi/IterableInboxTest.java
+++ b/iterableapi/src/test/java/com/iterable/iterableapi/IterableInboxTest.java
@@ -37,8 +37,6 @@ public class IterableInboxTest extends BaseTest {
     private IterableInAppHandler inAppHandler;
     private IterableCustomActionHandler customActionHandler;
     private IterableUrlHandler urlHandler;
-    private IterableUtil.IterableUtilImpl originalIterableUtil;
-    private IterableUtil.IterableUtilImpl iterableUtilSpy;
 
     @Before
     public void setUp() throws IOException {
@@ -60,17 +58,10 @@ public class IterableInboxTest extends BaseTest {
                         .setUrlHandler(urlHandler);
             }
         });
-
-        originalIterableUtil = IterableUtil.instance;
-        iterableUtilSpy = spy(originalIterableUtil);
-        IterableUtil.instance = iterableUtilSpy;
     }
 
     @After
     public void tearDown() throws IOException {
-        IterableUtil.instance = originalIterableUtil;
-        iterableUtilSpy = null;
-
         server.shutdown();
         server = null;
         IterableActivityMonitor.getInstance().unregisterLifecycleCallbacks(RuntimeEnvironment.application);

--- a/iterableapi/src/test/java/com/iterable/iterableapi/IterableNotificationTest.java
+++ b/iterableapi/src/test/java/com/iterable/iterableapi/IterableNotificationTest.java
@@ -7,6 +7,8 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.service.notification.StatusBarNotification;
 
+import androidx.test.core.app.ApplicationProvider;
+
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.After;
@@ -14,7 +16,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.RuntimeEnvironment;
 import org.robolectric.shadows.ShadowPendingIntent;
 
 import static com.iterable.iterableapi.IterableTestUtils.getResourceString;
@@ -28,7 +29,7 @@ public class IterableNotificationTest {
     private NotificationManager mNotificationManager;
 
     protected Context getContext() {
-        return RuntimeEnvironment.application;
+        return ApplicationProvider.getApplicationContext();
     }
 
     private IterableNotificationBuilder postNotification(Bundle notificationData) throws InterruptedException {

--- a/iterableapi/src/test/java/com/iterable/iterableapi/IterablePushRegistrationTest.java
+++ b/iterableapi/src/test/java/com/iterable/iterableapi/IterablePushRegistrationTest.java
@@ -7,7 +7,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
-import org.robolectric.RuntimeEnvironment;
 
 import java.util.HashMap;
 
@@ -99,7 +98,7 @@ public class IterablePushRegistrationTest extends BaseTest {
     @Test
     public void testDisableOldGcmToken() throws Exception {
         stubAnyRequestReturningStatusCode(server, 200, "{}");
-        IterableApi.initialize(RuntimeEnvironment.application, "apiKey", new IterableConfig.Builder().setLegacyGCMSenderId(GCM_SENDER_ID).build());
+        IterableApi.initialize(getContext(), "apiKey", new IterableConfig.Builder().setLegacyGCMSenderId(GCM_SENDER_ID).build());
 
         when(pushRegistrationUtilMock.getFirebaseToken()).thenReturn(NEW_TOKEN);
         when(pushRegistrationUtilMock.getFirebaseToken(eq(GCM_SENDER_ID), eq(IterableConstants.MESSAGING_PLATFORM_GOOGLE))).thenReturn(OLD_TOKEN);


### PR DESCRIPTION
This only removes some of them; `ApiClient` split is required to remove the others, so I'll do that there.