### PR TITLE
[MOB-2390] Enable extended exception logging in unit tests

### DIFF
--- a/iterableapi/build.gradle
+++ b/iterableapi/build.gradle
@@ -24,6 +24,11 @@ android {
             multiDexEnabled true
         }
     }
+    testOptions.unitTests.all {
+        testLogging {
+            exceptionFormat "full"
+        }
+    }
     testOptions.unitTests.includeAndroidResources = true
 }
 


### PR DESCRIPTION
Failed CI runs would previously only display limited information, pointing to the line of code in question, but not showing the full backtrace or the error message. This enables extended logging, so we should get more details, like what was expected and what was received for `assertEquals`, etc.