### PR TITLE
[MOB-2912] - Firebase Crash Fix

### DIFF
--- a/iterableapi/build.gradle
+++ b/iterableapi/build.gradle
@@ -38,7 +38,7 @@ dependencies {
     api 'androidx.legacy:legacy-support-v4:1.0.0'
     api 'androidx.appcompat:appcompat:1.0.0'
     api 'androidx.annotation:annotation:1.0.0'
-    api 'com.google.firebase:firebase-messaging:19.0.0'
+    api 'com.google.firebase:firebase-messaging:20.3.0'
 
     testImplementation 'junit:junit:4.12'
     testImplementation 'androidx.test:runner:1.3.0'

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableFirebaseMessagingService.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableFirebaseMessagingService.java
@@ -5,11 +5,13 @@ import android.os.AsyncTask;
 import android.os.Bundle;
 import androidx.annotation.NonNull;
 
-import com.google.firebase.iid.FirebaseInstanceId;
+import com.google.android.gms.tasks.Tasks;
+import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.FirebaseMessagingService;
 import com.google.firebase.messaging.RemoteMessage;
 
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
 
 public class IterableFirebaseMessagingService extends FirebaseMessagingService {
 
@@ -86,7 +88,16 @@ public class IterableFirebaseMessagingService extends FirebaseMessagingService {
      * Call this from a custom {@link FirebaseMessagingService} to register the new token with Iterable
      */
     public static void handleTokenRefresh() {
-        String registrationToken = FirebaseInstanceId.getInstance().getToken();
+        String registrationToken;
+        try {
+            registrationToken = Tasks.await(FirebaseMessaging.getInstance().getToken());
+        } catch (ExecutionException e) {
+            e.printStackTrace();
+            return;
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+            return;
+        }
         IterableLogger.d(TAG, "New Firebase Token generated: " + registrationToken);
         IterableApi.getInstance().registerForPush();
     }

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableFirebaseMessagingService.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableFirebaseMessagingService.java
@@ -88,18 +88,23 @@ public class IterableFirebaseMessagingService extends FirebaseMessagingService {
      * Call this from a custom {@link FirebaseMessagingService} to register the new token with Iterable
      */
     public static void handleTokenRefresh() {
-        String registrationToken;
+        String registrationToken = getFirebaseToken();
+        IterableLogger.d(TAG, "New Firebase Token generated: " + registrationToken);
+        IterableApi.getInstance().registerForPush();
+    }
+
+    public static String getFirebaseToken() {
+        String registrationToken = null;
         try {
             registrationToken = Tasks.await(FirebaseMessaging.getInstance().getToken());
         } catch (ExecutionException e) {
-            e.printStackTrace();
-            return;
+            IterableLogger.e(TAG, e.getLocalizedMessage());
         } catch (InterruptedException e) {
-            e.printStackTrace();
-            return;
+            IterableLogger.e(TAG, e.getLocalizedMessage());
+        } catch (Exception e) {
+            IterableLogger.e(TAG, "Failed to fetch firebase token");
         }
-        IterableLogger.d(TAG, "New Firebase Token generated: " + registrationToken);
-        IterableApi.getInstance().registerForPush();
+        return registrationToken;
     }
 
     /**

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterablePushRegistrationTask.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterablePushRegistrationTask.java
@@ -3,9 +3,11 @@ package com.iterable.iterableapi;
 import android.content.Context;
 import android.os.AsyncTask;
 
-import com.google.firebase.iid.FirebaseInstanceId;
+import com.google.android.gms.tasks.Tasks;
+import com.google.firebase.messaging.FirebaseMessaging;
 
 import java.io.IOException;
+import java.util.concurrent.ExecutionException;
 
 /**
  * Created by David Truong dt@iterable.com
@@ -81,23 +83,21 @@ class IterablePushRegistrationTask extends AsyncTask<IterablePushRegistrationDat
             return instance.getFirebaseToken();
         }
 
-        static String getFirebaseToken(String senderId, String platform) throws IOException {
-            return instance.getFirebaseToken(senderId, platform);
-        }
-
         static String getSenderId(Context applicationContext) {
             return instance.getSenderId(applicationContext);
         }
 
         static class UtilImpl {
             String getFirebaseToken() {
-                FirebaseInstanceId instanceID = FirebaseInstanceId.getInstance();
-                return instanceID.getToken();
-            }
-
-            String getFirebaseToken(String senderId, String platform) throws IOException {
-                FirebaseInstanceId instanceId = FirebaseInstanceId.getInstance();
-                return instanceId.getToken(senderId, platform);
+                try {
+                    return Tasks.await(FirebaseMessaging.getInstance().getToken());
+                } catch (ExecutionException e) {
+                    IterableLogger.e(TAG, e.getLocalizedMessage());
+                    return null;
+                } catch (InterruptedException e) {
+                    IterableLogger.e(TAG, e.getLocalizedMessage());
+                    return null;
+                }
             }
 
             String getSenderId(Context applicationContext) {

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterablePushRegistrationTask.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterablePushRegistrationTask.java
@@ -3,12 +3,6 @@ package com.iterable.iterableapi;
 import android.content.Context;
 import android.os.AsyncTask;
 
-import com.google.android.gms.tasks.Tasks;
-import com.google.firebase.messaging.FirebaseMessaging;
-
-import java.io.IOException;
-import java.util.concurrent.ExecutionException;
-
 /**
  * Created by David Truong dt@iterable.com
  */
@@ -89,15 +83,7 @@ class IterablePushRegistrationTask extends AsyncTask<IterablePushRegistrationDat
 
         static class UtilImpl {
             String getFirebaseToken() {
-                try {
-                    return Tasks.await(FirebaseMessaging.getInstance().getToken());
-                } catch (ExecutionException e) {
-                    IterableLogger.e(TAG, e.getLocalizedMessage());
-                    return null;
-                } catch (InterruptedException e) {
-                    IterableLogger.e(TAG, e.getLocalizedMessage());
-                    return null;
-                }
+                return IterableFirebaseMessagingService.getFirebaseToken();
             }
 
             String getSenderId(Context applicationContext) {


### PR DESCRIPTION


## 🔹 Jira Ticket(s) if any

https://iterable.atlassian.net/browse/MOB-2912

## ✏️ Description

1. Upgrading firebase to 20.3.0 to use FirebaseMessaging instead of FirebaseInstanceId to get Token.
2. Updated related methods.
