### PR TITLE
[MOB-2791] Update firebase-messaging dependency to 19.0.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,7 +9,7 @@ android {
 
     defaultConfig {
         applicationId "com.iterable.iterableapi.testapp"
-        minSdkVersion 15
+        minSdkVersion 16
         targetSdkVersion 27
         versionCode 1
         versionName "1.0"

--- a/iterableapi/build.gradle
+++ b/iterableapi/build.gradle
@@ -7,7 +7,7 @@ android {
     buildToolsVersion '29.0.3'
 
     defaultConfig {
-        minSdkVersion 15
+        minSdkVersion 16
         targetSdkVersion 27
 
         buildConfigField "String", "ITERABLE_SDK_VERSION", "\"3.3.0-beta3\""
@@ -36,7 +36,7 @@ dependencies {
     api 'androidx.legacy:legacy-support-v4:1.0.0'
     api 'androidx.appcompat:appcompat:1.0.0'
     api 'androidx.annotation:annotation:1.0.0'
-    api 'com.google.firebase:firebase-messaging:17.4.0'
+    api 'com.google.firebase:firebase-messaging:19.0.0'
 
     testImplementation 'junit:junit:4.12'
     testImplementation 'androidx.test:runner:1.3.0'


### PR DESCRIPTION
## 🔹 Jira Ticket(s) if any

* [MOB-2791](https://iterable.atlassian.net/browse/MOB-2791)

## ✏️ Description

19.0.0 was released in June 2019 and is the first version migrated to AndroidX. We’re already using AndroidX, so it makes sense to require at least version 19.0.0.
This also raises `minSdkVersion` to 16, which is the minimum supported by `firebase-messaging`.