### PR TITLE
Refactor channel naming

### DIFF
--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableConstants.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableConstants.java
@@ -142,6 +142,7 @@ public final class IterableConstants {
     public static final String INSTANCE_ID_CLASS        = "com.google.android.gms.iid.InstanceID";
     public static final String ICON_FOLDER_IDENTIFIER   = "drawable";
     public static final String NOTIFICATION_ICON_NAME   = "iterable_notification_icon";
+    public static final String NOTIFICAION_BADGING      = "iterable_notification_badging";
     public static final String NOTIFICATION_COLOR       = "iterable_notification_color";
     public static final String NOTIFICATION_CHANNEL_NAME = "iterable_notification_channel_name";
     public static final String DEFAULT_SOUND            = "default";

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableNotificationHelper.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableNotificationHelper.java
@@ -278,7 +278,7 @@ class IterableNotificationHelper {
 
             if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O
                     && mNotificationManager != null) {
-                String channelIdToDelete = isNotificationBadgingEnabled(context) ? context.getPackageName() : context.getPackageName() + NO_BADGE;
+                String channelIdToDelete = getOldChannelId(context);
                 NotificationChannel unusedChannel = mNotificationManager.getNotificationChannel(channelIdToDelete);
                 if (unusedChannel != null) {
                     for (StatusBarNotification activeNotification : mNotificationManager.getActiveNotifications()) {
@@ -316,6 +316,14 @@ class IterableNotificationHelper {
         }
 
         private String getChannelId(Context context) {
+            getChannelIdName(context, !isNotificationBadgingEnabled(context))
+        }
+        
+        private String getOldChannelId(Context context) {
+            getChannelIdName(context, isNotificationBadgingEnabled(context))
+        }
+        
+        private String getChannelIdName(Context context, boolean badgingEnabled) {
             String channelId = context.getPackageName();
             if (!isNotificationBadgingEnabled(context)) {
                 channelId = channelId + NO_BADGE;


### PR DESCRIPTION
Adds the NO_BADGE flag in a single place so we aren't defining the channelId in different locations.
