### PR TITLE
[MOB - 3970] - allow setShowBadge on notificationChannel

### DIFF
--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableConfig.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableConfig.java
@@ -70,6 +70,8 @@ public class IterableConfig {
      */
     final String[] allowedProtocols;
 
+    final boolean notificationBadge;
+
     private IterableConfig(Builder builder) {
         pushIntegrationName = builder.pushIntegrationName;
         urlHandler = builder.urlHandler;
@@ -82,6 +84,7 @@ public class IterableConfig {
         authHandler = builder.authHandler;
         expiringAuthTokenRefreshPeriod = builder.expiringAuthTokenRefreshPeriod;
         allowedProtocols = builder.allowedProtocols;
+        notificationBadge = builder.notificationBadge;
     }
 
     public static class Builder {
@@ -96,6 +99,7 @@ public class IterableConfig {
         private IterableAuthHandler authHandler;
         private long expiringAuthTokenRefreshPeriod = 60000L;
         private String[] allowedProtocols = new String[0];
+        private boolean notificationBadge = true;
         public Builder() {}
 
         /**
@@ -215,6 +219,16 @@ public class IterableConfig {
             this.allowedProtocols = allowedProtocols;
             return this;
         }
+
+        /**
+         * Set whether a badge or dot should be displayed for notification or/and on the app icon
+         */
+        @NonNull
+        public Builder setNotificationBadge(boolean notificationBadgeEnabled) {
+            this.notificationBadge = notificationBadgeEnabled;
+            return this;
+        }
+
 
         @NonNull
         public IterableConfig build() {

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableNotificationHelper.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableNotificationHelper.java
@@ -272,6 +272,9 @@ class IterableNotificationHelper {
                 notificationChannel = new NotificationChannel(channelId, channelName, NotificationManager.IMPORTANCE_HIGH);
                 notificationChannel.setDescription(channelDescription);
                 notificationChannel.enableLights(true);
+
+                //TODO: Is it a good idea to have the value fetched from config like this? Or should we have the value passed through a utility method? which will basically do the same thing. OR store it in sharedPreferences? and load it next time
+                notificationChannel.setShowBadge(IterableApi.getInstance().config.notificationBadge);
             }
             return notificationChannel;
         }


### PR DESCRIPTION
## 🔹 Jira Ticket(s) if any

* [MOB-3970](https://iterable.atlassian.net/browse/MOB-3970)

## ✏️ Description

1. Introduced a notificationBadge boolean value in IterableConfig. This has default set to true. setting it to false will hide the nofitication badge on app icon.

Note:
Notification badge is applied to a channel. And this configuration can disable all the notification badge passed through Iterable.
It is a single boolean value. As Iterable supports multiple Android Notification Channels, it will make sense to enable and disable badging for selected channels.