### PR TITLE
[MOB - 3754] - Handling Trampoline Restriction

### DIFF
--- a/iterableapi/src/main/AndroidManifest.xml
+++ b/iterableapi/src/main/AndroidManifest.xml
@@ -23,7 +23,7 @@
         </receiver>
 
         <activity
-            android:name=".TrampolineActivity"
+            android:name=".IterableTrampolineActivity"
             android:exported="false"
             android:launchMode="singleInstance"
             android:theme="@style/TrampolineActivity.Transparent"/>

--- a/iterableapi/src/main/AndroidManifest.xml
+++ b/iterableapi/src/main/AndroidManifest.xml
@@ -26,7 +26,7 @@
             android:name=".TrampolineActivity"
             android:exported="false"
             android:launchMode="singleInstance"
-            android:theme="@style/Theme.MaterialComponents.Light.DarkActionBar"/>
+            android:theme="@style/TrampolineActivity.Transparent"/>
     </application>
 
     <queries>

--- a/iterableapi/src/main/AndroidManifest.xml
+++ b/iterableapi/src/main/AndroidManifest.xml
@@ -22,6 +22,11 @@
             </intent-filter>
         </receiver>
 
+        <activity
+            android:name=".TrampolineActivity"
+            android:exported="false"
+            android:launchMode="singleInstance"
+            android:theme="@style/Theme.MaterialComponents.Light.DarkActionBar"/>
     </application>
 
     <queries>

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
@@ -303,7 +303,7 @@ private static final String TAG = "IterableApi";
         }
 
         loadLastSavedConfiguration(context);
-        IterablePushActionReceiver.processPendingAction(context);
+        IterablePushNotificationUtil.processPendingAction(context);
     }
 
     public static void setContext(Context context) {

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableNotificationBuilder.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableNotificationBuilder.java
@@ -112,7 +112,7 @@ public class IterableNotificationBuilder extends NotificationCompat.Builder {
      */
     public void createNotificationActionButton(Context context, IterableNotificationData.Button button, Bundle extras) {
         Intent buttonIntent = new Intent(IterableConstants.ACTION_PUSH_ACTION);
-        buttonIntent.setClass(context, TrampolineActivity.class);
+        buttonIntent.setClass(context, IterableTrampolineActivity.class);
         buttonIntent.putExtras(extras);
         buttonIntent.putExtra(IterableConstants.REQUEST_CODE, requestCode);
         buttonIntent.putExtra(IterableConstants.ITERABLE_DATA_ACTION_IDENTIFIER, button.identifier);

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableNotificationBuilder.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableNotificationBuilder.java
@@ -112,14 +112,14 @@ public class IterableNotificationBuilder extends NotificationCompat.Builder {
      */
     public void createNotificationActionButton(Context context, IterableNotificationData.Button button, Bundle extras) {
         Intent buttonIntent = new Intent(IterableConstants.ACTION_PUSH_ACTION);
-        buttonIntent.setClass(context, IterablePushActionReceiver.class);
+        buttonIntent.setClass(context, TrampolineActivity.class);
         buttonIntent.putExtras(extras);
         buttonIntent.putExtra(IterableConstants.REQUEST_CODE, requestCode);
         buttonIntent.putExtra(IterableConstants.ITERABLE_DATA_ACTION_IDENTIFIER, button.identifier);
         buttonIntent.putExtra(IterableConstants.ACTION_IDENTIFIER, button.identifier);
 
-        PendingIntent pendingButtonIntent = PendingIntent.getBroadcast(context, buttonIntent.hashCode(),
-                buttonIntent, PendingIntent.FLAG_UPDATE_CURRENT);
+        PendingIntent pendingButtonIntent = PendingIntent.getActivity(context, buttonIntent.hashCode(),
+                buttonIntent, PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
 
         NotificationCompat.Action.Builder actionBuilder = new NotificationCompat.Action
                 .Builder(NotificationCompat.BADGE_ICON_NONE, button.title, pendingButtonIntent);

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableNotificationHelper.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableNotificationHelper.java
@@ -178,7 +178,8 @@ class IterableNotificationHelper {
             }
 
             //Create an intent for TrampolineActivity instead of BroadcastReceiver
-            Intent trampolineActivityIntent = new Intent(context, IterableTrampolineActivity.class);
+            Intent trampolineActivityIntent = new Intent(IterableConstants.ACTION_PUSH_ACTION);
+            trampolineActivityIntent.setClass(context, IterableTrampolineActivity.class);
             trampolineActivityIntent.putExtras(extras);
             trampolineActivityIntent.putExtra(IterableConstants.ITERABLE_DATA_ACTION_IDENTIFIER, IterableConstants.ITERABLE_ACTION_DEFAULT);
             trampolineActivityIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableNotificationHelper.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableNotificationHelper.java
@@ -177,10 +177,11 @@ class IterableNotificationHelper {
                 IterableLogger.d(IterableNotificationBuilder.TAG, "Request code = " + notificationBuilder.requestCode);
             }
 
-            Intent pushContentIntent = new Intent(IterableConstants.ACTION_PUSH_ACTION);
-            pushContentIntent.setClass(context, IterablePushActionReceiver.class);
-            pushContentIntent.putExtras(extras);
-            pushContentIntent.putExtra(IterableConstants.ITERABLE_DATA_ACTION_IDENTIFIER, IterableConstants.ITERABLE_ACTION_DEFAULT);
+            //Create an intent for TrampolineActivity instead of BroadcastReceiver
+            Intent trampolineActivityIntent = new Intent(context, TrampolineActivity.class);
+            trampolineActivityIntent.putExtras(extras);
+            trampolineActivityIntent.putExtra(IterableConstants.ITERABLE_DATA_ACTION_IDENTIFIER, IterableConstants.ITERABLE_ACTION_DEFAULT);
+            trampolineActivityIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
 
             // Action buttons
             if (notificationData.getActionButtons() != null) {
@@ -192,8 +193,8 @@ class IterableNotificationHelper {
                 }
             }
 
-            PendingIntent notificationClickedIntent = PendingIntent.getBroadcast(context, notificationBuilder.requestCode,
-                    pushContentIntent, PendingIntent.FLAG_UPDATE_CURRENT);
+            PendingIntent notificationClickedIntent = PendingIntent.getActivity(context, notificationBuilder.requestCode,
+                    trampolineActivityIntent, PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
 
             notificationBuilder.setContentIntent(notificationClickedIntent);
             notificationBuilder.setIsGhostPush(isGhostPush(extras));

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableNotificationHelper.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableNotificationHelper.java
@@ -178,7 +178,7 @@ class IterableNotificationHelper {
             }
 
             //Create an intent for TrampolineActivity instead of BroadcastReceiver
-            Intent trampolineActivityIntent = new Intent(context, TrampolineActivity.class);
+            Intent trampolineActivityIntent = new Intent(context, IterableTrampolineActivity.class);
             trampolineActivityIntent.putExtras(extras);
             trampolineActivityIntent.putExtra(IterableConstants.ITERABLE_DATA_ACTION_IDENTIFIER, IterableConstants.ITERABLE_ACTION_DEFAULT);
             trampolineActivityIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterablePushActionReceiver.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterablePushActionReceiver.java
@@ -13,6 +13,11 @@ public class IterablePushActionReceiver extends BroadcastReceiver {
 
     @Override
     public void onReceive(Context context, Intent intent) {
-
+        IterablePushNotificationUtil.dismissNotification(context, intent);
+        IterablePushNotificationUtil.dismissNotificationPanel(context);
+        String actionName = intent.getAction();
+        if (IterableConstants.ACTION_PUSH_ACTION.equalsIgnoreCase(actionName)) {
+            IterablePushNotificationUtil.handlePushAction(context, intent);
+        }
     }
 }

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterablePushActionReceiver.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterablePushActionReceiver.java
@@ -1,15 +1,8 @@
 package com.iterable.iterableapi;
 
-import android.app.NotificationManager;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
-import android.os.Bundle;
-
-import androidx.core.app.RemoteInput;
-
-import org.json.JSONException;
-import org.json.JSONObject;
 
 /**
  * Handles incoming push actions built by {@link IterableNotificationBuilder}
@@ -17,137 +10,9 @@ import org.json.JSONObject;
  */
 public class IterablePushActionReceiver extends BroadcastReceiver {
     private static final String TAG = "IterablePushActionReceiver";
-    // Used to hold intents until the SDK is initialized
-    private static PendingAction pendingAction = null;
 
     @Override
     public void onReceive(Context context, Intent intent) {
-        // Dismiss the notification
-        int requestCode = intent.getIntExtra(IterableConstants.REQUEST_CODE, 0);
-        NotificationManager mNotificationManager = (NotificationManager)
-                context.getSystemService(Context.NOTIFICATION_SERVICE);
-        mNotificationManager.cancel(requestCode);
 
-        // Dismiss the notifications panel
-        try {
-            context.sendBroadcast(new Intent(Intent.ACTION_CLOSE_SYSTEM_DIALOGS));
-        } catch (SecurityException e) {
-            IterableLogger.w(TAG, e.getLocalizedMessage());
-        }
-
-        String actionName = intent.getAction();
-        if (IterableConstants.ACTION_PUSH_ACTION.equalsIgnoreCase(actionName)) {
-            handlePushAction(context, intent);
-        }
     }
-
-    static boolean processPendingAction(Context context) {
-        boolean handled = false;
-        if (pendingAction != null) {
-            handled = executeAction(context, pendingAction);
-            pendingAction = null;
-        }
-        return handled;
-    }
-
-    private static void handlePushAction(Context context, Intent intent) {
-        if (intent.getExtras() == null) {
-            IterableLogger.e(TAG, "handlePushAction: extras == null, can't handle push action");
-            return;
-        }
-        IterableNotificationData notificationData = new IterableNotificationData(intent.getExtras());
-        String actionIdentifier = intent.getStringExtra(IterableConstants.ITERABLE_DATA_ACTION_IDENTIFIER);
-        IterableAction action = null;
-        JSONObject dataFields = new JSONObject();
-
-        boolean openApp = true;
-
-        if (actionIdentifier != null) {
-            try {
-                if (actionIdentifier.equals(IterableConstants.ITERABLE_ACTION_DEFAULT)) {
-                    // Default action (click on a push)
-                    dataFields.put(IterableConstants.ITERABLE_DATA_ACTION_IDENTIFIER, IterableConstants.ITERABLE_ACTION_DEFAULT);
-                    action = notificationData.getDefaultAction();
-                    if (action == null) {
-                        action = getLegacyDefaultActionFromPayload(intent.getExtras());
-                    }
-                } else {
-                    dataFields.put(IterableConstants.ITERABLE_DATA_ACTION_IDENTIFIER, actionIdentifier);
-                    IterableNotificationData.Button button = notificationData.getActionButton(actionIdentifier);
-                    action = button.action;
-                    openApp = button.openApp;
-
-                    if (button.buttonType.equals(IterableNotificationData.Button.BUTTON_TYPE_TEXT_INPUT)) {
-                        Bundle results = RemoteInput.getResultsFromIntent(intent);
-                        if (results != null) {
-                            String userInput = results.getString(IterableConstants.USER_INPUT);
-                            if (userInput != null) {
-                                dataFields.putOpt(IterableConstants.KEY_USER_TEXT, userInput);
-                                action.userInput = userInput;
-                            }
-                        }
-                    }
-                }
-            } catch (JSONException e) {
-                IterableLogger.e(TAG, "Encountered an exception while trying to handle the push action", e);
-            }
-        }
-
-        pendingAction = new PendingAction(intent, notificationData, action, openApp, dataFields);
-
-        boolean handled = false;
-        if (IterableApi.getInstance().getMainActivityContext() != null) {
-            handled = processPendingAction(context);
-        }
-
-        // Open the launcher activity if the action was not handled by anything, and openApp is true
-        if (openApp && !handled) {
-            Intent launcherIntent = IterableNotificationHelper.getMainActivityIntent(context);
-            launcherIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP);
-            if (launcherIntent.resolveActivity(context.getPackageManager()) != null) {
-                context.startActivity(launcherIntent);
-            }
-        }
-    }
-
-    private static boolean executeAction(Context context, PendingAction action) {
-        // Automatic tracking
-        IterableApi.sharedInstance.setPayloadData(action.intent);
-        IterableApi.sharedInstance.setNotificationData(action.notificationData);
-        IterableApi.sharedInstance.trackPushOpen(action.notificationData.getCampaignId(), action.notificationData.getTemplateId(),
-                action.notificationData.getMessageId(), action.dataFields);
-
-        return IterableActionRunner.executeAction(context, action.iterableAction, IterableActionSource.PUSH);
-    }
-
-    private static IterableAction getLegacyDefaultActionFromPayload(Bundle extras) {
-        try {
-            if (extras.containsKey(IterableConstants.ITERABLE_DATA_DEEP_LINK_URL)) {
-                JSONObject actionJson = new JSONObject();
-                actionJson.put("type", IterableAction.ACTION_TYPE_OPEN_URL);
-                actionJson.put("data", extras.getString(IterableConstants.ITERABLE_DATA_DEEP_LINK_URL));
-                return IterableAction.from(actionJson);
-            }
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-        return null;
-    }
-
-    private static class PendingAction {
-        Intent intent;
-        IterableNotificationData notificationData;
-        IterableAction iterableAction;
-        boolean openApp;
-        JSONObject dataFields;
-
-        PendingAction(Intent intent, IterableNotificationData notificationData, IterableAction iterableAction, boolean openApp, JSONObject dataFields) {
-            this.intent = intent;
-            this.notificationData = notificationData;
-            this.iterableAction = iterableAction;
-            this.openApp = openApp;
-            this.dataFields = dataFields;
-        }
-    }
-
 }

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterablePushNotificationUtil.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterablePushNotificationUtil.java
@@ -1,5 +1,6 @@
 package com.iterable.iterableapi;
 
+import android.app.NotificationManager;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
@@ -9,7 +10,7 @@ import androidx.core.app.RemoteInput;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-public class IterablePushNotificationUtil {
+class IterablePushNotificationUtil {
     private static PendingAction pendingAction = null;
     private static final String TAG = "IterablePushNotificationUtil";
 
@@ -120,5 +121,22 @@ public class IterablePushNotificationUtil {
             this.openApp = openApp;
             this.dataFields = dataFields;
         }
+    }
+
+    static void dismissNotificationPanel(Context context) {
+        // Dismiss the notifications panel
+        try {
+            context.sendBroadcast(new Intent(Intent.ACTION_CLOSE_SYSTEM_DIALOGS));
+        } catch (SecurityException e) {
+            IterableLogger.w(TAG, e.getLocalizedMessage());
+        }
+    }
+
+    static void dismissNotification(Context context, Intent notificationIntent) {
+        // Dismiss the notification
+        int requestCode = notificationIntent.getIntExtra(IterableConstants.REQUEST_CODE, 0);
+        NotificationManager mNotificationManager = (NotificationManager)
+                context.getSystemService(Context.NOTIFICATION_SERVICE);
+        mNotificationManager.cancel(requestCode);
     }
 }

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterablePushNotificationUtil.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterablePushNotificationUtil.java
@@ -1,0 +1,124 @@
+package com.iterable.iterableapi;
+
+import android.content.Context;
+import android.content.Intent;
+import android.os.Bundle;
+
+import androidx.core.app.RemoteInput;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+public class IterablePushNotificationUtil {
+    private static PendingAction pendingAction = null;
+    private static final String TAG = "IterablePushNotificationUtil";
+
+    static boolean processPendingAction(Context context) {
+        boolean handled = false;
+        if (pendingAction != null) {
+            handled = executeAction(context, pendingAction);
+            pendingAction = null;
+        }
+        return handled;
+    }
+
+    static boolean executeAction(Context context, PendingAction action) {
+        // Automatic tracking
+        IterableApi.sharedInstance.setPayloadData(action.intent);
+        IterableApi.sharedInstance.setNotificationData(action.notificationData);
+        IterableApi.sharedInstance.trackPushOpen(action.notificationData.getCampaignId(), action.notificationData.getTemplateId(),
+                action.notificationData.getMessageId(), action.dataFields);
+
+        return IterableActionRunner.executeAction(context, action.iterableAction, IterableActionSource.PUSH);
+    }
+
+
+    static void handlePushAction(Context context, Intent intent) {
+        if (intent.getExtras() == null) {
+            IterableLogger.e(TAG, "handlePushAction: extras == null, can't handle push action");
+            return;
+        }
+        IterableNotificationData notificationData = new IterableNotificationData(intent.getExtras());
+        String actionIdentifier = intent.getStringExtra(IterableConstants.ITERABLE_DATA_ACTION_IDENTIFIER);
+        IterableAction action = null;
+        JSONObject dataFields = new JSONObject();
+
+        boolean openApp = true;
+
+        if (actionIdentifier != null) {
+            try {
+                if (actionIdentifier.equals(IterableConstants.ITERABLE_ACTION_DEFAULT)) {
+                    // Default action (click on a push)
+                    dataFields.put(IterableConstants.ITERABLE_DATA_ACTION_IDENTIFIER, IterableConstants.ITERABLE_ACTION_DEFAULT);
+                    action = notificationData.getDefaultAction();
+                    if (action == null) {
+                        action = getLegacyDefaultActionFromPayload(intent.getExtras());
+                    }
+                } else {
+                    dataFields.put(IterableConstants.ITERABLE_DATA_ACTION_IDENTIFIER, actionIdentifier);
+                    IterableNotificationData.Button button = notificationData.getActionButton(actionIdentifier);
+                    action = button.action;
+                    openApp = button.openApp;
+
+                    if (button.buttonType.equals(IterableNotificationData.Button.BUTTON_TYPE_TEXT_INPUT)) {
+                        Bundle results = RemoteInput.getResultsFromIntent(intent);
+                        if (results != null) {
+                            String userInput = results.getString(IterableConstants.USER_INPUT);
+                            if (userInput != null) {
+                                dataFields.putOpt(IterableConstants.KEY_USER_TEXT, userInput);
+                                action.userInput = userInput;
+                            }
+                        }
+                    }
+                }
+            } catch (JSONException e) {
+                IterableLogger.e(TAG, "Encountered an exception while trying to handle the push action", e);
+            }
+        }
+        pendingAction = new PendingAction(intent, notificationData, action, openApp, dataFields);
+
+        boolean handled = false;
+        if (IterableApi.getInstance().getMainActivityContext() != null) {
+            handled = processPendingAction(context);
+        }
+
+        // Open the launcher activity if the action was not handled by anything, and openApp is true
+        if (openApp && !handled) {
+            Intent launcherIntent = IterableNotificationHelper.getMainActivityIntent(context);
+            launcherIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP);
+            if (launcherIntent.resolveActivity(context.getPackageManager()) != null) {
+                context.startActivity(launcherIntent);
+            }
+        }
+    }
+
+    private static IterableAction getLegacyDefaultActionFromPayload(Bundle extras) {
+        try {
+            if (extras.containsKey(IterableConstants.ITERABLE_DATA_DEEP_LINK_URL)) {
+                JSONObject actionJson = new JSONObject();
+                actionJson.put("type", IterableAction.ACTION_TYPE_OPEN_URL);
+                actionJson.put("data", extras.getString(IterableConstants.ITERABLE_DATA_DEEP_LINK_URL));
+                return IterableAction.from(actionJson);
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
+
+    private static class PendingAction {
+        Intent intent;
+        IterableNotificationData notificationData;
+        IterableAction iterableAction;
+        boolean openApp;
+        JSONObject dataFields;
+
+        PendingAction(Intent intent, IterableNotificationData notificationData, IterableAction iterableAction, boolean openApp, JSONObject dataFields) {
+            this.intent = intent;
+            this.notificationData = notificationData;
+            this.iterableAction = iterableAction;
+            this.openApp = openApp;
+            this.dataFields = dataFields;
+        }
+    }
+}

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableTrampolineActivity.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableTrampolineActivity.java
@@ -1,11 +1,7 @@
 package com.iterable.iterableapi;
 
-import static com.iterable.iterableapi.IterablePushNotificationUtil.handlePushAction;
-
 import androidx.appcompat.app.AppCompatActivity;
 
-import android.app.NotificationManager;
-import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
 
@@ -38,23 +34,11 @@ public class IterableTrampolineActivity extends AppCompatActivity {
             return;
         }
 
-        // Dismiss the notification
-        int requestCode = notificationIntent.getIntExtra(IterableConstants.REQUEST_CODE, 0);
-        NotificationManager mNotificationManager = (NotificationManager)
-                this.getSystemService(Context.NOTIFICATION_SERVICE);
-        mNotificationManager.cancel(requestCode);
-
-        // Dismiss the notifications panel
-        try {
-            this.sendBroadcast(new Intent(Intent.ACTION_CLOSE_SYSTEM_DIALOGS));
-        } catch (SecurityException e) {
-            IterableLogger.w(TAG, e.getLocalizedMessage());
-        }
-
+        IterablePushNotificationUtil.dismissNotification(this, notificationIntent);
+        IterablePushNotificationUtil.dismissNotificationPanel(this);
         if (IterableConstants.ACTION_PUSH_ACTION.equalsIgnoreCase(actionName)) {
-            handlePushAction(this, notificationIntent);
+            IterablePushNotificationUtil.handlePushAction(this, notificationIntent);
         }
-
         finish();
     }
 

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableTrampolineActivity.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableTrampolineActivity.java
@@ -4,9 +4,8 @@ import androidx.appcompat.app.AppCompatActivity;
 
 import android.content.Intent;
 import android.os.Bundle;
-import android.util.Log;
 
-public class TrampolineActivity extends AppCompatActivity {
+public class IterableTrampolineActivity extends AppCompatActivity {
 
     private static final String TAG = "TrampolineActivity";
 
@@ -32,6 +31,8 @@ public class TrampolineActivity extends AppCompatActivity {
             finish();
             return;
         }
+
+
         Intent pushContentIntent = new Intent(IterableConstants.ACTION_PUSH_ACTION);
         pushContentIntent.setClass(this, IterablePushActionReceiver.class);
         pushContentIntent.putExtras(notificationIntent.getExtras());
@@ -41,7 +42,8 @@ public class TrampolineActivity extends AppCompatActivity {
 
     @Override
     protected void onPause() {
-        super.onPause();  IterableLogger.v(TAG, "Notification Trampoline Activity on pause");
+        super.onPause();
+        IterableLogger.v(TAG, "Notification Trampoline Activity on pause");
 
     }
 

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableTrampolineActivity.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableTrampolineActivity.java
@@ -30,13 +30,13 @@ public class IterableTrampolineActivity extends AppCompatActivity {
             finish();
             return;
         }
+
         String actionName = notificationIntent.getAction();
         if (actionName == null) {
-            IterableLogger.d(TAG, "Intent actino is null. Doing nothing.");
+            IterableLogger.d(TAG, "Intent action is null. Doing nothing.");
             finish();
             return;
         }
-
 
         // Dismiss the notification
         int requestCode = notificationIntent.getIntExtra(IterableConstants.REQUEST_CODE, 0);

--- a/iterableapi/src/main/java/com/iterable/iterableapi/TrampolineActivity.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/TrampolineActivity.java
@@ -1,0 +1,53 @@
+package com.iterable.iterableapi;
+
+import androidx.appcompat.app.AppCompatActivity;
+
+import android.content.Intent;
+import android.os.Bundle;
+import android.util.Log;
+
+public class TrampolineActivity extends AppCompatActivity {
+
+    private static final String TAG = "TrampolineActivity";
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        IterableLogger.v(TAG, "Notification Trampoline Activity created");
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        IterableLogger.v(TAG, "Notification Trampoline Activity resumed");
+
+        Intent notificationIntent = getIntent();
+        if (notificationIntent == null) {
+            finish();
+            return;
+        }
+        String action = notificationIntent.getAction();
+        if (action == null) {
+            IterableLogger.d(TAG, "Notification trampoline activity received intent with null action. Doing nothing.");
+            finish();
+            return;
+        }
+        Intent pushContentIntent = new Intent(IterableConstants.ACTION_PUSH_ACTION);
+        pushContentIntent.setClass(this, IterablePushActionReceiver.class);
+        pushContentIntent.putExtras(notificationIntent.getExtras());
+        this.sendBroadcast(pushContentIntent);
+        finish();
+    }
+
+    @Override
+    protected void onPause() {
+        super.onPause();  IterableLogger.v(TAG, "Notification Trampoline Activity on pause");
+
+    }
+
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+        IterableLogger.v(TAG, "Notification Trampoline Activity destroyed");
+    }
+}

--- a/iterableapi/src/main/res/values/styles.xml
+++ b/iterableapi/src/main/res/values/styles.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <style name="TrampolineActivity.Transparent" parent="Theme.AppCompat.Light.NoActionBar">
+        <item name="android:windowIsTranslucent">true</item>
+        <item name="android:windowBackground">@android:color/transparent</item>
+        <item name="android:windowContentOverlay">@null</item>
+        <item name="android:windowNoTitle">true</item>
+        <item name="android:windowIsFloating">true</item>
+        <item name="android:backgroundDimEnabled">false</item>
+    </style>
+</resources>


### PR DESCRIPTION
## 🔹 Jira Ticket(s) if any

[[MOB-3754]](https://iterable.atlassian.net/browse/MOB-3754)

## ✏️ Description

1. Introduced new Activity - `IterableTrampolineActivity` with transparent style which now replaces `IterablePushActionReceiver` as a starting point when user taps notification replacing.
2. Notification Builder creates PendingIntent from `getActivity` instead of `getBroadcast` to accommodate to above change. [Except for custom action with openApp false]
3. Data from notification is thus, now routed through `IterableTrampolineActivity `
4. ~~`IterableTrampolineActivity ` passes the data as is to `IterablePushActionReceiver` and dismisses itself`~~
5. `IterablePushActionReceiver` is still applicable for those actions which invoke custom actions with openApp flag unchecked. `IterableTrampolineActivity` will not be invoked in this flow.
6. `IterablePushNotificationUtil` class now performs handling the operations post tap of push notification/ push notification buttons. Both `IterableTrampolineActivity ` and `IterablePushActionReceiver` use this class to accomplish common functionality.


[MOB-3754]: https://iterable.atlassian.net/browse/MOB-3754?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ