### PR TITLE
[Issue #377] Android 12: Set flag PendingIntent.FLAG_IMMUTABLE

### DIFF
--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableNotificationBuilder.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableNotificationBuilder.java
@@ -119,7 +119,7 @@ public class IterableNotificationBuilder extends NotificationCompat.Builder {
         buttonIntent.putExtra(IterableConstants.ACTION_IDENTIFIER, button.identifier);
 
         PendingIntent pendingButtonIntent = PendingIntent.getBroadcast(context, buttonIntent.hashCode(),
-                buttonIntent, PendingIntent.FLAG_UPDATE_CURRENT);
+                buttonIntent, PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
 
         NotificationCompat.Action.Builder actionBuilder = new NotificationCompat.Action
                 .Builder(NotificationCompat.BADGE_ICON_NONE, button.title, pendingButtonIntent);

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableNotificationHelper.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableNotificationHelper.java
@@ -193,7 +193,7 @@ class IterableNotificationHelper {
             }
 
             PendingIntent notificationClickedIntent = PendingIntent.getBroadcast(context, notificationBuilder.requestCode,
-                    pushContentIntent, PendingIntent.FLAG_UPDATE_CURRENT);
+                    pushContentIntent, PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
 
             notificationBuilder.setContentIntent(notificationClickedIntent);
             notificationBuilder.setIsGhostPush(isGhostPush(extras));


### PR DESCRIPTION
## 🔹 Jira Ticket(s) if any

* #377

## ✏️ Description

After deploying iterable SDK 3.4.0 with the Kiva Android app, I noticed [Android 12 specific crashes](https://github.com/Iterable/iterable-android-sdk/issues/377#issuecomment-1006741121) in our crash logging caused by a missing PendingIntent flag. 

It appears as if the fixes for this issue in previous releases (https://github.com/Iterable/iterable-android-sdk/pull/380 and https://github.com/Iterable/iterable-android-sdk/pull/390) regressed in SDK 3.4.0 (a278c7d773a62a1e356ac47263b4e12bea2373d7), as the change to these files was not called out as intentional in https://github.com/Iterable/iterable-android-sdk/pull/413.

I restored both [IterableNotificationBuilder.java](https://github.com/Iterable/iterable-android-sdk/blob/master/iterableapi/src/main/java/com/iterable/iterableapi/IterableNotificationBuilder.java) and [IterableNotificationHelper.java](https://github.com/Iterable/iterable-android-sdk/blob/master/iterableapi/src/main/java/com/iterable/iterableapi/IterableNotificationHelper.java) to revision 9e0a29fa278f674f23f3b72b92c55e1b3fd2e646 as part of this PR.

Workaround for those encountering this issue until a fix is released: reverting to [SDK 3.3.9](https://github.com/Iterable/iterable-android-sdk/releases/tag/3.3.9) should restore the previous behavior.

Thank you!
~ SteveC @ Kiva

Edit: Fixed conflicts w/ master's Trampoline changes. The PendingIntent mutablity is now specified in IterableNotificationHelper so did not need to be changed.