### PR TITLE
[MOB - 2656] - InApp Dismiss to allow stateloss

### DIFF
--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableInAppFragmentHTMLNotification.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableInAppFragmentHTMLNotification.java
@@ -383,7 +383,7 @@ public class IterableInAppFragmentHTMLNotification extends DialogFragment implem
             @Override
             public void run() {
                 if (getContext() != null && getDialog() != null && getDialog().getWindow() != null) {
-                    IterableInAppFragmentHTMLNotification.super.dismiss();
+                    dismissAllowingStateLoss();
                 }
             }
         };


### PR DESCRIPTION
## 🔹 Jira Ticket(s) if any

https://iterable.atlassian.net/browse/MOB-2656

## ✏️ Description

1. Allowing dismiss with state loss.

This allows the inapp to be dismissed in background without crashing, after the app is minimized. Dismiss after app background happens in attempt to achieve smooth dismiss animation.

Resolves the github issue - https://github.com/Iterable/iterable-android-sdk/issues/322

