### PR TITLE
[MOB-3588] Add PendingIntent.FLAG_UPDATE_CURRENT to action button intents

### DIFF
--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableNotificationBuilder.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableNotificationBuilder.java
@@ -119,7 +119,7 @@ public class IterableNotificationBuilder extends NotificationCompat.Builder {
         buttonIntent.putExtra(IterableConstants.ACTION_IDENTIFIER, button.identifier);
 
         PendingIntent pendingButtonIntent = PendingIntent.getBroadcast(context, buttonIntent.hashCode(),
-                buttonIntent, 0);
+                buttonIntent, PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
 
         NotificationCompat.Action.Builder actionBuilder = new NotificationCompat.Action
                 .Builder(NotificationCompat.BADGE_ICON_NONE, button.title, pendingButtonIntent);


### PR DESCRIPTION
## 🔹 Jira Ticket(s) if any

* [MOB-3588](https://iterable.atlassian.net/browse/MOB-XXXX)

## ✏️ Description

Without it, if the hashCodes matches a button from one of the previous notifications, the pending intent won't be updated, and it may perform an action from the old message.

The root of the issue is that we generate PendingIntents with a `requestCode` that is not guaranteed to be unique per message. As a result, if `requestCode` collides with a pendingIntent created by an older message (potentially from another template entirely), it will reuse the PendingIntent from the old notification. Adding `PendingIntent.FLAG_UPDATE_CURRENT` should make it update the PendingIntent if `requestCode`s collide.