### PR TITLE
[MOB-3564] ignore messages that are already read for delivery

### DIFF
--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableInAppManager.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableInAppManager.java
@@ -338,7 +338,7 @@ public class IterableInAppManager implements IterableActivityMonitor.AppStateCal
         for (IterableInAppMessage localMessage : storage.getMessages()) {
             if (!remoteQueueMap.containsKey(localMessage.getMessageId())) {
                 storage.removeMessage(localMessage);
-                
+
                 changed = true;
             }
         }


### PR DESCRIPTION
## 🔹 Jira Ticket(s) if any

* [MOB-3564](https://iterable.atlassian.net/browse/MOB-3564)

## ✏️ Description

* mirrors the [fix on the iOS SDK](https://github.com/Iterable/swift-sdk/pull/508), which fixes `read` messages getting counted as delivered, when getting in-apps (which caused duplicate deliveries)