### PR TITLE
[MOB - 2417] - CreatedAt and SentAt in requests

### DIFF
--- a/iterableapi/src/androidTest/java/com/iterable/iterableapi/IterableApiRequestsTest.java
+++ b/iterableapi/src/androidTest/java/com/iterable/iterableapi/IterableApiRequestsTest.java
@@ -48,6 +48,7 @@ public class IterableApiRequestsTest {
         assertEquals("/" + IterableConstants.ENDPOINT_TRACK, request.getPath());
         assertEquals("Android", request.getHeader(IterableConstants.HEADER_SDK_PLATFORM));
         assertEquals(IterableConstants.ITBL_KEY_SDK_VERSION_NUMBER, request.getHeader(IterableConstants.HEADER_SDK_VERSION));
+        assertNotNull(request.getHeader(IterableConstants.KEY_SENT_AT));
         assertEquals("fake_key", request.getHeader(IterableConstants.HEADER_API_KEY));
     }
 

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableConstants.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableConstants.java
@@ -38,6 +38,8 @@ public final class IterableConstants {
     public static final String KEY_PREFER_USER_ID       = "preferUserId";
     public static final String KEY_RECIPIENT_EMAIL      = "recipientEmail";
     public static final String KEY_SEND_AT              = "sendAt";
+    public static final String KEY_CREATED_AT           = "createdAt";
+    public static final String KEY_SENT_AT              = "sentAt";
     public static final String KEY_TEMPLATE_ID          = "templateId";
     public static final String KEY_MESSAGE_CONTEXT      = "messageContext";
     public static final String KEY_MESSAGE_ID           = "messageId";

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableRequestTask.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableRequestTask.java
@@ -18,6 +18,7 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.util.Date;
 import java.util.Iterator;
 
 /**
@@ -87,6 +88,7 @@ class IterableRequestTask extends AsyncTask<IterableApiRequest, Void, IterableAp
                     urlConnection.setRequestProperty(IterableConstants.HEADER_API_KEY, iterableApiRequest.apiKey);
                     urlConnection.setRequestProperty(IterableConstants.HEADER_SDK_PLATFORM, "Android");
                     urlConnection.setRequestProperty(IterableConstants.HEADER_SDK_VERSION, IterableConstants.ITBL_KEY_SDK_VERSION_NUMBER);
+                    urlConnection.setRequestProperty(IterableConstants.KEY_SENT_AT, String.valueOf(new Date().getTime()));
 
                     if (iterableApiRequest.authToken != null) {
                         urlConnection.setRequestProperty(IterableConstants.HEADER_SDK_AUTHORIZATION, IterableConstants.HEADER_SDK_AUTH_FORMAT + iterableApiRequest.authToken);
@@ -108,6 +110,7 @@ class IterableRequestTask extends AsyncTask<IterableApiRequest, Void, IterableAp
                     urlConnection.setRequestProperty(IterableConstants.HEADER_API_KEY, iterableApiRequest.apiKey);
                     urlConnection.setRequestProperty(IterableConstants.HEADER_SDK_PLATFORM, "Android");
                     urlConnection.setRequestProperty(IterableConstants.HEADER_SDK_VERSION, IterableConstants.ITBL_KEY_SDK_VERSION_NUMBER);
+                    urlConnection.setRequestProperty(IterableConstants.KEY_SENT_AT, String.valueOf(new Date().getTime()));
 
                     if (iterableApiRequest.authToken != null) {
                         urlConnection.setRequestProperty(IterableConstants.HEADER_SDK_AUTHORIZATION, IterableConstants.HEADER_SDK_AUTH_FORMAT + iterableApiRequest.authToken);
@@ -365,6 +368,9 @@ class IterableApiRequest {
                 authToken = jsonData.getString("authToken");
             }
             JSONObject json = jsonData.getJSONObject("data");
+            if (jsonData.has(IterableConstants.KEY_CREATED_AT)) {
+                json.put(IterableConstants.KEY_CREATED_AT, jsonData.getString(IterableConstants.KEY_CREATED_AT));
+            }
             return new IterableApiRequest(apikey, resourcePath, json, requestType, authToken, onSuccess, onFailure);
         } catch (JSONException e) {
             IterableLogger.e(TAG, "Failed to create Iterable request from JSON");

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableRequestTask.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableRequestTask.java
@@ -88,7 +88,7 @@ class IterableRequestTask extends AsyncTask<IterableApiRequest, Void, IterableAp
                     urlConnection.setRequestProperty(IterableConstants.HEADER_API_KEY, iterableApiRequest.apiKey);
                     urlConnection.setRequestProperty(IterableConstants.HEADER_SDK_PLATFORM, "Android");
                     urlConnection.setRequestProperty(IterableConstants.HEADER_SDK_VERSION, IterableConstants.ITBL_KEY_SDK_VERSION_NUMBER);
-                    urlConnection.setRequestProperty(IterableConstants.KEY_SENT_AT, String.valueOf(new Date().getTime()));
+                    urlConnection.setRequestProperty(IterableConstants.KEY_SENT_AT, String.valueOf(new Date().getTime() / 1000));
 
                     if (iterableApiRequest.authToken != null) {
                         urlConnection.setRequestProperty(IterableConstants.HEADER_SDK_AUTHORIZATION, IterableConstants.HEADER_SDK_AUTH_FORMAT + iterableApiRequest.authToken);
@@ -110,7 +110,7 @@ class IterableRequestTask extends AsyncTask<IterableApiRequest, Void, IterableAp
                     urlConnection.setRequestProperty(IterableConstants.HEADER_API_KEY, iterableApiRequest.apiKey);
                     urlConnection.setRequestProperty(IterableConstants.HEADER_SDK_PLATFORM, "Android");
                     urlConnection.setRequestProperty(IterableConstants.HEADER_SDK_VERSION, IterableConstants.ITBL_KEY_SDK_VERSION_NUMBER);
-                    urlConnection.setRequestProperty(IterableConstants.KEY_SENT_AT, String.valueOf(new Date().getTime()));
+                    urlConnection.setRequestProperty(IterableConstants.KEY_SENT_AT, String.valueOf(new Date().getTime() / 1000));
 
                     if (iterableApiRequest.authToken != null) {
                         urlConnection.setRequestProperty(IterableConstants.HEADER_SDK_AUTHORIZATION, IterableConstants.HEADER_SDK_AUTH_FORMAT + iterableApiRequest.authToken);

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableRequestTask.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableRequestTask.java
@@ -368,9 +368,6 @@ class IterableApiRequest {
                 authToken = jsonData.getString("authToken");
             }
             JSONObject json = jsonData.getJSONObject("data");
-            if (jsonData.has(IterableConstants.KEY_CREATED_AT)) {
-                json.put(IterableConstants.KEY_CREATED_AT, jsonData.getString(IterableConstants.KEY_CREATED_AT));
-            }
             return new IterableApiRequest(apikey, resourcePath, json, requestType, authToken, onSuccess, onFailure);
         } catch (JSONException e) {
             IterableLogger.e(TAG, "Failed to create Iterable request from JSON");

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableTask.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableTask.java
@@ -12,11 +12,11 @@ class IterableTask {
     String id;
     String name;
     int version;
-    Date createdAt;
-    Date modifiedAt;
-    Date lastAttemptedAt;
-    Date scheduledAt;
-    Date requestedAt;
+    long createdAt;
+    long modifiedAt;
+    long lastAttemptedAt;
+    long scheduledAt;
+    long requestedAt;
 
     boolean processing;
     boolean failed;
@@ -29,7 +29,7 @@ class IterableTask {
     int attempts;
 
     //To be used when creating IterableTask from database
-    IterableTask(String id, @NonNull String name, int version, @NonNull Date createdAt, Date modifiedAt, Date lastAttemptedAt, Date scheduledAt, Date requestedAt, boolean processing, boolean failed, boolean blocking, String data, String taskFailureData, IterableTaskType taskType, int attempts) {
+    IterableTask(String id, @NonNull String name, int version, @NonNull long createdAt, long modifiedAt, long lastAttemptedAt, long scheduledAt, long requestedAt, boolean processing, boolean failed, boolean blocking, String data, String taskFailureData, IterableTaskType taskType, int attempts) {
         this.id = id;
         this.name = name;
         this.version = version;
@@ -51,9 +51,9 @@ class IterableTask {
     IterableTask(String name, IterableTaskType taskType, String data) {
         this.id = UUID.randomUUID().toString();
         this.name = name;
-        this.createdAt = new Date();
-        this.scheduledAt = new Date();
-        this.requestedAt = new Date();
+        this.createdAt = new Date().getTime();
+        this.scheduledAt = new Date().getTime();
+        this.requestedAt = new Date().getTime();
         this.data = data;
         this.taskType = taskType;
     }

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableTaskRunner.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableTaskRunner.java
@@ -9,6 +9,7 @@ import androidx.annotation.MainThread;
 import androidx.annotation.NonNull;
 import androidx.annotation.WorkerThread;
 
+import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.util.ArrayList;
@@ -104,7 +105,8 @@ class IterableTaskRunner implements IterableTaskStorage.TaskCreatedListener, Han
             IterableApiResponse response = null;
             TaskResult result = TaskResult.FAILURE;
             try {
-                IterableApiRequest request = IterableApiRequest.fromJSON(new JSONObject(task.data), null, null);
+                IterableApiRequest request = IterableApiRequest.fromJSON(getTaskDataWithDate(task), null, null);
+                //TODO: Any chances of request getting null?
                 response = IterableRequestTask.executeApiRequest(request);
             } catch (Exception e) {
                 IterableLogger.e(TAG, "Error while processing request task", e);
@@ -117,6 +119,17 @@ class IterableTaskRunner implements IterableTaskStorage.TaskCreatedListener, Han
             return true;
         }
         return false;
+    }
+
+    JSONObject getTaskDataWithDate(IterableTask task) {
+        try {
+            JSONObject jsonData = new JSONObject(task.data);
+            jsonData.put(IterableConstants.KEY_CREATED_AT, task.createdAt);
+            return jsonData;
+        } catch (JSONException e) {
+            e.printStackTrace();
+        }
+        return null;
     }
 
     @WorkerThread

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableTaskRunner.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableTaskRunner.java
@@ -162,7 +162,7 @@ class IterableTaskRunner implements IterableTaskStorage.TaskCreatedListener, Han
     JSONObject getTaskDataWithDate(IterableTask task) {
         try {
             JSONObject jsonData = new JSONObject(task.data);
-            jsonData.put(IterableConstants.KEY_CREATED_AT, task.createdAt / 1000);
+            jsonData.getJSONObject("data").put(IterableConstants.KEY_CREATED_AT, task.createdAt / 1000);
             return jsonData;
         } catch (JSONException e) {
             e.printStackTrace();

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableTaskRunner.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableTaskRunner.java
@@ -106,7 +106,6 @@ class IterableTaskRunner implements IterableTaskStorage.TaskCreatedListener, Han
             TaskResult result = TaskResult.FAILURE;
             try {
                 IterableApiRequest request = IterableApiRequest.fromJSON(getTaskDataWithDate(task), null, null);
-                //TODO: Any chances of request getting null?
                 response = IterableRequestTask.executeApiRequest(request);
             } catch (Exception e) {
                 IterableLogger.e(TAG, "Error while processing request task", e);
@@ -124,7 +123,7 @@ class IterableTaskRunner implements IterableTaskStorage.TaskCreatedListener, Han
     JSONObject getTaskDataWithDate(IterableTask task) {
         try {
             JSONObject jsonData = new JSONObject(task.data);
-            jsonData.put(IterableConstants.KEY_CREATED_AT, task.createdAt);
+            jsonData.put(IterableConstants.KEY_CREATED_AT, task.createdAt / 1000);
             return jsonData;
         } catch (JSONException e) {
             e.printStackTrace();

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableTaskStorage.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableTaskStorage.java
@@ -112,18 +112,19 @@ class IterableTaskStorage {
         contentValues.put(TASK_ID, iterableTask.id);
         contentValues.put(NAME, iterableTask.name);
         contentValues.put(VERSION, iterableTask.version);
-        contentValues.put(CREATED_AT, iterableTask.createdAt.toString());
-        if (iterableTask.modifiedAt != null) {
-            contentValues.put(MODIFIED_AT, iterableTask.modifiedAt.toString());
+        //TODO: you might have to change the created to epoch literally while storing
+        contentValues.put(CREATED_AT, iterableTask.createdAt);
+        if (iterableTask.modifiedAt != 0) {
+            contentValues.put(MODIFIED_AT, iterableTask.modifiedAt);
         }
-        if (iterableTask.lastAttemptedAt != null) {
-            contentValues.put(LAST_ATTEMPTED_AT, iterableTask.lastAttemptedAt.toString());
+        if (iterableTask.lastAttemptedAt != 0) {
+            contentValues.put(LAST_ATTEMPTED_AT, iterableTask.lastAttemptedAt);
         }
-        if (iterableTask.scheduledAt != null) {
-            contentValues.put(SCHEDULED_AT, iterableTask.scheduledAt.toString());
+        if (iterableTask.scheduledAt != 0) {
+            contentValues.put(SCHEDULED_AT, iterableTask.scheduledAt);
         }
-        if (iterableTask.requestedAt != null) {
-            contentValues.put(REQUESTED_AT, iterableTask.requestedAt.toString());
+        if (iterableTask.requestedAt != 0) {
+            contentValues.put(REQUESTED_AT, iterableTask.requestedAt);
         }
         contentValues.put(PROCESSING, iterableTask.processing);
         contentValues.put(FAILED, iterableTask.failed);
@@ -184,25 +185,25 @@ class IterableTaskStorage {
         IterableTaskType type = null;
         int version = 1;
         int attempts = 0;
-        Date dateCreated = null, dateModified = null, dateLastAttempted = null, dateScheduled = null, dateRequested = null;
+        long dateCreated = 0, dateModified = 0, dateLastAttempted = 0, dateScheduled = 0, dateRequested = 0;
         boolean processing = false, failed = false, blocking = false;
         String data = null, error = null;
 
         id = cursor.getString(cursor.getColumnIndex(TASK_ID));
         name = cursor.getString(cursor.getColumnIndex(NAME));
         version = cursor.getInt(cursor.getColumnIndex(VERSION));
-        dateCreated = new Date(cursor.getString(cursor.getColumnIndex(CREATED_AT)));
+        dateCreated = cursor.getLong(cursor.getColumnIndex(CREATED_AT));
         if (!cursor.isNull(cursor.getColumnIndex(MODIFIED_AT))) {
-            dateModified = new Date(cursor.getString(cursor.getColumnIndex(MODIFIED_AT)));
+            dateModified = cursor.getLong(cursor.getColumnIndex(MODIFIED_AT));
         }
         if (!cursor.isNull(cursor.getColumnIndex(LAST_ATTEMPTED_AT))) {
-            dateLastAttempted = new Date(cursor.getString(cursor.getColumnIndex(LAST_ATTEMPTED_AT)));
+            dateLastAttempted = cursor.getLong(cursor.getColumnIndex(LAST_ATTEMPTED_AT));
         }
         if (!cursor.isNull(cursor.getColumnIndex(SCHEDULED_AT))) {
-            dateScheduled = new Date(cursor.getString(cursor.getColumnIndex(SCHEDULED_AT)));
+            dateScheduled = cursor.getLong(cursor.getColumnIndex(SCHEDULED_AT));
         }
         if (!cursor.isNull(cursor.getColumnIndex(REQUESTED_AT))) {
-            dateRequested = new Date(cursor.getString(cursor.getColumnIndex(REQUESTED_AT)));
+            dateRequested = cursor.getLong(cursor.getColumnIndex(REQUESTED_AT));
         }
         if (!cursor.isNull(cursor.getColumnIndex(PROCESSING))) {
             processing = cursor.getInt(cursor.getColumnIndex(PROCESSING)) > 0;

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableTaskStorage.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableTaskStorage.java
@@ -42,11 +42,11 @@ class IterableTaskStorage {
     static final String OFFLINE_TASK_COLUMN_DATA = " (" + TASK_ID + " TEXT PRIMARY KEY," +
             NAME + " TEXT," +
             VERSION + " INTEGER," +
-            CREATED_AT + " NUMERIC," +
-            MODIFIED_AT + " NUMERIC," +
-            LAST_ATTEMPTED_AT + " NUMERIC," +
-            SCHEDULED_AT + " NUMERIC," +
-            REQUESTED_AT + " NUMERIC," +
+            CREATED_AT + " BIGINT," +
+            MODIFIED_AT + " BIGINT," +
+            LAST_ATTEMPTED_AT + " BIGINT," +
+            SCHEDULED_AT + " BIGINT," +
+            REQUESTED_AT + " BIGINT," +
             PROCESSING + " BOOLEAN," +
             FAILED + " BOOLEAN," +
             BLOCKING + " BOOLEAN," +

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableTaskStorage.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableTaskStorage.java
@@ -42,11 +42,11 @@ class IterableTaskStorage {
     static final String OFFLINE_TASK_COLUMN_DATA = " (" + TASK_ID + " TEXT PRIMARY KEY," +
             NAME + " TEXT," +
             VERSION + " INTEGER," +
-            CREATED_AT + " TEXT," +
-            MODIFIED_AT + " TEXT," +
-            LAST_ATTEMPTED_AT + " TEXT," +
-            SCHEDULED_AT + " TEXT," +
-            REQUESTED_AT + " TEXT," +
+            CREATED_AT + " NUMERIC," +
+            MODIFIED_AT + " NUMERIC," +
+            LAST_ATTEMPTED_AT + " NUMERIC," +
+            SCHEDULED_AT + " NUMERIC," +
+            REQUESTED_AT + " NUMERIC," +
             PROCESSING + " BOOLEAN," +
             FAILED + " BOOLEAN," +
             BLOCKING + " BOOLEAN," +
@@ -112,7 +112,6 @@ class IterableTaskStorage {
         contentValues.put(TASK_ID, iterableTask.id);
         contentValues.put(NAME, iterableTask.name);
         contentValues.put(VERSION, iterableTask.version);
-        //TODO: you might have to change the created to epoch literally while storing
         contentValues.put(CREATED_AT, iterableTask.createdAt);
         if (iterableTask.modifiedAt != 0) {
             contentValues.put(MODIFIED_AT, iterableTask.modifiedAt);


### PR DESCRIPTION
## 🔹 Jira Ticket(s) if any

https://iterable.atlassian.net/browse/MOB-2417

## ✏️ Description

1. Changed date type from Date to long to store unix epoch time in milliseconds
2. Added sentAt dates in headers
3. Added check in test method to see if sentAt is sent in headers for all the requests
4. Added method in taskRunner to add createdAt in json data when making request back from database.

Pending -> Test method to see if createdAt is present in offline requests.