### PR TITLE
[MOB - 2939] - Remove bintray reference

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,6 @@ buildscript {
         classpath ('com.hiya:jacoco-android:0.2') {
             exclude group: 'org.codehaus.groovy', module: 'groovy-all'
         }
-        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.0'
         classpath "com.github.dcendents:android-maven-gradle-plugin:2.1"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/iterableapi-ui/build.gradle
+++ b/iterableapi-ui/build.gradle
@@ -39,9 +39,6 @@ dependencies {
 }
 
 ext {
-    bintrayRepo = 'maven'
-    bintrayName = 'Iterable-SDK-UI'
-
     publishedGroupId = 'com.iterable'
     libraryName = 'iterableapi-ui'
     artifact = 'iterableapi-ui'
@@ -62,9 +59,6 @@ ext {
     allLicenses = ["Apache-2.0"]
 }
 
-
-apply from: 'https://raw.githubusercontent.com/nuuneoi/JCenter/master/installv1.gradle'
-apply from: 'https://raw.githubusercontent.com/nuuneoi/JCenter/master/bintrayv1.gradle'
 
 if(hasProperty("mavenPublishEnabled")) {
     apply from: '../maven-push.gradle'

--- a/iterableapi-ui/build.gradle
+++ b/iterableapi-ui/build.gradle
@@ -64,6 +64,11 @@ if(hasProperty("mavenPublishEnabled")) {
     apply from: '../maven-push.gradle'
 }
 
+task javadoc(type: Javadoc) {
+    source = android.sourceSets.main.java.srcDirs
+    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
+}
+
 // A hack to import the classpath and BuildConfig into the javadoc task
 afterEvaluate {
     javadoc.classpath += files(android.libraryVariants.collect { variant -> variant.javaCompile.classpath.files })

--- a/iterableapi/build.gradle
+++ b/iterableapi/build.gradle
@@ -62,9 +62,6 @@ dependencies {
 }
 
 ext {
-    bintrayRepo = 'maven'
-    bintrayName = 'Iterable-SDK'
-
     publishedGroupId = 'com.iterable'
     libraryName = 'iterableapi'
     artifact = 'iterableapi'
@@ -86,8 +83,6 @@ ext {
 }
 
 
-apply from: 'https://raw.githubusercontent.com/nuuneoi/JCenter/master/installv1.gradle'
-apply from: 'https://raw.githubusercontent.com/nuuneoi/JCenter/master/bintrayv1.gradle'
 if(hasProperty("mavenPublishEnabled")) {
     apply from: '../maven-push.gradle'
 }

--- a/iterableapi/build.gradle
+++ b/iterableapi/build.gradle
@@ -87,6 +87,11 @@ if(hasProperty("mavenPublishEnabled")) {
     apply from: '../maven-push.gradle'
 }
 
+task javadoc(type: Javadoc) {
+    source = android.sourceSets.main.java.srcDirs
+    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
+}
+
 tasks.withType(Test) {
     jacoco.includeNoLocationClasses = true
 }


### PR DESCRIPTION
## 🔹 Jira Ticket(s) if any

https://iterable.atlassian.net/browse/MOB-2939

## ✏️ Description

 - Removes residual tasks and code from build.gradle file left from our Jcentre/Bintray to Maven migration. 
