### PR TITLE
[MOB-3091] - Sync In App after initialization

### DIFF
--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableInAppManager.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableInAppManager.java
@@ -74,7 +74,7 @@ public class IterableInAppManager implements IterableActivityMonitor.AppStateCal
         this.displayer = displayer;
         this.activityMonitor = activityMonitor;
         this.activityMonitor.addCallback(this);
-
+        syncInApp();
     }
 
     /**


### PR DESCRIPTION
## 🔹 Jira Ticket(s) if any

https://iterable.atlassian.net/browse/MOB-3091

This is fix suggested in review: https://github.com/Iterable/react-native-sdk/pull/174. This way RN Android wont need any change.

## ✏️ Description

syncInApp() is called right after InAppManager is initialized. SyncInApp call when switching to foreground remains unaffected. Duplicate calls will also be not made as lastSyncTime is updated inside SyncInApp call.
