### PR TITLE
[MOB-3238] - Add missing install script in build.gradle

### DIFF
--- a/iterableapi-ui/build.gradle
+++ b/iterableapi-ui/build.gradle
@@ -59,7 +59,7 @@ ext {
     allLicenses = ["Apache-2.0"]
 }
 
-
+apply from: 'https://raw.githubusercontent.com/nuuneoi/JCenter/master/installv1.gradle'
 if(hasProperty("mavenPublishEnabled")) {
     apply from: '../maven-push.gradle'
 }

--- a/iterableapi/build.gradle
+++ b/iterableapi/build.gradle
@@ -82,7 +82,7 @@ ext {
     allLicenses = ["Apache-2.0"]
 }
 
-
+apply from: 'https://raw.githubusercontent.com/nuuneoi/JCenter/master/installv1.gradle'
 if(hasProperty("mavenPublishEnabled")) {
     apply from: '../maven-push.gradle'
 }


### PR DESCRIPTION
## 🔹 Jira Ticket(s) if any

https://iterable.atlassian.net/browse/MOB-3238

## ✏️ Description

This was removed in its last iteration during the clean up of bintray related files. But looks like we need it as part for performing ./gradlew install command.

NOTE:
This is the place from where gradle gets definition of `install`:
https://raw.githubusercontent.com/nuuneoi/JCenter/master/installv1.gradle
This task generates pom file.

Most of the content looks similar to our existing script in [maven-push.gradle](https://github.com/Iterable/iterable-android-sdk/blob/ffabfe74a087bc9721bc18a1a9429ddcaf0481fb/maven-push.gradle#L56-L101) file, which also generates pom file. 