### PR TITLE
[MOB-2971] - Set Context method

### DIFF
--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
@@ -310,6 +310,10 @@ private static final String TAG = "IterableApi";
         IterablePushActionReceiver.processPendingAction(context);
     }
 
+    public static void setContext(Context context) {
+        IterableActivityMonitor.getInstance().registerLifecycleCallbacks(context);
+    }
+
     static void loadLastSavedConfiguration(Context context) {
         SharedPreferences sharedPref = context.getSharedPreferences(IterableConstants.SHARED_PREFS_SAVED_CONFIGURATION, Context.MODE_PRIVATE);
         boolean offlineMode = sharedPref.getBoolean(IterableConstants.SHARED_PREFS_OFFLINE_MODE_BETA_KEY, false);


### PR DESCRIPTION
## 🔹 Jira Ticket(s) if any

https://iterable.atlassian.net/browse/MOB-2971

## ✏️ Description

This method `setContext` will be called from RN Android Application class to just keep context ready with Iterable. This way, by the time IterableSDK is initialized and starts processing request, IterableActivitymonitor will already be aware of activities on the screen.

