### PR TITLE
[MOB - 2541] - Remove offline configuration from IterableConfig

### DIFF
--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
@@ -320,6 +320,10 @@ private static final String TAG = "IterableApi";
         apiClient.getRemoteConfiguration(new IterableHelper.IterableActionHandler() {
             @Override
             public void execute(@Nullable String data) {
+                if (data == null) {
+                    IterableLogger.e(TAG, "Remote configuration returned null");
+                    return;
+                }
                 try {
                     JSONObject jsonData = new JSONObject(data);
                     boolean offlineConfiguration = jsonData.getBoolean(IterableConstants.SHARED_PREFS_OFFLINE_MODE_BETA_KEY);
@@ -1054,9 +1058,7 @@ private static final String TAG = "IterableApi";
         }
         getInAppManager().reset();
         getAuthManager().clearRefreshTimer();
-        if (config.offlineProcessing) {
-            IterableTaskStorage.sharedInstance(getMainActivityContext()).deleteAllTasks();
-        }
+        apiClient.onLogout();
     }
 
     private void onLogIn() {

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableApiClient.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableApiClient.java
@@ -533,4 +533,8 @@ class IterableApiClient {
     void sendGetRequest(@NonNull String resourcePath, @NonNull JSONObject json, @Nullable IterableHelper.IterableActionHandler onCallback) {
         getRequestProcessor().processGetRequest(authProvider.getApiKey(), resourcePath, json, authProvider.getAuthToken(), onCallback);
     }
+
+    void onLogout() {
+        getRequestProcessor().onLogout(authProvider.getContext());
+    }
 }

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableConfig.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableConfig.java
@@ -66,11 +66,6 @@ public class IterableConfig {
     final IterableAuthHandler authHandler;
 
     /**
-     * When set to true, the SDK will keep track of events when the device and trigger them once the network establishes
-     */
-    boolean offlineProcessing;
-
-    /**
      * Duration prior to an auth expiration that a new auth token should be requested.
      */
     final long expiringAuthTokenRefreshPeriod;
@@ -87,7 +82,6 @@ public class IterableConfig {
         inAppDisplayInterval = builder.inAppDisplayInterval;
         authHandler = builder.authHandler;
         expiringAuthTokenRefreshPeriod = builder.expiringAuthTokenRefreshPeriod;
-        offlineProcessing = builder.offlineProcessing;
     }
 
     public static class Builder {
@@ -102,7 +96,6 @@ public class IterableConfig {
         private double inAppDisplayInterval = 30.0;
         private IterableAuthHandler authHandler;
         private long expiringAuthTokenRefreshPeriod = 60000L;
-        private boolean offlineProcessing = false;
         public Builder() {}
 
         /**
@@ -221,16 +214,6 @@ public class IterableConfig {
         @NonNull
         public Builder setExpiringAuthTokenRefreshPeriod(@NonNull Long period) {
             this.expiringAuthTokenRefreshPeriod = period * 1000L;
-            return this;
-        }
-
-        /**
-         * When set to true, the SDK will capture events when the device goes offline.
-         * @param offlineProcessing boolean which will enable offline processing
-         */
-        @NonNull
-        Builder setOfflineProcessing(@NonNull boolean offlineProcessing) {
-            this.offlineProcessing = offlineProcessing;
             return this;
         }
 

--- a/iterableapi/src/main/java/com/iterable/iterableapi/OfflineRequestProcessor.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/OfflineRequestProcessor.java
@@ -18,6 +18,7 @@ import java.util.Set;
 class OfflineRequestProcessor implements RequestProcessor {
     private TaskScheduler taskScheduler;
     private IterableTaskRunner taskRunner;
+    private IterableTaskStorage taskStorage;
     private static final Set<String> offlineApiSet = new HashSet<>(Arrays.asList(
             IterableConstants.ENDPOINT_TRACK,
             IterableConstants.ENDPOINT_TRACK_PUSH_OPEN,
@@ -30,7 +31,7 @@ class OfflineRequestProcessor implements RequestProcessor {
             IterableConstants.ENDPOINT_INAPP_CONSUME));
 
     OfflineRequestProcessor(Context context) {
-        IterableTaskStorage taskStorage = IterableTaskStorage.sharedInstance(context);
+        taskStorage = IterableTaskStorage.sharedInstance(context);
         IterableNetworkConnectivityManager networkConnectivityManager = IterableNetworkConnectivityManager.sharedInstance(context);
         taskRunner = new IterableTaskRunner(taskStorage, IterableActivityMonitor.getInstance(), networkConnectivityManager);
         taskScheduler = new TaskScheduler(taskStorage, taskRunner);
@@ -56,6 +57,11 @@ class OfflineRequestProcessor implements RequestProcessor {
         } else {
             new IterableRequestTask().execute(request);
         }
+    }
+
+    @Override
+    public void onLogout(Context context) {
+        taskStorage.deleteAllTasks();
     }
 
     boolean isRequestOfflineCompatible(String baseUrl) {

--- a/iterableapi/src/main/java/com/iterable/iterableapi/OnlineRequestProcessor.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/OnlineRequestProcessor.java
@@ -1,5 +1,7 @@
 package com.iterable.iterableapi;
 
+import android.content.Context;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
@@ -24,6 +26,11 @@ class OnlineRequestProcessor implements RequestProcessor {
         new IterableRequestTask().execute(request);
     }
 
+    @Override
+    public void onLogout(Context context) {
+
+    }
+
     JSONObject addCreatedAtToJson(JSONObject jsonObject) {
         try {
             jsonObject.put(IterableConstants.KEY_CREATED_AT, new Date().getTime() / 1000);
@@ -32,4 +39,5 @@ class OnlineRequestProcessor implements RequestProcessor {
         }
         return jsonObject;
     }
+
 }

--- a/iterableapi/src/main/java/com/iterable/iterableapi/RequestProcessor.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/RequestProcessor.java
@@ -1,5 +1,7 @@
 package com.iterable.iterableapi;
 
+import android.content.Context;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
@@ -8,4 +10,5 @@ import org.json.JSONObject;
 public interface RequestProcessor {
     void processGetRequest(@Nullable String apiKey, @NonNull String resourcePath, @NonNull JSONObject json, String authToken, @Nullable IterableHelper.IterableActionHandler onCallback);
     void processPostRequest(@Nullable String apiKey, @NonNull String resourcePath, @NonNull JSONObject json, String authToken, @Nullable IterableHelper.SuccessHandler onSuccess, @Nullable IterableHelper.FailureHandler onFailure);
+    void onLogout(Context context);
 }

--- a/iterableapi/src/test/java/com/iterable/iterableapi/IterableApiTest.java
+++ b/iterableapi/src/test/java/com/iterable/iterableapi/IterableApiTest.java
@@ -348,7 +348,28 @@ public class IterableApiTest extends BaseTest {
 
     @Test
     public void databaseClearOnLogout() throws Exception {
-        IterableApi.initialize(getContext(), "fake_key", new IterableConfig.Builder().setPushIntegrationName("pushIntegration").setAutoPushRegistration(true).setOfflineProcessing(true).build());
+
+        server.enqueue(new MockResponse().setResponseCode(200).setBody("{\n" +
+                "            \"offlineMode\": false,\n" +
+                "            \"offlineModeBeta\": true,\n" +
+                "            \"someOtherKey1\": \"someOtherValue1\"\n" +
+                "        }"));
+        IterableActivityMonitor.getInstance().unregisterLifecycleCallbacks(getContext());
+        IterableActivityMonitor.instance = new IterableActivityMonitor();
+
+        IterableApi.initialize(getContext(), "apiKey", new IterableConfig.Builder().setAutoPushRegistration(false).build());
+        verify(mockApiClient).setOfflineProcessingEnabled(false);
+        clearInvocations(mockApiClient);
+        Robolectric.buildActivity(Activity.class).create().start().resume();
+        shadowOf(getMainLooper()).idle();
+        RecordedRequest trackInAppConsumeRequest = server.takeRequest(1, TimeUnit.SECONDS);
+        assertNotNull(trackInAppConsumeRequest);
+        assertTrue(trackInAppConsumeRequest.getRequestUrl().toString().contains("/getRemoteConfiguration"));
+        verify(mockApiClient).setOfflineProcessingEnabled(true);
+
+        IterableActivityMonitor.getInstance().unregisterLifecycleCallbacks(getContext());
+        IterableActivityMonitor.instance = new IterableActivityMonitor();
+
         IterableApi.getInstance().setEmail("test@email.com");
         IterableTaskStorage taskStorage = IterableTaskStorage.sharedInstance(getContext());
         taskStorage.createTask("Test", IterableTaskType.API, "data");


### PR DESCRIPTION
## 🔹 Jira Ticket(s) if any

https://iterable.atlassian.net/browse/MOB-2541

## ✏️ Description

1. Removed offlineProcessing flag from IterableConfig
2. New interface method `onLogout(context)` introduced in `RequestProcessor`
3.  `apiClient` now has onLogout() method which makes calls to its requestProcessor's `onLogout(context)`
4. `IterableAPI` calls `onLogout()` of `apiClient`
5. Updated test method to check if database is cleared by calling fetch remote configuration.

