### PR TITLE
[MOB-2789] Remove legacyGCMSenderId

### DIFF
--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableConfig.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableConfig.java
@@ -32,12 +32,6 @@ public class IterableConfig {
     final boolean autoPushRegistration;
 
     /**
-     * GCM sender ID for the previous integration
-     * Only set this if you're migrating from GCM to FCM and they're in different projects / have different sender IDs
-     */
-    final String legacyGCMSenderId;
-
-    /**
      * When set to true, it will check for deferred deep links on first time app launch
      * after installation.
      */
@@ -75,7 +69,6 @@ public class IterableConfig {
         urlHandler = builder.urlHandler;
         customActionHandler = builder.customActionHandler;
         autoPushRegistration = builder.autoPushRegistration;
-        legacyGCMSenderId = builder.legacyGCMSenderId;
         checkForDeferredDeeplink = builder.checkForDeferredDeeplink;
         logLevel = builder.logLevel;
         inAppHandler = builder.inAppHandler;
@@ -89,7 +82,6 @@ public class IterableConfig {
         private IterableUrlHandler urlHandler;
         private IterableCustomActionHandler customActionHandler;
         private boolean autoPushRegistration = true;
-        private String legacyGCMSenderId;
         private boolean checkForDeferredDeeplink;
         private int logLevel = Log.ERROR;
         private IterableInAppHandler inAppHandler = new IterableDefaultInAppHandler();
@@ -140,17 +132,6 @@ public class IterableConfig {
         @NonNull
         public Builder setAutoPushRegistration(boolean enabled) {
             this.autoPushRegistration = enabled;
-            return this;
-        }
-
-        /**
-         * Set the GCM sender ID for the previous integration
-         * Only set this if you're migrating from GCM to FCM and they're in different projects / have different sender IDs
-         * @param legacyGCMSenderId legacy GCM sender ID
-         */
-        @NonNull
-        public Builder setLegacyGCMSenderId(@NonNull String legacyGCMSenderId) {
-            this.legacyGCMSenderId = legacyGCMSenderId;
             return this;
         }
 

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterablePushRegistrationTask.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterablePushRegistrationTask.java
@@ -1,14 +1,9 @@
 package com.iterable.iterableapi;
 
 import android.content.Context;
-import android.content.SharedPreferences;
 import android.os.AsyncTask;
 
-import androidx.annotation.NonNull;
-
 import com.google.firebase.iid.FirebaseInstanceId;
-
-import org.json.JSONObject;
 
 import java.io.IOException;
 
@@ -47,7 +42,6 @@ class IterablePushRegistrationTask extends AsyncTask<IterablePushRegistrationDat
                             null
                     );
                 }
-                disableOldDeviceIfNeeded();
             }
         } else {
             IterableLogger.e("IterablePush", "iterablePushRegistrationData has not been specified");
@@ -77,36 +71,6 @@ class IterablePushRegistrationTask extends AsyncTask<IterablePushRegistrationDat
         } catch (Exception e) {
             IterableLogger.e(TAG, "Exception while retrieving the device token: check that firebase is added to the build dependencies", e);
             return null;
-        }
-    }
-
-    /**
-     * If {@link IterableConfig#legacyGCMSenderId} is specified, this will attempt to retrieve the old token
-     * and disable it to avoid duplicate notifications
-     */
-    private void disableOldDeviceIfNeeded() {
-        try {
-            Context applicationContext = IterableApi.sharedInstance.getMainActivityContext();
-            String gcmSenderId = IterableApi.sharedInstance.config.legacyGCMSenderId;
-            if (gcmSenderId != null && gcmSenderId.length() > 0 && !gcmSenderId.equals(Util.getSenderId(applicationContext))) {
-                final SharedPreferences sharedPref = applicationContext.getSharedPreferences(IterableConstants.PUSH_APP_ID, Context.MODE_PRIVATE);
-                boolean migrationDone = sharedPref.getBoolean(IterableConstants.SHARED_PREFS_FCM_MIGRATION_DONE_KEY, false);
-                if (!migrationDone) {
-                    String oldToken = Util.getFirebaseToken(gcmSenderId, IterableConstants.MESSAGING_PLATFORM_GOOGLE);
-
-                    // We disable the device on Iterable but keep the token
-                    if (oldToken != null) {
-                        IterableApi.sharedInstance.disableToken(iterablePushRegistrationData.email, iterablePushRegistrationData.userId, iterablePushRegistrationData.authToken, oldToken, new IterableHelper.SuccessHandler() {
-                            @Override
-                            public void onSuccess(@NonNull JSONObject data) {
-                                sharedPref.edit().putBoolean(IterableConstants.SHARED_PREFS_FCM_MIGRATION_DONE_KEY, true).apply();
-                            }
-                        }, null);
-                    }
-                }
-            }
-        } catch (Exception e) {
-            IterableLogger.e(TAG, "Exception while trying to disable the old device token", e);
         }
     }
 


### PR DESCRIPTION
## 🔹 Jira Ticket(s) if any

* [MOB-2789](https://iterable.atlassian.net/browse/MOB-2789)

## ✏️ Description

`IterableConfig.legacyGCMSenderId` was used for GCM → FCM migration that happened 2 years ago. At this point, most likely no one is using it, and everyone migrated to FCM long time ago.
