### PR TITLE
[MOB-2476] - Making NetworkManager threadsafe

### DIFF
--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableNetworkConnectivityManager.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableNetworkConnectivityManager.java
@@ -53,7 +53,8 @@ class IterableNetworkConnectivityManager {
                     super.onAvailable(network);
                     IterableLogger.v(TAG, "Network Connected");
                     isConnected = true;
-                    for (IterableNetworkMonitorListener listener : networkMonitorListeners) {
+                    ArrayList<IterableNetworkMonitorListener> networkListenersCopy = new ArrayList<>(networkMonitorListeners);
+                    for (IterableNetworkMonitorListener listener : networkListenersCopy) {
                         listener.onNetworkConnected();
                     }
                 }
@@ -63,7 +64,8 @@ class IterableNetworkConnectivityManager {
                     super.onLost(network);
                     IterableLogger.v(TAG, "Network Disconnected");
                     isConnected = false;
-                    for (IterableNetworkMonitorListener listener : networkMonitorListeners) {
+                    ArrayList<IterableNetworkMonitorListener> networkListenersCopy = new ArrayList<>(networkMonitorListeners);
+                    for (IterableNetworkMonitorListener listener : networkListenersCopy) {
                         listener.onNetworkDisconnected();
                     }
                 }
@@ -71,11 +73,11 @@ class IterableNetworkConnectivityManager {
         }
     }
 
-    void addNetworkListener(IterableNetworkMonitorListener listener) {
+    synchronized void addNetworkListener(IterableNetworkMonitorListener listener) {
         networkMonitorListeners.add(listener);
     }
 
-    void removeNetworkListener(IterableNetworkMonitorListener listener) {
+    synchronized void removeNetworkListener(IterableNetworkMonitorListener listener) {
         networkMonitorListeners.remove(listener);
     }
 


### PR DESCRIPTION
## 🔹 Jira Ticket(s) if any

https://iterable.atlassian.net/browse/MOB-2476

## ✏️ Description

Added synchronized keyword to add and remove listeners so that regardless from which thread the listeners are added or removed, while the listeners are being iterated over, they will have lock over the array.
