### PR TITLE
[MOB-2433] Fix Firebase check to work without a Firebase database URL

### DIFF
--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableConstants.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableConstants.java
@@ -148,7 +148,6 @@ public final class IterableConstants {
     public static final String USER_INPUT               = "userInput";
 
     //Firebase
-    public static final String FIREBASE_RESOURCE_ID     = "firebase_database_url";
     public static final String FIREBASE_SENDER_ID       = "gcm_defaultSenderId";
     public static final String FIREBASE_MESSAGING_CLASS = "com.google.firebase.messaging.FirebaseMessaging";
     public static final String FIREBASE_COMPATIBLE      = "firebaseCompatible";

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterablePushRegistrationTask.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterablePushRegistrationTask.java
@@ -66,9 +66,9 @@ class IterablePushRegistrationTask extends AsyncTask<IterablePushRegistrationDat
                 return null;
             }
 
-            int firebaseResourceId = Util.getFirebaseResouceId(applicationContext);
-            if (firebaseResourceId == 0) {
-                IterableLogger.e(TAG, "Could not find firebase_database_url, please check that Firebase SDK is set up properly");
+            String senderId = Util.getSenderId(applicationContext);
+            if (senderId == null) {
+                IterableLogger.e(TAG, "Could not find gcm_defaultSenderId, please check that Firebase SDK is set up properly");
                 return null;
             }
 
@@ -113,10 +113,6 @@ class IterablePushRegistrationTask extends AsyncTask<IterablePushRegistrationDat
     static class Util {
         static UtilImpl instance = new UtilImpl();
 
-        static int getFirebaseResouceId(Context applicationContext) {
-            return instance.getFirebaseResouceId(applicationContext);
-        }
-
         static String getFirebaseToken() {
             return instance.getFirebaseToken();
         }
@@ -130,10 +126,6 @@ class IterablePushRegistrationTask extends AsyncTask<IterablePushRegistrationDat
         }
 
         static class UtilImpl {
-            int getFirebaseResouceId(Context applicationContext) {
-                return applicationContext.getResources().getIdentifier(IterableConstants.FIREBASE_RESOURCE_ID, IterableConstants.ANDROID_STRING, applicationContext.getPackageName());
-            }
-
             String getFirebaseToken() {
                 FirebaseInstanceId instanceID = FirebaseInstanceId.getInstance();
                 return instanceID.getToken();

--- a/iterableapi/src/test/java/com/iterable/iterableapi/IterableApiIntegrationTest.java
+++ b/iterableapi/src/test/java/com/iterable/iterableapi/IterableApiIntegrationTest.java
@@ -54,7 +54,7 @@ public class IterableApiIntegrationTest extends BaseTest {
     @Test
     public void testDisablePushOnLogout() throws Exception {
         server.enqueue(new MockResponse().setResponseCode(200).setBody("{}"));
-        when(pushRegistrationUtilMock.getFirebaseResouceId(any(Context.class))).thenReturn(1);
+        when(pushRegistrationUtilMock.getSenderId(any(Context.class))).thenReturn("12345");
         when(pushRegistrationUtilMock.getFirebaseToken()).thenReturn(TEST_TOKEN);
         IterableApi.initialize(getContext(), "apiKey", new IterableConfig.Builder().setAutoPushRegistration(true).build());
         IterableApi.getInstance().setEmail("test@email.com");

--- a/iterableapi/src/test/java/com/iterable/iterableapi/IterablePushRegistrationTaskTest.java
+++ b/iterableapi/src/test/java/com/iterable/iterableapi/IterablePushRegistrationTaskTest.java
@@ -59,7 +59,7 @@ public class IterablePushRegistrationTaskTest extends BaseTest {
         pushRegistrationUtilMock = mock(IterablePushRegistrationTask.Util.UtilImpl.class);
         IterablePushRegistrationTask.Util.instance = pushRegistrationUtilMock;
 
-        when(pushRegistrationUtilMock.getFirebaseResouceId(any(Context.class))).thenReturn(1);
+        when(pushRegistrationUtilMock.getSenderId(any(Context.class))).thenReturn("12345");
     }
 
     @After


### PR DESCRIPTION
## 🔹 Jira Ticket(s) if any

* [MOB-2433](https://iterable.atlassian.net/browse/MOB-2433)

## ✏️ Description

The code was checking for the presence of a Firebase database URL, that is not directly necessary for push to work. This PR changes the check to get the FCM sender id, that is actually necessary for push and is a better indicator of FCM being set up correctly.