### PR TITLE
[MOB - 2371] - Delete all tasks on log out

### DIFF
--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
@@ -1028,6 +1028,9 @@ private static final String TAG = "IterableApi";
         }
         getInAppManager().reset();
         getAuthManager().clearRefreshTimer();
+        if (config.offlineProcessing) {
+            IterableTaskStorage.sharedInstance(getMainActivityContext()).deleteAllTasks();
+        }
     }
 
     private void onLogIn() {

--- a/iterableapi/src/test/java/com/iterable/iterableapi/IterableApiTest.java
+++ b/iterableapi/src/test/java/com/iterable/iterableapi/IterableApiTest.java
@@ -27,6 +27,7 @@ import okhttp3.mockwebserver.RecordedRequest;
 
 import static android.os.Looper.getMainLooper;
 import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertFalse;
 import static junit.framework.Assert.assertNotNull;
 import static junit.framework.Assert.assertNull;
 import static junit.framework.Assert.assertTrue;
@@ -343,6 +344,17 @@ public class IterableApiTest extends BaseTest {
         IterableApi.getInstance().setEmail("test@email.com");
         IterableApi.getInstance().setEmail(null);
         verify(IterableApi.sharedInstance.getInAppManager(), times(2)).reset();
+    }
+
+    @Test
+    public void databaseClearOnLogout() throws Exception {
+        IterableApi.initialize(getContext(), "fake_key", new IterableConfig.Builder().setPushIntegrationName("pushIntegration").setAutoPushRegistration(true).setOfflineProcessing(true).build());
+        IterableApi.getInstance().setEmail("test@email.com");
+        IterableTaskStorage taskStorage = IterableTaskStorage.sharedInstance(getContext());
+        taskStorage.createTask("Test", IterableTaskType.API, "data");
+        assertFalse(taskStorage.getAllTaskIds().isEmpty());
+        IterableApi.getInstance().setEmail(null);
+        assertTrue(taskStorage.getAllTaskIds().isEmpty());
     }
 
     @Test


### PR DESCRIPTION
## 🔹 Jira Ticket(s) if any

https://iterable.atlassian.net/browse/MOB-2371

## ✏️ Description

Calling IterableTaskStorage.deleteAlltasks in IterableApi's onlogout method when offline processing is enabled.
