### PR TITLE
[MOB-2585] - No message view for inbox

### DIFF
--- a/app/src/androidTest/java/com/iterable/iterableapi/MainActivityTest.java
+++ b/app/src/androidTest/java/com/iterable/iterableapi/MainActivityTest.java
@@ -238,8 +238,8 @@ public class MainActivityTest {
         Intent intent = new Intent();
         String noMessageTitle = "OOPSY";
         String noMessageBody = "No messages for you";
-        intent.putExtra(IterableConstants.NO_MESSAGES_TITLE,noMessageTitle);
-        intent.putExtra(IterableConstants.NO_MESSAGES_BODY,noMessageBody);
+        intent.putExtra(IterableConstants.NO_MESSAGES_TITLE, noMessageTitle);
+        intent.putExtra(IterableConstants.NO_MESSAGES_BODY, noMessageBody);
         rule.launchActivity(intent);
         onView(withText(noMessageTitle)).check(matches(isDisplayed()));
         onView(withText(noMessageBody)).check(matches(isDisplayed()));

--- a/app/src/androidTest/java/com/iterable/iterableapi/MainActivityTest.java
+++ b/app/src/androidTest/java/com/iterable/iterableapi/MainActivityTest.java
@@ -233,6 +233,18 @@ public class MainActivityTest {
         onView(withText("Tips and tricks 2")).check(doesNotExist());
     }
 
+    @Test
+    public void testNoMessagesTitleAndText() throws Exception {
+        Intent intent = new Intent();
+        String noMessageTitle = "OOPSY";
+        String noMessageBody = "No messages for you";
+        intent.putExtra(IterableConstants.NO_MESSAGES_TITLE,noMessageTitle);
+        intent.putExtra(IterableConstants.NO_MESSAGES_BODY,noMessageBody);
+        rule.launchActivity(intent);
+        onView(withText(noMessageTitle)).check(matches(isDisplayed()));
+        onView(withText(noMessageBody)).check(matches(isDisplayed()));
+    }
+
 
     static class Matchers{
         public static Matcher<View> withListSize (final int size) {

--- a/app/src/androidTest/java/com/iterable/iterableapi/testapp/InboxUITest.java
+++ b/app/src/androidTest/java/com/iterable/iterableapi/testapp/InboxUITest.java
@@ -30,7 +30,6 @@ public class InboxUITest {
 
     @Test
     public void basicTest() {
-        onView(withId(R.id.list)).perform(click());
         assertNotNull(rule.getActivity());
     }
 }

--- a/app/src/test/java/com/iterable/iterableapi/InboxUITest.java
+++ b/app/src/test/java/com/iterable/iterableapi/InboxUITest.java
@@ -29,7 +29,6 @@ public class InboxUITest {
 
     @Test
     public void basicTest() {
-        onView(withId(R.id.list)).perform(click());
         assertNotNull(rule.getActivity());
     }
 }

--- a/iterableapi-ui/src/main/java/com/iterable/iterableapi/ui/inbox/IterableInboxActivity.java
+++ b/iterableapi-ui/src/main/java/com/iterable/iterableapi/ui/inbox/IterableInboxActivity.java
@@ -5,6 +5,7 @@ import android.os.Bundle;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 
+import com.iterable.iterableapi.IterableConstants;
 import com.iterable.iterableapi.IterableLogger;
 import com.iterable.iterableapi.ui.R;
 
@@ -37,8 +38,14 @@ public class IterableInboxActivity extends AppCompatActivity {
             if (inboxModeExtra instanceof InboxMode) {
                 inboxMode = (InboxMode) inboxModeExtra;
             }
-            inboxFragment = IterableInboxFragment.newInstance(inboxMode, itemLayoutId);
-            inboxFragment.setArguments(intent.getExtras());
+            String noMessageTitle = null;
+            String noMessageBody = null;
+            Bundle extraBundle = getIntent().getExtras();
+            if (extraBundle != null) {
+                noMessageTitle = extraBundle.getString(IterableConstants.NO_MESSAGES_TITLE, null);
+                noMessageBody = extraBundle.getString(IterableConstants.NO_MESSAGES_BODY, null);
+            }
+            inboxFragment = IterableInboxFragment.newInstance(inboxMode, itemLayoutId, noMessageTitle, noMessageBody);
 
             if (intent.getStringExtra(ACTIVITY_TITLE) != null) {
                 setTitle(intent.getStringExtra(ACTIVITY_TITLE));

--- a/iterableapi-ui/src/main/java/com/iterable/iterableapi/ui/inbox/IterableInboxActivity.java
+++ b/iterableapi-ui/src/main/java/com/iterable/iterableapi/ui/inbox/IterableInboxActivity.java
@@ -38,6 +38,7 @@ public class IterableInboxActivity extends AppCompatActivity {
                 inboxMode = (InboxMode) inboxModeExtra;
             }
             inboxFragment = IterableInboxFragment.newInstance(inboxMode, itemLayoutId);
+            inboxFragment.setArguments(intent.getExtras());
 
             if (intent.getStringExtra(ACTIVITY_TITLE) != null) {
                 setTitle(intent.getStringExtra(ACTIVITY_TITLE));

--- a/iterableapi-ui/src/main/java/com/iterable/iterableapi/ui/inbox/IterableInboxFragment.java
+++ b/iterableapi-ui/src/main/java/com/iterable/iterableapi/ui/inbox/IterableInboxFragment.java
@@ -58,6 +58,9 @@ public class IterableInboxFragment extends Fragment implements IterableInAppMana
     private String noMessagesTitle = "No Messages";
     private String noMessagesBody = "There are no messages in the inbox";
 
+    TextView noMessagesTitleTextView;
+    TextView noMessagesBodyTextView;
+    RecyclerView recyclerView;
     /**
      * Create an Inbox fragment with default parameters
      *
@@ -167,29 +170,34 @@ public class IterableInboxFragment extends Fragment implements IterableInAppMana
         }
 
         RelativeLayout relativeLayout = (RelativeLayout) inflater.inflate(R.layout.iterable_inbox_fragment, container, false);
-        RecyclerView view = relativeLayout.findViewById(R.id.list);
-        view.setLayoutManager(new LinearLayoutManager(getContext()));
+        recyclerView = relativeLayout.findViewById(R.id.list);
+        recyclerView.setLayoutManager(new LinearLayoutManager(getContext()));
         IterableInboxAdapter adapter = new IterableInboxAdapter(IterableApi.getInstance().getInAppManager().getInboxMessages(), IterableInboxFragment.this, adapterExtension, comparator, filter, dateMapper);
-        view.setAdapter(adapter);
+        recyclerView.setAdapter(adapter);
         ItemTouchHelper itemTouchHelper = new ItemTouchHelper(new IterableInboxTouchHelper(getContext(), adapter));
-        itemTouchHelper.attachToRecyclerView(view);
+        itemTouchHelper.attachToRecyclerView(recyclerView);
         return relativeLayout.getRootView();
+    }
+
+    @Override
+    public void onStart() {
+        super.onStart();
+        updateEmptyInboxMessage();
     }
 
     @Override
     public void onResume() {
         super.onResume();
-        updateEmptyInboxMessage();
         updateList();
         IterableApi.getInstance().getInAppManager().addListener(this);
         startSession();
     }
 
     private void updateEmptyInboxMessage() {
-        TextView emptyInboxTitleTextView = getView().findViewById(R.id.emptyInboxTitle);
-        emptyInboxTitleTextView.setText(noMessagesTitle);
-        TextView emptyInboxMessageTextView = getView().findViewById(R.id.emptyInboxMessage);
-        emptyInboxMessageTextView.setText(noMessagesBody);
+        noMessagesTitleTextView = getView().findViewById(R.id.emptyInboxTitle);
+        noMessagesBodyTextView = getView().findViewById(R.id.emptyInboxMessage);
+        noMessagesTitleTextView.setText(noMessagesTitle);
+        noMessagesBodyTextView.setText(noMessagesBody);
     }
 
     @Override
@@ -241,13 +249,13 @@ public class IterableInboxFragment extends Fragment implements IterableInAppMana
 
     private void handleEmptyInbox(IterableInboxAdapter adapter) {
         if (adapter.getItemCount() == 0) {
-            getView().findViewById(R.id.emptyInboxMessage).setVisibility(View.VISIBLE);
-            getView().findViewById(R.id.emptyInboxTitle).setVisibility(View.VISIBLE);
-            getView().findViewById(R.id.list).setVisibility(View.INVISIBLE);
+            noMessagesTitleTextView.setVisibility(View.VISIBLE);
+            noMessagesBodyTextView.setVisibility(View.VISIBLE);
+            recyclerView.setVisibility(View.INVISIBLE);
         } else {
-            getView().findViewById(R.id.emptyInboxMessage).setVisibility(View.INVISIBLE);
-            getView().findViewById(R.id.emptyInboxTitle).setVisibility(View.INVISIBLE);
-            getView().findViewById(R.id.list).setVisibility(View.VISIBLE);
+            noMessagesTitleTextView.setVisibility(View.INVISIBLE);
+            noMessagesBodyTextView.setVisibility(View.INVISIBLE);
+            recyclerView.setVisibility(View.VISIBLE);
         }
     }
 

--- a/iterableapi-ui/src/main/java/com/iterable/iterableapi/ui/inbox/IterableInboxFragment.java
+++ b/iterableapi-ui/src/main/java/com/iterable/iterableapi/ui/inbox/IterableInboxFragment.java
@@ -48,6 +48,11 @@ public class IterableInboxFragment extends Fragment implements IterableInAppMana
 
     private InboxMode inboxMode = InboxMode.POPUP;
     private @LayoutRes int itemLayoutId = R.layout.iterable_inbox_item;
+    private String noMessagesTitle;
+    private String noMessagesBody;
+    TextView noMessagesTitleTextView;
+    TextView noMessagesBodyTextView;
+    RecyclerView recyclerView;
 
     private final SessionManager sessionManager = new SessionManager();
     private IterableInboxAdapterExtension adapterExtension = new DefaultAdapterExtension();
@@ -55,12 +60,7 @@ public class IterableInboxFragment extends Fragment implements IterableInAppMana
     private IterableInboxFilter filter = new DefaultInboxFilter();
     private IterableInboxDateMapper dateMapper = new DefaultInboxDateMapper();
     private boolean sessionStarted = false;
-    private String noMessagesTitle;
-    private String noMessagesBody;
 
-    TextView noMessagesTitleTextView;
-    TextView noMessagesBodyTextView;
-    RecyclerView recyclerView;
     /**
      * Create an Inbox fragment with default parameters
      *
@@ -80,10 +80,16 @@ public class IterableInboxFragment extends Fragment implements IterableInAppMana
      * @return {@link IterableInboxFragment} instance
      */
     @NonNull public static IterableInboxFragment newInstance(@NonNull InboxMode inboxMode, @LayoutRes int itemLayoutId) {
+        return newInstance(inboxMode, itemLayoutId, null, null);
+    }
+
+    @NonNull public static IterableInboxFragment newInstance(@NonNull InboxMode inboxMode, @LayoutRes int itemLayoutId, @Nullable String noMessagesTitle, @Nullable String noMessagesBody) {
         IterableInboxFragment inboxFragment = new IterableInboxFragment();
         Bundle bundle = new Bundle();
         bundle.putSerializable(INBOX_MODE, inboxMode);
         bundle.putInt(ITEM_LAYOUT_ID, itemLayoutId);
+        bundle.putString(IterableConstants.NO_MESSAGES_TITLE, noMessagesTitle);
+        bundle.putString(IterableConstants.NO_MESSAGES_BODY, noMessagesBody);
         inboxFragment.setArguments(bundle);
 
         return inboxFragment;
@@ -162,10 +168,10 @@ public class IterableInboxFragment extends Fragment implements IterableInAppMana
                 itemLayoutId = arguments.getInt(ITEM_LAYOUT_ID);
             }
             if (arguments.getString(IterableConstants.NO_MESSAGES_TITLE) != null) {
-                this.noMessagesTitle = arguments.getString(IterableConstants.NO_MESSAGES_TITLE);
+                noMessagesTitle = arguments.getString(IterableConstants.NO_MESSAGES_TITLE);
             }
             if (arguments.getString(IterableConstants.NO_MESSAGES_BODY) != null) {
-                this.noMessagesBody = arguments.getString(IterableConstants.NO_MESSAGES_BODY);
+                noMessagesBody = arguments.getString(IterableConstants.NO_MESSAGES_BODY);
             }
         }
 
@@ -180,7 +186,7 @@ public class IterableInboxFragment extends Fragment implements IterableInAppMana
         noMessagesBodyTextView.setText(noMessagesBody);
         ItemTouchHelper itemTouchHelper = new ItemTouchHelper(new IterableInboxTouchHelper(getContext(), adapter));
         itemTouchHelper.attachToRecyclerView(recyclerView);
-        return relativeLayout.getRootView();
+        return relativeLayout;
     }
 
     @Override

--- a/iterableapi-ui/src/main/java/com/iterable/iterableapi/ui/inbox/IterableInboxFragment.java
+++ b/iterableapi-ui/src/main/java/com/iterable/iterableapi/ui/inbox/IterableInboxFragment.java
@@ -174,15 +174,13 @@ public class IterableInboxFragment extends Fragment implements IterableInAppMana
         recyclerView.setLayoutManager(new LinearLayoutManager(getContext()));
         IterableInboxAdapter adapter = new IterableInboxAdapter(IterableApi.getInstance().getInAppManager().getInboxMessages(), IterableInboxFragment.this, adapterExtension, comparator, filter, dateMapper);
         recyclerView.setAdapter(adapter);
+        noMessagesTitleTextView = relativeLayout.findViewById(R.id.emptyInboxTitle);
+        noMessagesBodyTextView = relativeLayout.findViewById(R.id.emptyInboxMessage);
+        noMessagesTitleTextView.setText(noMessagesTitle);
+        noMessagesBodyTextView.setText(noMessagesBody);
         ItemTouchHelper itemTouchHelper = new ItemTouchHelper(new IterableInboxTouchHelper(getContext(), adapter));
         itemTouchHelper.attachToRecyclerView(recyclerView);
         return relativeLayout.getRootView();
-    }
-
-    @Override
-    public void onStart() {
-        super.onStart();
-        updateEmptyInboxMessage();
     }
 
     @Override
@@ -191,13 +189,6 @@ public class IterableInboxFragment extends Fragment implements IterableInAppMana
         updateList();
         IterableApi.getInstance().getInAppManager().addListener(this);
         startSession();
-    }
-
-    private void updateEmptyInboxMessage() {
-        noMessagesTitleTextView = getView().findViewById(R.id.emptyInboxTitle);
-        noMessagesBodyTextView = getView().findViewById(R.id.emptyInboxMessage);
-        noMessagesTitleTextView.setText(noMessagesTitle);
-        noMessagesBodyTextView.setText(noMessagesBody);
     }
 
     @Override
@@ -241,7 +232,6 @@ public class IterableInboxFragment extends Fragment implements IterableInAppMana
     }
 
     private void updateList() {
-        RecyclerView recyclerView = getView().findViewById(R.id.list);
         IterableInboxAdapter adapter = (IterableInboxAdapter) recyclerView.getAdapter();
         adapter.setInboxItems(IterableApi.getInstance().getInAppManager().getInboxMessages());
         handleEmptyInbox(adapter);

--- a/iterableapi-ui/src/main/java/com/iterable/iterableapi/ui/inbox/IterableInboxFragment.java
+++ b/iterableapi-ui/src/main/java/com/iterable/iterableapi/ui/inbox/IterableInboxFragment.java
@@ -55,8 +55,8 @@ public class IterableInboxFragment extends Fragment implements IterableInAppMana
     private IterableInboxFilter filter = new DefaultInboxFilter();
     private IterableInboxDateMapper dateMapper = new DefaultInboxDateMapper();
     private boolean sessionStarted = false;
-    private String noMessagesTitle = "No Messages";
-    private String noMessagesBody = "There are no messages in the inbox";
+    private String noMessagesTitle;
+    private String noMessagesBody;
 
     TextView noMessagesTitleTextView;
     TextView noMessagesBodyTextView;

--- a/iterableapi-ui/src/main/res/layout/iterable_inbox_fragment.xml
+++ b/iterableapi-ui/src/main/res/layout/iterable_inbox_fragment.xml
@@ -2,18 +2,18 @@
 
 <RelativeLayout xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:layout_height="match_parent"
+    xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/inboxFragmentLayout"
+    android:name="com.iterable.iterableapi.ui.InboxFragment"
+    android:layout_height="match_parent"
     android:layout_width="match_parent"
-    xmlns:android="http://schemas.android.com/apk/res/android">
+    tools:context=".inbox.IterableInboxFragment">
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/list"
-        android:name="com.iterable.iterableapi.ui.InboxFragment"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         app:layoutManager="LinearLayoutManager"
-        tools:context=".inbox.IterableInboxFragment"
         tools:listitem="@layout/iterable_inbox_item" />
 
     <TextView

--- a/iterableapi-ui/src/main/res/layout/iterable_inbox_fragment.xml
+++ b/iterableapi-ui/src/main/res/layout/iterable_inbox_fragment.xml
@@ -19,16 +19,16 @@
     <TextView
         android:id="@+id/emptyInboxTitle"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_centerInParent="true"
         android:gravity="center"
         android:textSize="18sp"
-        android:textStyle="bold"
-        android:translationY="-16sp" />
+        android:textStyle="bold" />
 
     <TextView
+        android:layout_below="@id/emptyInboxTitle"
         android:id="@+id/emptyInboxMessage"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:gravity="center"
-        android:translationY="16sp" />
+        android:layout_height="wrap_content"
+        android:gravity="center" />
 </RelativeLayout>

--- a/iterableapi-ui/src/main/res/layout/iterable_inbox_fragment.xml
+++ b/iterableapi-ui/src/main/res/layout/iterable_inbox_fragment.xml
@@ -1,11 +1,34 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.recyclerview.widget.RecyclerView xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
+
+<RelativeLayout xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/list"
-    android:name="com.iterable.iterableapi.ui.InboxFragment"
-    android:layout_width="match_parent"
     android:layout_height="match_parent"
-    app:layoutManager="LinearLayoutManager"
-    tools:context=".inbox.IterableInboxFragment"
-    tools:listitem="@layout/iterable_inbox_item" />
+    android:id="@+id/inboxFragmentLayout"
+    android:layout_width="match_parent"
+    xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/list"
+        android:name="com.iterable.iterableapi.ui.InboxFragment"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layoutManager="LinearLayoutManager"
+        tools:context=".inbox.IterableInboxFragment"
+        tools:listitem="@layout/iterable_inbox_item" />
+
+    <TextView
+        android:id="@+id/emptyInboxTitle"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:gravity="center"
+        android:textSize="18sp"
+        android:textStyle="bold"
+        android:translationY="-16sp" />
+
+    <TextView
+        android:id="@+id/emptyInboxMessage"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:gravity="center"
+        android:translationY="16sp" />
+</RelativeLayout>

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableConstants.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableConstants.java
@@ -244,4 +244,7 @@ public final class IterableConstants {
     public static final String ITBL_PLATFORM_ANDROID = "Android";
     public static final String ITBL_KEY_SDK_VERSION_NUMBER = BuildConfig.ITERABLE_SDK_VERSION;
     public static final String ITBL_SYSTEM_VERSION = "systemVersion";
+
+    public static final String NO_MESSAGES_TITLE = "noMessagesTitle";
+    public static final String NO_MESSAGES_BODY = "noMessagesBody";
 }


### PR DESCRIPTION
## 🔹 Jira Ticket(s) if any

https://iterable.atlassian.net/browse/MOB-2585

## ✏️ Description

1. When passed with title and text in bundle, IterableInboxFragment can take that text and override default title and message text
2. Visibility are toggled based on inbox count on every update
3. Inbox Fragment XML now has two text views kept inside RelativeLayout beside recyclerView instead of just having RecyclerView
4. If inbox is displayed using `IterableInboxAcitivity` instead of `IterableInboxFragment`, we still relay the bundle arguments to `IterableInboxFragment` internally. So bundle passed to `IterableInboxActivity` will still work.
5. Added test method to see if passed texts are actually displayed on inbox screen.