### PR TITLE
[MOB-2762] - Bug fix - In App read state

### DIFF
--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableInAppManager.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableInAppManager.java
@@ -428,7 +428,6 @@ public class IterableInAppManager implements IterableActivityMonitor.AppStateCal
 
     @Override
     public void onSwitchToForeground() {
-        scheduleProcessing();
         if (IterableUtil.currentTimeMillis() - lastSyncTime > MOVE_TO_FOREGROUND_SYNC_INTERVAL_MS) {
             syncInApp();
         }

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableInAppManager.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableInAppManager.java
@@ -181,6 +181,8 @@ public class IterableInAppManager implements IterableActivityMonitor.AppStateCal
                     } catch (JSONException e) {
                         IterableLogger.e(TAG, e.toString());
                     }
+                } else {
+                    scheduleProcessing();
                 }
             }
         });
@@ -430,6 +432,8 @@ public class IterableInAppManager implements IterableActivityMonitor.AppStateCal
     public void onSwitchToForeground() {
         if (IterableUtil.currentTimeMillis() - lastSyncTime > MOVE_TO_FOREGROUND_SYNC_INTERVAL_MS) {
             syncInApp();
+        } else {
+            scheduleProcessing();
         }
     }
 

--- a/iterableapi/src/test/java/com/iterable/iterableapi/IterableInAppManagerTest.java
+++ b/iterableapi/src/test/java/com/iterable/iterableapi/IterableInAppManagerTest.java
@@ -163,15 +163,14 @@ public class IterableInAppManagerTest extends BaseTest {
     @Test
     public void testProcessAfterForeground() throws Exception {
         dispatcher.enqueueResponse("/inApp/getMessages", new MockResponse().setBody(IterableTestUtils.getResourceString("inapp_payload_single.json")));
-        IterableInAppManager inAppManager = IterableApi.getInstance().getInAppManager();
-        assertEquals(0, inAppManager.getMessages().size());
-
-        inAppManager.syncInApp();
-        shadowOf(getMainLooper()).idle();
-        assertEquals(1, inAppManager.getMessages().size());
 
         ActivityController<Activity> activityController = Robolectric.buildActivity(Activity.class).create().start().resume();
         shadowOf(getMainLooper()).idle();
+        shadowOf(getMainLooper()).runToEndOfTasks();
+
+        IterableInAppManager inAppManager = IterableApi.getInstance().getInAppManager();
+        shadowOf(getMainLooper()).idle();
+        assertEquals(1, inAppManager.getMessages().size());
 
         ArgumentCaptor<IterableInAppMessage> inAppMessageCaptor = ArgumentCaptor.forClass(IterableInAppMessage.class);
         verify(inAppHandler).onNewInApp(inAppMessageCaptor.capture());

--- a/iterableapi/src/test/java/com/iterable/iterableapi/IterableInboxTest.java
+++ b/iterableapi/src/test/java/com/iterable/iterableapi/IterableInboxTest.java
@@ -127,13 +127,9 @@ public class IterableInboxTest extends BaseTest {
                 return builder.setInAppHandler(inAppHandler).setCustomActionHandler(customActionHandler).setUrlHandler(urlHandler);
             }
         });
-        inAppManager.syncInApp();
-        shadowOf(getMainLooper()).idle();
-
-        assertEquals(2, inAppManager.getInboxMessages().size());
-        assertEquals(2, inAppManager.getUnreadInboxMessagesCount());
 
         Robolectric.buildActivity(Activity.class).create().start().resume();
+        shadowOf(getMainLooper()).idle();
 
         verify(inAppDisplayerMock).showMessage(any(IterableInAppMessage.class), eq(IterableInAppLocation.IN_APP), any(IterableHelper.IterableUrlCallback.class));
 

--- a/iterableapi/src/test/resources/inapp_payload_inbox_show.json
+++ b/iterableapi/src/test/resources/inapp_payload_inbox_show.json
@@ -2,6 +2,7 @@
   "inAppMessages": [
     {
       "messageId": "message1",
+      "read": false,
       "trigger": {
         "type": "immediate"
       },
@@ -28,6 +29,7 @@
       }
     },{
       "messageId": "message2",
+      "read": false,
       "trigger": {
         "type": "immediate"
       },

--- a/iterableapi/src/test/resources/inapp_payload_single.json
+++ b/iterableapi/src/test/resources/inapp_payload_single.json
@@ -3,6 +3,7 @@
     {
       "messageId": "7kx2MmoGdCpuZao9fDueuQoXVAZuDaVV",
       "expiresAt": 1949157312395,
+      "read": false,
       "trigger": {
         "type": "immediate"
       },


### PR DESCRIPTION
## 🔹 Jira Ticket(s) if any

https://iterable.atlassian.net/browse/MOB-2762

## ✏️ Description

1. Dont show inapp (process message) right on switching to foreground. Wait for sync to happen and it will trigger scheduleProcessing automatically.
2. Schedule Processing is manually called if the app comes to foreground within 60 seconds of its last sync.
3. Schedule processing is also called when getMessage call fails. It compensates for network being offline