### PR TITLE
[MOB - 4026] Fix - App not visible in recent apps

### DIFF
--- a/iterableapi/src/main/AndroidManifest.xml
+++ b/iterableapi/src/main/AndroidManifest.xml
@@ -25,7 +25,7 @@
         <activity
             android:name=".IterableTrampolineActivity"
             android:exported="false"
-            android:launchMode="singleInstance"
+            android:launchMode="singleTop"
             android:theme="@style/TrampolineActivity.Transparent"/>
     </application>
 


### PR DESCRIPTION
## 🔹 Jira Ticket(s) if any

* [MOB-4026](https://iterable.atlassian.net/browse/MOB-4026)

## ✏️ Description

> 1. `singleInstance` launchmode of TrampolineActivity did not allow for parent activity to show in recent apps after destorying itself. Setting it to `singleTop` allows it.

