### PR TITLE
[MOB-4068] - Reset jwtToken when logging out

### DIFF
--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
@@ -1139,6 +1139,12 @@ private static final String TAG = "IterableApi";
         public Context getContext() {
             return _applicationContext;
         }
+
+        @Override
+        public void resetAuth() {
+            IterableLogger.d(TAG, "Resetting authToken");
+            _authToken = null;
+        }
     }
 
 //---------------------------------------------------------------------------------------

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableApiClient.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableApiClient.java
@@ -33,6 +33,8 @@ class IterableApiClient {
         String getDeviceId();
         @Nullable
         Context getContext();
+
+        void resetAuth();
     }
 
     IterableApiClient(@NonNull AuthProvider authProvider) {
@@ -559,5 +561,6 @@ class IterableApiClient {
 
     void onLogout() {
         getRequestProcessor().onLogout(authProvider.getContext());
+        authProvider.resetAuth();
     }
 }


### PR DESCRIPTION
## 🔹 Jira Ticket(s) if any

* [MOB-4068](https://iterable.atlassian.net/browse/MOB-4068)

## ✏️ Description

For JWT enabled projects using Android SDK, a logout and login ends up disabling the user but not registering the user again(stopping them from getting push notification). Reason being the auth not reset because the authHandler kept returning the same authtoken and was not set again. Instead it should be set to null and then next time user logs in, the code can continue normally
