### PR TITLE
[MOB-2548] - send SDK Request Processor in Header

### DIFF
--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableConstants.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableConstants.java
@@ -20,6 +20,7 @@ public final class IterableConstants {
     public static final String HEADER_SDK_VERSION       = "SDK-Version";
     public static final String HEADER_SDK_AUTHORIZATION = "Authorization";
     public static final String HEADER_SDK_AUTH_FORMAT   = "Bearer ";
+    public static final String HEADER_SDK_PROCESSOR_TYPE = "SDK-Request-Processor";
     public static final String KEY_APPLICATION_NAME     = "applicationName";
     public static final String KEY_CAMPAIGN_ID          = "campaignId";
     public static final String KEY_CURRENT_EMAIL        = "currentEmail";

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableRequestTask.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableRequestTask.java
@@ -89,7 +89,7 @@ class IterableRequestTask extends AsyncTask<IterableApiRequest, Void, IterableAp
                     urlConnection.setRequestProperty(IterableConstants.HEADER_SDK_PLATFORM, "Android");
                     urlConnection.setRequestProperty(IterableConstants.HEADER_SDK_VERSION, IterableConstants.ITBL_KEY_SDK_VERSION_NUMBER);
                     urlConnection.setRequestProperty(IterableConstants.KEY_SENT_AT, String.valueOf(new Date().getTime() / 1000));
-                    urlConnection.setRequestProperty(IterableConstants.HEADER_SDK_PROCESSOR_TYPE, iterableApiRequest.processorType.toString());
+                    urlConnection.setRequestProperty(IterableConstants.HEADER_SDK_PROCESSOR_TYPE, iterableApiRequest.getProcessorType().toString());
                     if (iterableApiRequest.authToken != null) {
                         urlConnection.setRequestProperty(IterableConstants.HEADER_SDK_AUTHORIZATION, IterableConstants.HEADER_SDK_AUTH_FORMAT + iterableApiRequest.authToken);
                     }
@@ -111,7 +111,7 @@ class IterableRequestTask extends AsyncTask<IterableApiRequest, Void, IterableAp
                     urlConnection.setRequestProperty(IterableConstants.HEADER_SDK_PLATFORM, "Android");
                     urlConnection.setRequestProperty(IterableConstants.HEADER_SDK_VERSION, IterableConstants.ITBL_KEY_SDK_VERSION_NUMBER);
                     urlConnection.setRequestProperty(IterableConstants.KEY_SENT_AT, String.valueOf(new Date().getTime() / 1000));
-                    urlConnection.setRequestProperty(IterableConstants.HEADER_SDK_PROCESSOR_TYPE, iterableApiRequest.processorType.toString());
+                    urlConnection.setRequestProperty(IterableConstants.HEADER_SDK_PROCESSOR_TYPE, iterableApiRequest.getProcessorType().toString());
                     if (iterableApiRequest.authToken != null) {
                         urlConnection.setRequestProperty(IterableConstants.HEADER_SDK_AUTHORIZATION, IterableConstants.HEADER_SDK_AUTH_FORMAT + iterableApiRequest.authToken);
                     }
@@ -312,7 +312,7 @@ class IterableApiRequest {
     final String requestType;
     final String authToken;
 
-    ProcessorType processorType = ProcessorType.ONLINE;
+    private ProcessorType processorType = ProcessorType.ONLINE;
     IterableHelper.IterableActionHandler legacyCallback;
     IterableHelper.SuccessHandler successCallback;
     IterableHelper.FailureHandler failureCallback;
@@ -334,7 +334,11 @@ class IterableApiRequest {
         }
     }
 
-    public void setProcessorType(ProcessorType processorType) {
+    public ProcessorType getProcessorType() {
+        return processorType;
+    }
+
+    void setProcessorType(ProcessorType processorType) {
         this.processorType = processorType;
     }
 

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableRequestTask.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableRequestTask.java
@@ -89,7 +89,7 @@ class IterableRequestTask extends AsyncTask<IterableApiRequest, Void, IterableAp
                     urlConnection.setRequestProperty(IterableConstants.HEADER_SDK_PLATFORM, "Android");
                     urlConnection.setRequestProperty(IterableConstants.HEADER_SDK_VERSION, IterableConstants.ITBL_KEY_SDK_VERSION_NUMBER);
                     urlConnection.setRequestProperty(IterableConstants.KEY_SENT_AT, String.valueOf(new Date().getTime() / 1000));
-
+                    urlConnection.setRequestProperty(IterableConstants.HEADER_SDK_PROCESSOR_TYPE, iterableApiRequest.processorType.toString());
                     if (iterableApiRequest.authToken != null) {
                         urlConnection.setRequestProperty(IterableConstants.HEADER_SDK_AUTHORIZATION, IterableConstants.HEADER_SDK_AUTH_FORMAT + iterableApiRequest.authToken);
                     }
@@ -111,7 +111,7 @@ class IterableRequestTask extends AsyncTask<IterableApiRequest, Void, IterableAp
                     urlConnection.setRequestProperty(IterableConstants.HEADER_SDK_PLATFORM, "Android");
                     urlConnection.setRequestProperty(IterableConstants.HEADER_SDK_VERSION, IterableConstants.ITBL_KEY_SDK_VERSION_NUMBER);
                     urlConnection.setRequestProperty(IterableConstants.KEY_SENT_AT, String.valueOf(new Date().getTime() / 1000));
-
+                    urlConnection.setRequestProperty(IterableConstants.HEADER_SDK_PROCESSOR_TYPE, iterableApiRequest.processorType.toString());
                     if (iterableApiRequest.authToken != null) {
                         urlConnection.setRequestProperty(IterableConstants.HEADER_SDK_AUTHORIZATION, IterableConstants.HEADER_SDK_AUTH_FORMAT + iterableApiRequest.authToken);
                     }
@@ -312,9 +312,31 @@ class IterableApiRequest {
     final String requestType;
     final String authToken;
 
+    ProcessorType processorType = ProcessorType.ONLINE;
     IterableHelper.IterableActionHandler legacyCallback;
     IterableHelper.SuccessHandler successCallback;
     IterableHelper.FailureHandler failureCallback;
+
+    enum ProcessorType {
+        ONLINE {
+            @NonNull
+            @Override
+            public String toString() {
+                return "Online";
+            }
+        },
+        OFFLINE {
+            @NonNull
+            @Override
+            public String toString() {
+                return "Offline";
+            }
+        }
+    }
+
+    public void setProcessorType(ProcessorType processorType) {
+        this.processorType = processorType;
+    }
 
     IterableApiRequest(String apiKey, String baseUrl, String resourcePath, JSONObject json, String requestType, String authToken, IterableHelper.SuccessHandler onSuccess, IterableHelper.FailureHandler onFailure) {
         this.apiKey = apiKey;

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableTaskRunner.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableTaskRunner.java
@@ -131,6 +131,7 @@ class IterableTaskRunner implements IterableTaskStorage.TaskCreatedListener, Han
             TaskResult result = TaskResult.FAILURE;
             try {
                 IterableApiRequest request = IterableApiRequest.fromJSON(getTaskDataWithDate(task), null, null);
+                request.setProcessorType(IterableApiRequest.ProcessorType.OFFLINE);
                 response = IterableRequestTask.executeApiRequest(request);
             } catch (Exception e) {
                 IterableLogger.e(TAG, "Error while processing request task", e);

--- a/iterableapi/src/main/java/com/iterable/iterableapi/OfflineRequestProcessor.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/OfflineRequestProcessor.java
@@ -45,6 +45,7 @@ class OfflineRequestProcessor implements RequestProcessor {
     @Override
     public void processGetRequest(@Nullable String apiKey, @NonNull String resourcePath, @NonNull JSONObject json, String authToken, @Nullable IterableHelper.IterableActionHandler onCallback) {
         IterableApiRequest request = new IterableApiRequest(apiKey, resourcePath, json, IterableApiRequest.GET, authToken, onCallback);
+        request.setProcessorType(IterableApiRequest.ProcessorType.OFFLINE);
         new IterableRequestTask().execute(request);
     }
 
@@ -52,6 +53,7 @@ class OfflineRequestProcessor implements RequestProcessor {
     public void processPostRequest(@Nullable String apiKey, @NonNull String resourcePath, @NonNull JSONObject json, String authToken, @Nullable IterableHelper.SuccessHandler onSuccess, @Nullable IterableHelper.FailureHandler onFailure) {
         IterableApiRequest request = new IterableApiRequest(apiKey, resourcePath, json, IterableApiRequest.POST, authToken, onSuccess, onFailure);
         if (isRequestOfflineCompatible(request.resourcePath)) {
+            request.setProcessorType(IterableApiRequest.ProcessorType.OFFLINE);
             taskScheduler.scheduleTask(request, onSuccess, onFailure);
         } else {
             new IterableRequestTask().execute(request);


### PR DESCRIPTION
## 🔹 Jira Ticket(s) if any
https://iterable.atlassian.net/browse/MOB-2548

## ✏️ Description

1. Added new enum ProcessorType in `IterableApiRequest`
2. Added the field in `IterableConstants`
3. Added a setter for processing type. If setter is not used, it will be defaulted to Online Processing.
4. All the cascading changes to other classes - Now offline processor's get and post request uses this setter before executing the request. Also same changes for TaskRunner where it fetches the task from database and executes the request.
