### PR TITLE
Checking duplicate messageIds before showing push

### DIFF
--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
@@ -753,6 +753,10 @@ private static final String TAG = "IterableApi";
         apiClient.trackInAppDelivery(message);
     }
 
+    void trackDuplicateSend(@NonNull String messageId) {
+        apiClient.trackDuplicatePush(messageId);
+    }
+
     /**
      * Consumes an InApp message.
      * @param messageId

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableApiClient.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableApiClient.java
@@ -140,6 +140,17 @@ class IterableApiClient {
         }
     }
 
+    public void trackDuplicatePush(@NonNull String messageId) {
+        JSONObject requestJSON = new JSONObject();
+        try {
+            requestJSON.put(IterableConstants.KEY_MESSAGE_ID, messageId);
+            requestJSON.put(IterableConstants.KEY_EVENT_TYPE, IterableConstants.ITERABLE_DATA_EVENT_TYPE);
+            sendPostRequest(IterableConstants.ENDPOINT_TRACK_DUPLICATE_SEND, requestJSON);
+        } catch (JSONException e) {
+            e.printStackTrace();
+        }
+    }
+
     public void updateEmail(final @NonNull String newEmail, final @Nullable IterableHelper.SuccessHandler successHandler, @Nullable IterableHelper.FailureHandler failureHandler) {
         JSONObject requestJSON = new JSONObject();
 

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableConstants.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableConstants.java
@@ -32,6 +32,7 @@ public final class IterableConstants {
     public static final String KEY_EMAIL                = "email";
     public static final String KEY_EMAIL_LIST_IDS       = "emailListIds";
     public static final String KEY_EVENT_NAME           = "eventName";
+    public static final String KEY_EVENT_TYPE           = "eventType";
     public static final String KEY_ITEMS                = "items";
     public static final String KEY_NEW_EMAIL            = "newEmail";
     public static final String KEY_PACKAGE_NAME         = "packageName";
@@ -73,6 +74,7 @@ public final class IterableConstants {
     public static final String ENDPOINT_UPDATE_USER_SUBS        = "users/updateSubscriptions";
     public static final String ENDPOINT_TRACK_INAPP_CLOSE       = "events/trackInAppClose";
     public static final String ENDPOINT_GET_REMOTE_CONFIGURATION = "mobile/getRemoteConfiguration";
+    public static final String ENDPOINT_TRACK_DUPLICATE_SEND    = "events/trackDupSend";
 
     public static final String PUSH_APP_ID                      = "IterableAppId";
     public static final String PUSH_GCM_PROJECT_NUMBER          = "GCMProjectNumber";
@@ -95,6 +97,7 @@ public final class IterableConstants {
     public static final String ITERABLE_DATA_TITLE  = "title";
     public static final String ITERABLE_DATA_ACTION_BUTTONS  = "actionButtons";
     public static final String ITERABLE_DATA_DEFAULT_ACTION  = "defaultAction";
+    public static final String ITERABLE_DATA_EVENT_TYPE = "pushSend";
 
     //SharedPreferences keys
     public static final String SHARED_PREFS_FILE = "com.iterable.iterableapi";

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableFirebaseMessagingService.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableFirebaseMessagingService.java
@@ -73,12 +73,13 @@ public class IterableFirebaseMessagingService extends FirebaseMessagingService {
                 if (isDuplicateMessageId(context, notificationBuilder.iterableNotificationData.getMessageId())) {
                     IterableLogger.d(TAG, "Notification is duplicate .Proceed to call dedeup API");
                     IterableApi.getInstance().trackDuplicateSend(notificationBuilder.iterableNotificationData.getMessageId());
+                    notificationBuilder = null;
                     return false;
                 }
-                if(BuildConfig.DEBUG && notificationBuilder.iterableNotificationData.getCampaignId() == 0) {
-                    IterableLogger.d(TAG, "Marking Push proof as duplicates. Proofs still continues to be shown on device. It wont be treated and skipped as duplicates");
-                    IterableApi.getInstance().trackDuplicateSend(notificationBuilder.iterableNotificationData.getMessageId());
-                }
+//                if(BuildConfig.DEBUG && notificationBuilder.iterableNotificationData.getCampaignId() == 0) {
+//                    IterableLogger.d(TAG, "Marking Push proof as duplicates. Proofs still continues to be shown on device. It wont be treated and skipped as duplicates");
+//                    IterableApi.getInstance().trackDuplicateSend(notificationBuilder.iterableNotificationData.getMessageId());
+//                }
                 new IterableNotificationManager().execute(notificationBuilder);
             } else {
                 IterableLogger.d(TAG, "Iterable OS notification push received");
@@ -108,10 +109,9 @@ public class IterableFirebaseMessagingService extends FirebaseMessagingService {
         ArrayList<String> recentMessageIdArrayList = new ArrayList<>();
         if (recentMessageIds != null) {
             //Only if there are previous messageIds, check for duplicates
-            IterableLogger.d(TAG, "No records of message ids in sharedPreference");
             recentMessageIdArrayList = new ArrayList<>(Arrays.asList(recentMessageIds.split(",")));
             if (recentMessageIdArrayList.contains(messageId)) {
-                IterableLogger.d(TAG, "Duplicate message id found");
+                IterableLogger.d(TAG, "Duplicate message id found matching " + messageId);
                 return true;
             }
             while (recentMessageIdArrayList.size() > 9) {

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableFirebaseMessagingService.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableFirebaseMessagingService.java
@@ -72,8 +72,12 @@ public class IterableFirebaseMessagingService extends FirebaseMessagingService {
                         context.getApplicationContext(), extras);
                 if (isDuplicateMessageId(context, notificationBuilder.iterableNotificationData.getMessageId())) {
                     IterableLogger.d(TAG, "Notification is duplicate .Proceed to call dedeup API");
-                    //TODO: Probably the right place to call /dupsend api
+                    IterableApi.getInstance().trackDuplicateSend(notificationBuilder.iterableNotificationData.getMessageId());
                     return false;
+                }
+                if(BuildConfig.DEBUG && notificationBuilder.iterableNotificationData.getCampaignId() == 0) {
+                    IterableLogger.d(TAG, "Marking Push proof as duplicates. Proofs still continues to be shown on device. It wont be treated and skipped as duplicates");
+                    IterableApi.getInstance().trackDuplicateSend(notificationBuilder.iterableNotificationData.getMessageId());
                 }
                 new IterableNotificationManager().execute(notificationBuilder);
             } else {


### PR DESCRIPTION


## 🔹 Jira Ticket(s) if any

Hack Week - Avoid showing duplicate push messages

## ✏️ Description

1. Comma seperated message Ids stored in shared preference
2. Arraylist implementation where New messageIds added at last and removed from index0 to keep size less than 10
3. All this functionality is clubbed into the new method: `isDuplicateMessageId` which now returns true if messageId duplicate is found. Else returns false where it successfully stores the last push messageId.

Remaining:
1. Call trackDuplicate Api call when return value of true is returned from this new method.
2. return false and do not proceed with showing the notification and discard the notification object created so far
