### PR TITLE
[MOB-2152] - Offline Network Monitoring

### DIFF
--- a/iterableapi/src/main/AndroidManifest.xml
+++ b/iterableapi/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.iterable.iterableapi">
 
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <application>
 
         <!--FCM-->

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableApiClient.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableApiClient.java
@@ -47,10 +47,12 @@ class IterableApiClient {
     }
 
     void setOfflineProcessingEnabled(boolean offlineMode) {
-        if (offlineMode) {
-            this.requestProcessor = new OfflineRequestProcessor(authProvider.getContext());
-        } else {
-            this.requestProcessor = new OnlineRequestProcessor();
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            if (offlineMode) {
+                this.requestProcessor = new OfflineRequestProcessor(authProvider.getContext());
+            } else {
+                this.requestProcessor = new OnlineRequestProcessor();
+            }
         }
     }
 

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableNetworkConnectivityManager.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableNetworkConnectivityManager.java
@@ -1,0 +1,85 @@
+package com.iterable.iterableapi;
+
+import android.content.Context;
+import android.net.ConnectivityManager;
+import android.net.Network;
+import android.net.NetworkRequest;
+import android.os.Build;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.RequiresApi;
+
+import java.util.ArrayList;
+
+class IterableNetworkConnectivityManager {
+    private static final String TAG = "NetworkConnectivityManager";
+    private boolean isConnected;
+
+    private static IterableNetworkConnectivityManager sharedInstance;
+
+    private ArrayList<IterableNetworkMonitorListener> networkMonitorListeners = new ArrayList<>();
+
+    public interface IterableNetworkMonitorListener {
+        void onNetworkConnected();
+
+        void onNetworkDisconnected();
+    }
+
+    static IterableNetworkConnectivityManager sharedInstance(Context context) {
+        if (sharedInstance == null) {
+            sharedInstance = new IterableNetworkConnectivityManager(context);
+        }
+        return sharedInstance;
+    }
+
+    private IterableNetworkConnectivityManager(Context context) {
+        if (context == null) {
+            return;
+        }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            startNetworkCallback(context);
+        }
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
+    public void startNetworkCallback(Context context) {
+        ConnectivityManager connectivityManager = (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
+        NetworkRequest.Builder networkBuilder = new NetworkRequest.Builder();
+
+        if (connectivityManager != null) {
+            connectivityManager.registerNetworkCallback(networkBuilder.build(), new ConnectivityManager.NetworkCallback() {
+                @Override
+                public void onAvailable(@NonNull Network network) {
+                    super.onAvailable(network);
+                    IterableLogger.v(TAG, "Network Connected");
+                    isConnected = true;
+                    for (IterableNetworkMonitorListener listener : networkMonitorListeners) {
+                        listener.onNetworkConnected();
+                    }
+                }
+
+                @Override
+                public void onLost(@NonNull Network network) {
+                    super.onLost(network);
+                    IterableLogger.v(TAG, "Network Disconnected");
+                    isConnected = false;
+                    for (IterableNetworkMonitorListener listener : networkMonitorListeners) {
+                        listener.onNetworkDisconnected();
+                    }
+                }
+            });
+        }
+    }
+
+    public void addNetworkListener(IterableNetworkMonitorListener listener) {
+        networkMonitorListeners.add(listener);
+    }
+
+    void removeNetworkListener(IterableNetworkMonitorListener listener) {
+        networkMonitorListeners.remove(listener);
+    }
+
+    boolean isConnected() {
+        return isConnected;
+    }
+}

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableNetworkConnectivityManager.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableNetworkConnectivityManager.java
@@ -42,7 +42,7 @@ class IterableNetworkConnectivityManager {
     }
 
     @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
-    public void startNetworkCallback(Context context) {
+    private void startNetworkCallback(Context context) {
         ConnectivityManager connectivityManager = (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
         NetworkRequest.Builder networkBuilder = new NetworkRequest.Builder();
 
@@ -71,7 +71,7 @@ class IterableNetworkConnectivityManager {
         }
     }
 
-    public void addNetworkListener(IterableNetworkMonitorListener listener) {
+    void addNetworkListener(IterableNetworkMonitorListener listener) {
         networkMonitorListeners.add(listener);
     }
 

--- a/iterableapi/src/main/java/com/iterable/iterableapi/OfflineRequestProcessor.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/OfflineRequestProcessor.java
@@ -31,7 +31,8 @@ class OfflineRequestProcessor implements RequestProcessor {
 
     OfflineRequestProcessor(Context context) {
         IterableTaskStorage taskStorage = IterableTaskStorage.sharedInstance(context);
-        taskRunner = new IterableTaskRunner(taskStorage, IterableActivityMonitor.getInstance());
+        IterableNetworkConnectivityManager networkConnectivityManager = IterableNetworkConnectivityManager.sharedInstance(context);
+        taskRunner = new IterableTaskRunner(taskStorage, IterableActivityMonitor.getInstance(), networkConnectivityManager);
         taskScheduler = new TaskScheduler(taskStorage, taskRunner);
     }
 

--- a/iterableapi/src/test/java/com/iterable/iterableapi/IterableTaskRunnerTest.java
+++ b/iterableapi/src/test/java/com/iterable/iterableapi/IterableTaskRunnerTest.java
@@ -29,13 +29,15 @@ public class IterableTaskRunnerTest {
     private IterableTaskRunner taskRunner;
     private IterableTaskStorage mockTaskStorage;
     private IterableActivityMonitor mockActivityMonitor;
+    private IterableNetworkConnectivityManager mockNetworkConnectivityManager;
     private MockWebServer server;
 
     @Before
     public void setUp() throws Exception {
         mockTaskStorage = mock(IterableTaskStorage.class);
         mockActivityMonitor = mock(IterableActivityMonitor.class);
-        taskRunner = new IterableTaskRunner(mockTaskStorage, mockActivityMonitor);
+        mockNetworkConnectivityManager = mock(IterableNetworkConnectivityManager.class);
+        taskRunner = new IterableTaskRunner(mockTaskStorage, mockActivityMonitor, mockNetworkConnectivityManager);
         server = new MockWebServer();
         IterableApi.overrideURLEndpointPath(server.url("").toString());
     }
@@ -50,6 +52,7 @@ public class IterableTaskRunnerTest {
         IterableApiRequest request = new IterableApiRequest("apiKey", "api/test", new JSONObject(), "POST", null, null, null);
         IterableTask task = new IterableTask("testTask", IterableTaskType.API, request.toJSONObject().toString());
         when(mockTaskStorage.getNextScheduledTask()).thenReturn(task).thenReturn(null);
+        when(mockNetworkConnectivityManager.isConnected()).thenReturn(true);
         taskRunner.onTaskCreated(null);
         runHandlerTasks(taskRunner);
         RecordedRequest recordedRequest = server.takeRequest(1, TimeUnit.SECONDS);
@@ -63,7 +66,7 @@ public class IterableTaskRunnerTest {
         IterableApiRequest request = new IterableApiRequest("apiKey", "api/test", new JSONObject(), "POST", null, null, null);
         IterableTask task = new IterableTask("testTask", IterableTaskType.API, request.toJSONObject().toString());
         when(mockTaskStorage.getNextScheduledTask()).thenReturn(task).thenReturn(null);
-
+        when(mockNetworkConnectivityManager.isConnected()).thenReturn(true);
         IterableTaskRunner.TaskCompletedListener taskCompletedListener = mock(IterableTaskRunner.TaskCompletedListener.class);
         taskRunner.addTaskCompletedListener(taskCompletedListener);
 


### PR DESCRIPTION

## 🔹 Jira Ticket(s) if any

https://iterable.atlassian.net/browse/MOB-2152

## ✏️ Description

1. Created NetworkConnectivity Manager: One place to have all out network related work. Made it with interface so other modules can subscribe to it and listen to network events
2. TaskRunner now implements ConnectivityManager interfaces too and calls RunNow function when onNetworkConnected callback is called.
3. ProcessTask function will check for networkConnectivity before processing and deleting the task
4. ConnectivityManager's lifecycle will start with initialization of OfflineRequestProcessor and will remain shared instance
5. Changes in Test method to accompany networkConnectivityMonitor in task runner
6. Pending work: What if device is below LOLLIPOP? What should the networkManager should do?
