### PR TITLE
Mob 3850 patch for allowed protocols

### DIFF
--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableActionRunner.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableActionRunner.java
@@ -11,7 +11,6 @@ import androidx.annotation.VisibleForTesting;
 
 import android.util.Log;
 
-import java.util.Arrays;
 import java.util.List;
 
 class IterableActionRunner {
@@ -68,7 +67,7 @@ class IterableActionRunner {
          */
         private boolean openUri(@NonNull Context context, @NonNull Uri uri, @NonNull IterableActionContext actionContext, String[] allowedProtocols) {
             // Handle URL: check for deep links within the app
-            if (!isUrlOpenAllowed(uri.toString(), allowedProtocols)) {
+            if (!IterableUtil.isUrlOpenAllowed(uri.toString(), allowedProtocols)) {
                 IterableLogger.e(TAG, "URL was not in the allowed protocols list");
                 return false;
             }
@@ -118,20 +117,6 @@ class IterableActionRunner {
                     return IterableApi.sharedInstance.config.customActionHandler.handleIterableCustomAction(action, actionContext);
                 }
             }
-            return false;
-        }
-
-        private static boolean isUrlOpenAllowed(@NonNull String url, @NonNull String[] allowedProtocols) {
-            if (url.startsWith("https")) {
-                return true;
-            }
-
-            for (String protocol : allowedProtocols) {
-                if (url.startsWith(protocol)) {
-                    return true;
-                }
-            }
-
             return false;
         }
     }

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableActionRunner.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableActionRunner.java
@@ -18,19 +18,11 @@ class IterableActionRunner {
     static IterableActionRunnerImpl instance = new IterableActionRunnerImpl();
 
     static boolean executeAction(@NonNull Context context, @Nullable IterableAction action, @NonNull IterableActionSource source) {
-        return instance.executeAction(context, action, source, IterableApi.getInstance().config.allowedProtocols);
-    }
-
-    static boolean executeAction(@NonNull Context context, @Nullable IterableAction action, @NonNull IterableActionSource source, @NonNull String[] allowedProtocols) {
-        return instance.executeAction(context, action, source, allowedProtocols);
+        return instance.executeAction(context, action, source);
     }
 
     static class IterableActionRunnerImpl {
         private static final String TAG = "IterableActionRunner";
-
-        boolean executeAction(@NonNull Context context, @Nullable IterableAction action, @NonNull IterableActionSource source) {
-            return executeAction(context, action, source, IterableApi.getInstance().config.allowedProtocols);
-        }
 
         /**
          * Execute an {@link IterableAction} as a response to push action
@@ -40,7 +32,7 @@ class IterableActionRunner {
          * @param allowedProtocols protocols that the SDK is allowed to open in addition to `https`
          * @return `true` if the action was handled, `false` if it was not
          */
-        boolean executeAction(@NonNull Context context, @Nullable IterableAction action, @NonNull IterableActionSource source, @NonNull String[] allowedProtocols) {
+        boolean executeAction(@NonNull Context context, @Nullable IterableAction action, @NonNull IterableActionSource source) {
             if (action == null) {
                 return false;
             }
@@ -48,7 +40,7 @@ class IterableActionRunner {
             IterableActionContext actionContext = new IterableActionContext(action, source);
 
             if (action.isOfType(IterableAction.ACTION_TYPE_OPEN_URL)) {
-                return openUri(context, Uri.parse(action.getData()), actionContext, allowedProtocols);
+                return openUri(context, Uri.parse(action.getData()), actionContext);
             } else {
                 return callCustomActionIfSpecified(action, actionContext);
             }
@@ -65,10 +57,9 @@ class IterableActionRunner {
          * @return `true` if the action was handled, or an activity was found for this URL
          * `false` if the handler did not handle this URL and no activity was found to open it with
          */
-        private boolean openUri(@NonNull Context context, @NonNull Uri uri, @NonNull IterableActionContext actionContext, String[] allowedProtocols) {
+        private boolean openUri(@NonNull Context context, @NonNull Uri uri, @NonNull IterableActionContext actionContext) {
             // Handle URL: check for deep links within the app
-            if (!IterableUtil.isUrlOpenAllowed(uri.toString(), allowedProtocols)) {
-                IterableLogger.e(TAG, "URL was not in the allowed protocols list");
+            if (!IterableUtil.isUrlOpenAllowed(uri.toString())) {
                 return false;
             }
 

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableActionRunner.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableActionRunner.java
@@ -11,6 +11,7 @@ import androidx.annotation.VisibleForTesting;
 
 import android.util.Log;
 
+import java.util.Arrays;
 import java.util.List;
 
 class IterableActionRunner {
@@ -18,7 +19,7 @@ class IterableActionRunner {
     static IterableActionRunnerImpl instance = new IterableActionRunnerImpl();
 
     static boolean executeAction(@NonNull Context context, @Nullable IterableAction action, @NonNull IterableActionSource source) {
-        return instance.executeAction(context, action, source, new String[0]);
+        return instance.executeAction(context, action, source, IterableApi.getInstance().config.allowedProtocols);
     }
 
     static boolean executeAction(@NonNull Context context, @Nullable IterableAction action, @NonNull IterableActionSource source, @NonNull String[] allowedProtocols) {
@@ -29,7 +30,7 @@ class IterableActionRunner {
         private static final String TAG = "IterableActionRunner";
 
         boolean executeAction(@NonNull Context context, @Nullable IterableAction action, @NonNull IterableActionSource source) {
-            return executeAction(context, action, source, new String[0]);
+            return executeAction(context, action, source, IterableApi.getInstance().config.allowedProtocols);
         }
 
         /**
@@ -66,16 +67,16 @@ class IterableActionRunner {
          * `false` if the handler did not handle this URL and no activity was found to open it with
          */
         private boolean openUri(@NonNull Context context, @NonNull Uri uri, @NonNull IterableActionContext actionContext, String[] allowedProtocols) {
-            if (IterableApi.sharedInstance.config.urlHandler != null) {
-                if (IterableApi.sharedInstance.config.urlHandler.handleIterableURL(uri, actionContext)) {
-                    return true;
-                }
-            }
-
             // Handle URL: check for deep links within the app
             if (!isUrlOpenAllowed(uri.toString(), allowedProtocols)) {
                 IterableLogger.e(TAG, "URL was not in the allowed protocols list");
                 return false;
+            }
+
+            if (IterableApi.sharedInstance.config.urlHandler != null) {
+                if (IterableApi.sharedInstance.config.urlHandler.handleIterableURL(uri, actionContext)) {
+                    return true;
+                }
             }
 
             Intent intent = new Intent(Intent.ACTION_VIEW);

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
@@ -427,7 +427,7 @@ private static final String TAG = "IterableApi";
                     IterableAction action = IterableAction.actionOpenUrl(originalUrl);
                     IterableActionRunner.executeAction(getInstance().getMainActivityContext(), action, IterableActionSource.APP_LINK);
                 }
-            }, config.allowedProtocols);
+            }, sharedInstance.config.allowedProtocols);
             return true;
         } else {
             IterableAction action = IterableAction.actionOpenUrl(uri);

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
@@ -299,7 +299,7 @@ private static final String TAG = "IterableApi";
 
         if (sharedInstance.inAppManager == null) {
             sharedInstance.inAppManager = new IterableInAppManager(sharedInstance, sharedInstance.config.inAppHandler,
-                    sharedInstance.config.inAppDisplayInterval, sharedInstance.config.allowedProtocols);
+                    sharedInstance.config.inAppDisplayInterval);
         }
 
         loadLastSavedConfiguration(context);

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
@@ -402,7 +402,7 @@ private static final String TAG = "IterableApi";
      *                   or the original url if it is not an Iterable link.
      */
     public void getAndTrackDeepLink(@NonNull String uri, @NonNull IterableHelper.IterableActionHandler onCallback) {
-        IterableDeeplinkManager.getAndTrackDeeplink(uri, onCallback, config.allowedProtocols);
+        IterableDeeplinkManager.getAndTrackDeeplink(uri, onCallback);
     }
 
     /**
@@ -427,7 +427,7 @@ private static final String TAG = "IterableApi";
                     IterableAction action = IterableAction.actionOpenUrl(originalUrl);
                     IterableActionRunner.executeAction(getInstance().getMainActivityContext(), action, IterableActionSource.APP_LINK);
                 }
-            }, sharedInstance.config.allowedProtocols);
+            });
             return true;
         } else {
             IterableAction action = IterableAction.actionOpenUrl(uri);

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableDeeplinkManager.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableDeeplinkManager.java
@@ -33,7 +33,7 @@ class IterableDeeplinkManager {
      */
     static void getAndTrackDeeplink(@Nullable String url, @NonNull IterableHelper.IterableActionHandler callback, @NonNull String[] allowedProtocols) {
         if (url != null) {
-            if (!isUrlOpenAllowed(url, allowedProtocols)) {
+            if (!IterableUtil.isUrlOpenAllowed(url, allowedProtocols)) {
                 IterableLogger.e(TAG, "URL was not in the allowed protocols list");
                 return;
             }
@@ -60,20 +60,6 @@ class IterableDeeplinkManager {
                 return true;
             }
         }
-        return false;
-    }
-
-    private static boolean isUrlOpenAllowed(@NonNull String url, @NonNull String[] allowedProtocols) {
-        if (url.startsWith("https")) {
-            return true;
-        }
-
-        for (String protocol : allowedProtocols) {
-            if (url.startsWith(protocol)) {
-                return true;
-            }
-        }
-
         return false;
     }
 

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableDeeplinkManager.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableDeeplinkManager.java
@@ -22,19 +22,8 @@ class IterableDeeplinkManager {
      * @param callback The callback to execute the original URL is retrieved
      */
     static void getAndTrackDeeplink(@Nullable String url, @NonNull IterableHelper.IterableActionHandler callback) {
-        IterableDeeplinkManager.getAndTrackDeeplink(url, callback, new String[0]);
-    }
-
-    /**
-     * Tracks a link click and passes the redirected URL to the callback
-     * @param url The URL that was clicked
-     * @param callback The callback to execute the original URL is retrieved
-     * @param allowedProtocols a list of protocols (on top of `https`) to allow opening
-     */
-    static void getAndTrackDeeplink(@Nullable String url, @NonNull IterableHelper.IterableActionHandler callback, @NonNull String[] allowedProtocols) {
         if (url != null) {
-            if (!IterableUtil.isUrlOpenAllowed(url, allowedProtocols)) {
-                IterableLogger.e(TAG, "URL was not in the allowed protocols list");
+            if (!IterableUtil.isUrlOpenAllowed(url)) {
                 return;
             }
 

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableInAppManager.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableInAppManager.java
@@ -43,7 +43,6 @@ public class IterableInAppManager implements IterableActivityMonitor.AppStateCal
     private final IterableInAppStorage storage;
     private final IterableInAppHandler handler;
     private final IterableInAppDisplayer displayer;
-    private final String[] allowedProtocols;
     private final IterableActivityMonitor activityMonitor;
     private final double inAppDisplayInterval;
     private final List<Listener> listeners = new ArrayList<>();
@@ -51,14 +50,13 @@ public class IterableInAppManager implements IterableActivityMonitor.AppStateCal
     private long lastInAppShown = 0;
     private boolean autoDisplayPaused = false;
 
-    IterableInAppManager(IterableApi iterableApi, IterableInAppHandler handler, double inAppDisplayInterval, String[] allowedProtocols) {
+    IterableInAppManager(IterableApi iterableApi, IterableInAppHandler handler, double inAppDisplayInterval) {
         this(iterableApi,
                 handler,
                 inAppDisplayInterval,
                 new IterableInAppFileStorage(iterableApi.getMainActivityContext()),
                 IterableActivityMonitor.getInstance(),
-                new IterableInAppDisplayer(IterableActivityMonitor.getInstance()),
-                allowedProtocols);
+                new IterableInAppDisplayer(IterableActivityMonitor.getInstance()));
     }
 
     @VisibleForTesting
@@ -67,8 +65,7 @@ public class IterableInAppManager implements IterableActivityMonitor.AppStateCal
                          double inAppDisplayInterval,
                          IterableInAppStorage storage,
                          IterableActivityMonitor activityMonitor,
-                         IterableInAppDisplayer displayer,
-                         String[] allowedProtocols) {
+                         IterableInAppDisplayer displayer) {
         this.api = iterableApi;
         this.context = iterableApi.getMainActivityContext();
         this.handler = handler;
@@ -77,7 +74,6 @@ public class IterableInAppManager implements IterableActivityMonitor.AppStateCal
         this.displayer = displayer;
         this.activityMonitor = activityMonitor;
         this.activityMonitor.addCallback(this);
-        this.allowedProtocols = allowedProtocols;
 
         syncInApp();
     }
@@ -275,17 +271,17 @@ public class IterableInAppManager implements IterableActivityMonitor.AppStateCal
             if (urlString.startsWith(IterableConstants.URL_SCHEME_ACTION)) {
                 // This is an action:// URL, pass that to the custom action handler
                 String actionName = urlString.replace(IterableConstants.URL_SCHEME_ACTION, "");
-                IterableActionRunner.executeAction(context, IterableAction.actionCustomAction(actionName), IterableActionSource.IN_APP, allowedProtocols);
+                IterableActionRunner.executeAction(context, IterableAction.actionCustomAction(actionName), IterableActionSource.IN_APP, IterableApi.getInstance().config.allowedProtocols);
             } else if (urlString.startsWith(IterableConstants.URL_SCHEME_ITBL)) {
                 // Handle itbl:// URLs, pass that to the custom action handler for compatibility
                 String actionName = urlString.replace(IterableConstants.URL_SCHEME_ITBL, "");
-                IterableActionRunner.executeAction(context, IterableAction.actionCustomAction(actionName), IterableActionSource.IN_APP, allowedProtocols);
+                IterableActionRunner.executeAction(context, IterableAction.actionCustomAction(actionName), IterableActionSource.IN_APP, IterableApi.getInstance().config.allowedProtocols);
             } else if (urlString.startsWith(IterableConstants.URL_SCHEME_ITERABLE)) {
                 // Handle iterable:// URLs - reserved for actions defined by the SDK only
                 String actionName = urlString.replace(IterableConstants.URL_SCHEME_ITERABLE, "");
                 handleIterableCustomAction(actionName, message);
             } else {
-                IterableActionRunner.executeAction(context, IterableAction.actionOpenUrl(urlString), IterableActionSource.IN_APP, allowedProtocols);
+                IterableActionRunner.executeAction(context, IterableAction.actionOpenUrl(urlString), IterableActionSource.IN_APP, IterableApi.getInstance().config.allowedProtocols);
             }
         }
     }

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableInAppManager.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableInAppManager.java
@@ -271,17 +271,17 @@ public class IterableInAppManager implements IterableActivityMonitor.AppStateCal
             if (urlString.startsWith(IterableConstants.URL_SCHEME_ACTION)) {
                 // This is an action:// URL, pass that to the custom action handler
                 String actionName = urlString.replace(IterableConstants.URL_SCHEME_ACTION, "");
-                IterableActionRunner.executeAction(context, IterableAction.actionCustomAction(actionName), IterableActionSource.IN_APP, IterableApi.getInstance().config.allowedProtocols);
+                IterableActionRunner.executeAction(context, IterableAction.actionCustomAction(actionName), IterableActionSource.IN_APP);
             } else if (urlString.startsWith(IterableConstants.URL_SCHEME_ITBL)) {
                 // Handle itbl:// URLs, pass that to the custom action handler for compatibility
                 String actionName = urlString.replace(IterableConstants.URL_SCHEME_ITBL, "");
-                IterableActionRunner.executeAction(context, IterableAction.actionCustomAction(actionName), IterableActionSource.IN_APP, IterableApi.getInstance().config.allowedProtocols);
+                IterableActionRunner.executeAction(context, IterableAction.actionCustomAction(actionName), IterableActionSource.IN_APP);
             } else if (urlString.startsWith(IterableConstants.URL_SCHEME_ITERABLE)) {
                 // Handle iterable:// URLs - reserved for actions defined by the SDK only
                 String actionName = urlString.replace(IterableConstants.URL_SCHEME_ITERABLE, "");
                 handleIterableCustomAction(actionName, message);
             } else {
-                IterableActionRunner.executeAction(context, IterableAction.actionOpenUrl(urlString), IterableActionSource.IN_APP, IterableApi.getInstance().config.allowedProtocols);
+                IterableActionRunner.executeAction(context, IterableAction.actionOpenUrl(urlString), IterableActionSource.IN_APP);
             }
         }
     }

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableUtil.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableUtil.java
@@ -279,17 +279,19 @@ class IterableUtil {
         }
     }
 
-    static boolean isUrlOpenAllowed(@NonNull String url, @NonNull String[] allowedProtocols) {
+    static boolean isUrlOpenAllowed(@NonNull String url) {
         String urlProtocol = url.split("://")[0];
-        if(urlProtocol.equals("https")){
+        if (urlProtocol.equals("https")) {
             return true;
         }
-        for (String allowedProtocol : allowedProtocols) {
+
+        for (String allowedProtocol : IterableApi.getInstance().config.allowedProtocols) {
             if (urlProtocol.equals(allowedProtocol)) {
                 return true;
             }
         }
 
+        IterableLogger.d(TAG, urlProtocol + " is not in the allowed protocols");
         return false;
     }
 }

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableUtil.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableUtil.java
@@ -5,6 +5,7 @@ import android.content.SharedPreferences;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 
@@ -276,5 +277,19 @@ class IterableUtil {
             }
             return false;
         }
+    }
+
+    static boolean isUrlOpenAllowed(@NonNull String url, @NonNull String[] allowedProtocols) {
+        if (url.startsWith("https")) {
+            return true;
+        }
+
+        for (String protocol : allowedProtocols) {
+            if (url.startsWith(protocol)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableUtil.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableUtil.java
@@ -280,12 +280,12 @@ class IterableUtil {
     }
 
     static boolean isUrlOpenAllowed(@NonNull String url, @NonNull String[] allowedProtocols) {
-        if (url.startsWith("https")) {
+        String urlProtocol = url.split("://")[0];
+        if(urlProtocol.equals("https")){
             return true;
         }
-
-        for (String protocol : allowedProtocols) {
-            if (url.startsWith(protocol)) {
+        for (String allowedProtocol : allowedProtocols) {
+            if (urlProtocol.equals(allowedProtocol)) {
                 return true;
             }
         }

--- a/iterableapi/src/test/java/com/iterable/iterableapi/IterableInAppManagerSyncTest.java
+++ b/iterableapi/src/test/java/com/iterable/iterableapi/IterableInAppManagerSyncTest.java
@@ -38,7 +38,7 @@ public class IterableInAppManagerSyncTest extends BaseTest {
     @Before
     public void setUp() throws Exception {
         MockitoAnnotations.initMocks(this);
-        inAppManager = spy(new IterableInAppManager(iterableApiMock, handlerMock, 30.0, storageMock, activityMonitorMock, inAppDisplayerMock, new String[0]));
+        inAppManager = spy(new IterableInAppManager(iterableApiMock, handlerMock, 30.0, storageMock, activityMonitorMock, inAppDisplayerMock));
         doAnswer(new Answer() {
             @Override
             public Object answer(InvocationOnMock invocation) throws Throwable {

--- a/iterableapi/src/test/java/com/iterable/iterableapi/IterableInAppManagerTest.java
+++ b/iterableapi/src/test/java/com/iterable/iterableapi/IterableInAppManagerTest.java
@@ -264,7 +264,7 @@ public class IterableInAppManagerTest extends BaseTest {
         IterableActivityMonitor.instance = new IterableActivityMonitor();
 
         IterableInAppDisplayer inAppDisplayerMock = mock(IterableInAppDisplayer.class);
-        IterableInAppManager inAppManager = spy(new IterableInAppManager(IterableApi.sharedInstance, new IterableDefaultInAppHandler(), 30.0, new IterableInAppMemoryStorage(), IterableActivityMonitor.getInstance(), inAppDisplayerMock, new String[0]));
+        IterableInAppManager inAppManager = spy(new IterableInAppManager(IterableApi.sharedInstance, new IterableDefaultInAppHandler(), 30.0, new IterableInAppMemoryStorage(), IterableActivityMonitor.getInstance(), inAppDisplayerMock));
         IterableApi.sharedInstance = new IterableApi(inAppManager);
         IterableTestUtils.createIterableApiNew(new IterableTestUtils.ConfigBuilderExtender() {
             @Override
@@ -328,7 +328,7 @@ public class IterableInAppManagerTest extends BaseTest {
         IterableActivityMonitor.instance = new IterableActivityMonitor();
 
         IterableInAppDisplayer inAppDisplayerMock = mock(IterableInAppDisplayer.class);
-        IterableInAppManager inAppManager = spy(new IterableInAppManager(IterableApi.sharedInstance, new IterableSkipInAppHandler(), 30.0, new IterableInAppMemoryStorage(), IterableActivityMonitor.getInstance(), inAppDisplayerMock, new String[0]));
+        IterableInAppManager inAppManager = spy(new IterableInAppManager(IterableApi.sharedInstance, new IterableSkipInAppHandler(), 30.0, new IterableInAppMemoryStorage(), IterableActivityMonitor.getInstance(), inAppDisplayerMock));
         IterableApi.sharedInstance = new IterableApi(inAppManager);
         IterableTestUtils.createIterableApiNew(new IterableTestUtils.ConfigBuilderExtender() {
             @Override

--- a/iterableapi/src/test/java/com/iterable/iterableapi/IterableInboxTest.java
+++ b/iterableapi/src/test/java/com/iterable/iterableapi/IterableInboxTest.java
@@ -119,7 +119,7 @@ public class IterableInboxTest extends BaseTest {
 
         IterableInAppDisplayer inAppDisplayerMock = mock(IterableInAppDisplayer.class);
         when(inAppDisplayerMock.showMessage(any(IterableInAppMessage.class), eq(IterableInAppLocation.IN_APP), any(IterableHelper.IterableUrlCallback.class))).thenReturn(true);
-        IterableInAppManager inAppManager = spy(new IterableInAppManager(IterableApi.sharedInstance, new IterableDefaultInAppHandler(), 30.0, new IterableInAppMemoryStorage(), IterableActivityMonitor.getInstance(), inAppDisplayerMock, new String[0]));
+        IterableInAppManager inAppManager = spy(new IterableInAppManager(IterableApi.sharedInstance, new IterableDefaultInAppHandler(), 30.0, new IterableInAppMemoryStorage(), IterableActivityMonitor.getInstance(), inAppDisplayerMock));
         IterableApi.sharedInstance = new IterableApi(inAppManager);
         IterableTestUtils.createIterableApiNew(new IterableTestUtils.ConfigBuilderExtender() {
             @Override

--- a/iterableapi/src/test/java/com/iterable/iterableapi/IterablePushActionReceiverTest.java
+++ b/iterableapi/src/test/java/com/iterable/iterableapi/IterablePushActionReceiverTest.java
@@ -80,7 +80,7 @@ public class IterablePushActionReceiverTest extends BaseTest {
 
         // Verify that IterableActionRunner was called with the proper action
         ArgumentCaptor<IterableAction> capturedAction = ArgumentCaptor.forClass(IterableAction.class);
-        verify(actionRunnerMock).executeAction(any(Context.class), capturedAction.capture(), eq(IterableActionSource.PUSH), eq(new String[0]));
+        verify(actionRunnerMock).executeAction(any(Context.class), capturedAction.capture(), eq(IterableActionSource.PUSH));
         assertEquals("customAction", capturedAction.getValue().getType());
 
         // Verify that the main app activity was launched
@@ -133,7 +133,7 @@ public class IterablePushActionReceiverTest extends BaseTest {
 
         // Verify that IterableActionRunner was called with the proper action
         ArgumentCaptor<IterableAction> actionCaptor = ArgumentCaptor.forClass(IterableAction.class);
-        verify(actionRunnerMock).executeAction(any(Context.class), actionCaptor.capture(), eq(IterableActionSource.PUSH), eq(new String[0]));
+        verify(actionRunnerMock).executeAction(any(Context.class), actionCaptor.capture(), eq(IterableActionSource.PUSH));
         IterableAction capturedAction = actionCaptor.getValue();
         assertEquals("handleTextInput", capturedAction.getType());
         assertEquals("input text", capturedAction.userInput);
@@ -151,7 +151,7 @@ public class IterablePushActionReceiverTest extends BaseTest {
 
         // Verify that IterableActionRunner was called with openUrl action
         ArgumentCaptor<IterableAction> capturedAction = ArgumentCaptor.forClass(IterableAction.class);
-        verify(actionRunnerMock).executeAction(any(Context.class), capturedAction.capture(), eq(IterableActionSource.PUSH), eq(new String[0]));
+        verify(actionRunnerMock).executeAction(any(Context.class), capturedAction.capture(), eq(IterableActionSource.PUSH));
         assertEquals("openUrl", capturedAction.getValue().getType());
         assertEquals("https://example.com", capturedAction.getValue().getData());
     }


### PR DESCRIPTION
## 🔹 Jira Ticket(s) if any

[* [MOB-XXXX](https://iterable.atlassian.net/browse/MOB-XXXX)](https://iterable.atlassian.net/browse/MOB-3850)

## ✏️ Description

1. InAppManager no more holds array of allowedProtocols. Its always accessed from IterableConfig.
2. `isUrlOpenAllowed` is now a common utility method in IterableUtil
3. Modified test methods to accomodate the changes
