### PR TITLE
[MOB-3266] - Timestamp on notification

### DIFF
--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableNotificationHelper.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableNotificationHelper.java
@@ -10,6 +10,7 @@ import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
 import android.content.res.Resources;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
 import androidx.annotation.VisibleForTesting;
 import androidx.core.app.NotificationCompat;
@@ -145,6 +146,9 @@ class IterableNotificationHelper {
                     .setContentTitle(title)
                     .setPriority(NotificationCompat.PRIORITY_HIGH)
                     .setContentText(notificationBody);
+            if (Build.VERSION.SDK_INT >= 17) {
+                notificationBuilder.setShowWhen(true);
+            }
             notificationBuilder.setImageUrl(pushImage);
             notificationBuilder.setExpandedContent(notificationBody);
 


### PR DESCRIPTION
## 🔹 Jira Ticket(s) if any

https://iterable.atlassian.net/browse/MOB-3266

## ✏️ Description

Check for Build version if its >=17, use the API setShowWhen(Boolean variable) to show timestamp.
Reference: https://developer.android.com/reference/android/app/Notification.Builder#setShowWhen(boolean)

Can remove the check once minimum version of SDK is set to >=17