### PR TITLE
[MOB-2411] - Offline flag in config

### DIFF
--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
@@ -306,6 +306,7 @@ private static final String TAG = "IterableApi";
             sharedInstance.inAppManager = new IterableInAppManager(sharedInstance, sharedInstance.config.inAppHandler,
                     sharedInstance.config.inAppDisplayInterval);
         }
+        sharedInstance.apiClient.setOfflineProcessingEnabled(sharedInstance.config.offlineProcessing);
         IterablePushActionReceiver.processPendingAction(context);
     }
 

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableApiClient.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableApiClient.java
@@ -46,6 +46,14 @@ class IterableApiClient {
         return requestProcessor;
     }
 
+    void setOfflineProcessingEnabled(boolean offlineMode) {
+        if (offlineMode) {
+            this.requestProcessor = new OfflineRequestProcessor(authProvider.getContext());
+        } else {
+            this.requestProcessor = new OnlineRequestProcessor();
+        }
+    }
+
     public void track(@NonNull String eventName, int campaignId, int templateId, @Nullable JSONObject dataFields) {
         JSONObject requestJSON = new JSONObject();
         try {

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableConfig.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableConfig.java
@@ -66,6 +66,11 @@ public class IterableConfig {
     final IterableAuthHandler authHandler;
 
     /**
+     * When set to true, the SDK will keep track of events when the device and trigger them once the network establishes
+     */
+    boolean offlineProcessing;
+
+    /**
      * Duration prior to an auth expiration that a new auth token should be requested.
      */
     final long expiringAuthTokenRefreshPeriod;
@@ -82,6 +87,7 @@ public class IterableConfig {
         inAppDisplayInterval = builder.inAppDisplayInterval;
         authHandler = builder.authHandler;
         expiringAuthTokenRefreshPeriod = builder.expiringAuthTokenRefreshPeriod;
+        offlineProcessing = builder.offlineProcessing;
     }
 
     public static class Builder {
@@ -96,7 +102,7 @@ public class IterableConfig {
         private double inAppDisplayInterval = 30.0;
         private IterableAuthHandler authHandler;
         private long expiringAuthTokenRefreshPeriod = 60000L;
-
+        private boolean offlineProcessing = false;
         public Builder() {}
 
         /**
@@ -215,6 +221,16 @@ public class IterableConfig {
         @NonNull
         public Builder setExpiringAuthTokenRefreshPeriod(@NonNull Long period) {
             this.expiringAuthTokenRefreshPeriod = period * 1000L;
+            return this;
+        }
+
+        /**
+         * When set to true, the SDK will capture events when the device goes offline.
+         * @param offlineProcessing boolean which will enable offline processing
+         */
+        @NonNull
+        Builder setOfflineProcessing(@NonNull boolean offlineProcessing) {
+            this.offlineProcessing = offlineProcessing;
             return this;
         }
 

--- a/iterableapi/src/test/java/com/iterable/iterableapi/IterableApiTest.java
+++ b/iterableapi/src/test/java/com/iterable/iterableapi/IterableApiTest.java
@@ -33,6 +33,7 @@ import static junit.framework.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -40,7 +41,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static org.robolectric.Shadows.shadowOf;
 
@@ -82,8 +83,9 @@ public class IterableApiTest extends BaseTest {
     @Test
     public void testSdkInitializedWithoutEmailOrUserId() throws Exception {
         IterableApi.initialize(getContext(), "apiKey");
-        IterableApi.getInstance().setEmail(null);
+        clearInvocations(mockApiClient);
 
+        IterableApi.getInstance().setEmail(null);
         // Verify that none of the calls to the API result in a request
         IterableApi.getInstance().track("testEvent");
         IterableApi.getInstance().trackInAppOpen("12345");
@@ -94,8 +96,7 @@ public class IterableApiTest extends BaseTest {
         IterableApi.getInstance().updateUser(new JSONObject());
         IterableApi.getInstance().updateEmail("");
         IterableApi.getInstance().trackPurchase(10.0, new ArrayList<CommerceItem>());
-
-        verifyNoInteractions(mockApiClient);
+        verifyNoMoreInteractions(mockApiClient);
     }
 
     @Test


### PR DESCRIPTION


## 🔹 Jira Ticket(s) if any

https://iterable.atlassian.net/browse/MOB-2411

## ✏️ Description

1.  Added offlineProcessing boolean flag in config defaulted to false.
2. Added setRequestProcessor method in apiClient for IterableApi to be able to set offline mode after/during initializaiton.
3. In IterableAPI, if the flag is true, setRequestProcessor to offline.

Consequence: Had to make apiClient static and its required authProvider static as well.
