### PR TITLE
[MOB-2437] - Get Remote Configuration

### DIFF
--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
@@ -311,19 +311,15 @@ private static final String TAG = "IterableApi";
     }
 
     void fetchRemoteConfiguration() {
-        apiClient.getRemoteConfiguration(new IterableHelper.SuccessHandler() {
+        apiClient.getRemoteConfiguration(new IterableHelper.IterableActionHandler() {
             @Override
-            public void onSuccess(@NonNull JSONObject data) {
+            public void execute(@Nullable String data) {
                 try {
-                    sharedInstance.apiClient.setOfflineProcessingEnabled(data.getBoolean("offlineModeBeta"));
+                    JSONObject jsonData = new JSONObject(data);
+                    sharedInstance.apiClient.setOfflineProcessingEnabled(jsonData.getBoolean("offlineModeBeta"));
                 } catch (JSONException e) {
-                    IterableLogger.e(TAG, "OfflineMode parameter not found");
+                    IterableLogger.e(TAG, "Failed to read remote configuration");
                 }
-            }
-        }, new IterableHelper.FailureHandler() {
-            @Override
-            public void onFailure(@NonNull String reason, @Nullable JSONObject data) {
-                IterableLogger.e(TAG, "Failed to fetch remote configuration. Default values will be used");
             }
         });
     }
@@ -984,8 +980,8 @@ private static final String TAG = "IterableApi";
                 IterableLogger.d(TAG, "Performing automatic push registration");
                 sharedInstance.registerForPush();
             }
+            fetchRemoteConfiguration();
         }
-        fetchRemoteConfiguration();
     }
 
     private boolean isInitialized() {

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
@@ -310,6 +310,24 @@ private static final String TAG = "IterableApi";
         IterablePushActionReceiver.processPendingAction(context);
     }
 
+    void fetchRemoteConfiguration() {
+        apiClient.getRemoteConfiguration(new IterableHelper.SuccessHandler() {
+            @Override
+            public void onSuccess(@NonNull JSONObject data) {
+                try {
+                    sharedInstance.apiClient.setOfflineProcessingEnabled(data.getBoolean("offlineModeBeta"));
+                } catch (JSONException e) {
+                    IterableLogger.e(TAG, "OfflineMode parameter not found");
+                }
+            }
+        }, new IterableHelper.FailureHandler() {
+            @Override
+            public void onFailure(@NonNull String reason, @Nullable JSONObject data) {
+                IterableLogger.e(TAG, "Failed to fetch remote configuration. Default values will be used");
+            }
+        });
+    }
+
     /**
      * Set user email used for API calls
      * Calling this or {@link #setUserId(String)} is required before making any API calls.
@@ -967,6 +985,7 @@ private static final String TAG = "IterableApi";
                 sharedInstance.registerForPush();
             }
         }
+        fetchRemoteConfiguration();
     }
 
     private boolean isInitialized() {

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableApiClient.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableApiClient.java
@@ -60,15 +60,14 @@ class IterableApiClient {
         }
     }
 
-    void getRemoteConfiguration(IterableHelper.SuccessHandler successHandler, IterableHelper.FailureHandler failureHandler) {
+    void getRemoteConfiguration(IterableHelper.IterableActionHandler actionHandler) {
         JSONObject requestJSON = new JSONObject();
         try {
-            //TODO: Add data and make request
             requestJSON.putOpt(IterableConstants.KEY_PLATFORM, IterableConstants.ITBL_PLATFORM_ANDROID);
             requestJSON.putOpt(IterableConstants.DEVICE_APP_PACKAGE_NAME, authProvider.getContext().getPackageName());
             requestJSON.put(IterableConstants.ITBL_KEY_SDK_VERSION, IterableConstants.ITBL_KEY_SDK_VERSION_NUMBER);
             requestJSON.put(IterableConstants.ITBL_SYSTEM_VERSION, Build.VERSION.RELEASE);
-            sendPostRequest(IterableConstants.ENDPOINT_GET_REMOTE_CONFIGURATION, requestJSON, successHandler, failureHandler);
+            sendGetRequest(IterableConstants.ENDPOINT_GET_REMOTE_CONFIGURATION, requestJSON, actionHandler);
         } catch (JSONException e) {
             e.printStackTrace();
         }

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableApiClient.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableApiClient.java
@@ -49,10 +49,28 @@ class IterableApiClient {
     void setOfflineProcessingEnabled(boolean offlineMode) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             if (offlineMode) {
-                this.requestProcessor = new OfflineRequestProcessor(authProvider.getContext());
+                if (this.requestProcessor == null || this.requestProcessor.getClass() != OfflineRequestProcessor.class) {
+                    this.requestProcessor = new OfflineRequestProcessor(authProvider.getContext());
+                }
             } else {
-                this.requestProcessor = new OnlineRequestProcessor();
+                if (this.requestProcessor == null || this.requestProcessor.getClass() != OnlineRequestProcessor.class) {
+                    this.requestProcessor = new OnlineRequestProcessor();
+                }
             }
+        }
+    }
+
+    void getRemoteConfiguration(IterableHelper.SuccessHandler successHandler, IterableHelper.FailureHandler failureHandler) {
+        JSONObject requestJSON = new JSONObject();
+        try {
+            //TODO: Add data and make request
+            requestJSON.putOpt(IterableConstants.KEY_PLATFORM, IterableConstants.ITBL_PLATFORM_ANDROID);
+            requestJSON.putOpt(IterableConstants.DEVICE_APP_PACKAGE_NAME, authProvider.getContext().getPackageName());
+            requestJSON.put(IterableConstants.ITBL_KEY_SDK_VERSION, IterableConstants.ITBL_KEY_SDK_VERSION_NUMBER);
+            requestJSON.put(IterableConstants.ITBL_SYSTEM_VERSION, Build.VERSION.RELEASE);
+            sendPostRequest(IterableConstants.ENDPOINT_GET_REMOTE_CONFIGURATION, requestJSON, successHandler, failureHandler);
+        } catch (JSONException e) {
+            e.printStackTrace();
         }
     }
 

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableConstants.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableConstants.java
@@ -69,6 +69,7 @@ public final class IterableConstants {
     public static final String ENDPOINT_UPDATE_USER_SUBS        = "users/updateSubscriptions";
     public static final String ENDPOINT_DDL_MATCH               = "a/matchFp";
     public static final String ENDPOINT_TRACK_INAPP_CLOSE       = "events/trackInAppClose";
+    public static final String ENDPOINT_GET_REMOTE_CONFIGURATION = "mobile/getRemoteConfiguration";
 
     public static final String PUSH_APP_ID                      = "IterableAppId";
     public static final String PUSH_GCM_PROJECT_NUMBER          = "GCMProjectNumber";


### PR DESCRIPTION
## 🔹 Jira Ticket(s) if any

https://iterable.atlassian.net/browse/MOB-2437

## ✏️ Description

Get remote configuration for offline mode.
1. Call get remote configuration when app comes to foreground. Should ideally call it during initialization But existing tests are failing.
2. On Success -> call the setOfflineProcessingEnabled
3. A type check to NOT reassign and reinitialize similar request processor.