### PR TITLE
Disable logging in production

### DIFF
--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableConfig.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableConfig.java
@@ -1,7 +1,8 @@
 package com.iterable.iterableapi;
 
 import androidx.annotation.NonNull;
-import android.util.Log;
+
+import com.iterable.iterableapi.util.LogLevel;
 
 /**
  *
@@ -40,7 +41,7 @@ public class IterableConfig {
     /**
      * Log level for Iterable SDK log messages
      */
-    final int logLevel;
+    final @LogLevel.Level int logLevel;
 
     /**
      * Custom in-app handler that can be used to control whether an incoming in-app message should
@@ -90,7 +91,7 @@ public class IterableConfig {
         private IterableCustomActionHandler customActionHandler;
         private boolean autoPushRegistration = true;
         private boolean checkForDeferredDeeplink;
-        private int logLevel = Log.ERROR;
+        private @LogLevel.Level int logLevel = LogLevel.NONE;
         private IterableInAppHandler inAppHandler = new IterableDefaultInAppHandler();
         private double inAppDisplayInterval = 30.0;
         private IterableAuthHandler authHandler;
@@ -156,10 +157,10 @@ public class IterableConfig {
 
         /**
          * Set the log level for Iterable SDK log messages
-         * @param logLevel Log level, defaults to {@link Log#ERROR}
+         * @param logLevel Log level, defaults to {@link LogLevel#NONE}
          */
         @NonNull
-        public Builder setLogLevel(int logLevel) {
+        public Builder setLogLevel(@LogLevel.Level int logLevel) {
             this.logLevel = logLevel;
             return this;
         }

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableLogger.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableLogger.java
@@ -58,7 +58,7 @@ public class IterableLogger {
     }
 
     private static boolean isLoggableLevel(int messageLevel) {
-        return messageLevel >= getLogLevel();
+        return BuildConfig.DEBUG && messageLevel >= getLogLevel();
     }
 
     private static int getLogLevel() {

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableLogger.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableLogger.java
@@ -2,49 +2,53 @@ package com.iterable.iterableapi;
 
 import android.util.Log;
 
+import androidx.annotation.VisibleForTesting;
+
+import com.iterable.iterableapi.util.LogLevel;
+
 /**
  * Created by David Truong dt@iterable.com.
  */
-public class IterableLogger {
+public final class IterableLogger {
 
     public static void d(String tag, String msg) {
-        if (isLoggableLevel(Log.DEBUG)) {
+        if (isLoggableLevel(LogLevel.DEBUG)) {
             Log.d(tag, " 💚 " + msg);
         }
     }
 
     public static void d(String tag, String msg, Throwable tr) {
-        if (isLoggableLevel(Log.DEBUG)) {
+        if (isLoggableLevel(LogLevel.DEBUG)) {
             Log.d(tag, " 💚 " + msg, tr);
         }
     }
 
     public static void v(String tag, String msg) {
-        if (isLoggableLevel(Log.VERBOSE)) {
+        if (isLoggableLevel(LogLevel.VERBOSE)) {
             Log.v(tag, " 💛 " + msg);
         }
     }
 
     public static void w(String tag, String msg) {
-        if (isLoggableLevel(Log.WARN)) {
+        if (isLoggableLevel(LogLevel.WARN)) {
             Log.w(tag, " 🧡️ " + msg);
         }
     }
 
     public static void w(String tag, String msg, Throwable tr) {
-        if (isLoggableLevel(Log.WARN)) {
+        if (isLoggableLevel(LogLevel.WARN)) {
             Log.w(tag, " 🧡 " + msg, tr);
         }
     }
 
     public static void e(String tag, String msg) {
-        if (isLoggableLevel(Log.ERROR)) {
+        if (isLoggableLevel(LogLevel.ERROR)) {
             Log.e(tag, " ❤️ " + msg);
         }
     }
 
     public static void e(String tag, String msg, Throwable tr) {
-        if (isLoggableLevel(Log.ERROR)) {
+        if (isLoggableLevel(LogLevel.ERROR)) {
             Log.e(tag, " ❤️ " + msg, tr);
         }
     }
@@ -57,18 +61,20 @@ public class IterableLogger {
         }
     }
 
-    private static boolean isLoggableLevel(int messageLevel) {
-        return BuildConfig.DEBUG && messageLevel >= getLogLevel();
+    @VisibleForTesting
+    protected static boolean isLoggableLevel(@LogLevel.Level int messageLevel) {
+        return messageLevel >= getLogLevel();
     }
 
+    @LogLevel.Level
     private static int getLogLevel() {
         if (IterableApi.sharedInstance != null) {
             if (IterableApi.sharedInstance.getDebugMode()) {
-                return Log.VERBOSE;
+                return LogLevel.VERBOSE;
             } else {
                 return IterableApi.sharedInstance.config.logLevel;
             }
         }
-        return Log.ERROR;
+        return LogLevel.NONE;
     }
 }

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableLogger.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableLogger.java
@@ -11,6 +11,8 @@ import com.iterable.iterableapi.util.LogLevel;
  */
 public final class IterableLogger {
 
+    private IterableLogger() { }
+
     public static void d(String tag, String msg) {
         if (isLoggableLevel(LogLevel.DEBUG)) {
             Log.d(tag, " 💚 " + msg);

--- a/iterableapi/src/main/java/com/iterable/iterableapi/util/LogLevel.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/util/LogLevel.java
@@ -1,0 +1,47 @@
+package com.iterable.iterableapi.util;
+
+import android.util.Log;
+
+import androidx.annotation.IntDef;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+public final class LogLevel {
+
+    /**
+     * Priority constant to use instead of Log.v.
+     */
+    public static final int VERBOSE = Log.VERBOSE;
+
+    /**
+     * Priority constant to use instead of Log.d.
+     */
+    public static final int DEBUG = Log.DEBUG;
+
+    /**
+     * Priority constant to use instead of Log.i.
+     */
+    public static final int INFO = Log.INFO;
+
+    /**
+     * Priority constant to use instead of Log.w.
+     */
+    public static final int WARN = Log.WARN;
+
+    /**
+     * Priority constant to use instead of Log.e.
+     */
+    public static final int ERROR = Log.ERROR;
+
+    /**
+     * Priority constant to use to disable logging.
+     */
+    public static final int NONE = Integer.MAX_VALUE;
+
+    @IntDef({VERBOSE, DEBUG, INFO, WARN, ERROR, NONE})
+    @Retention(RetentionPolicy.SOURCE)
+    public @interface Level {}
+
+    private LogLevel() { }
+}

--- a/iterableapi/src/test/java/com/iterable/iterableapi/IterableLoggerTest.java
+++ b/iterableapi/src/test/java/com/iterable/iterableapi/IterableLoggerTest.java
@@ -1,0 +1,72 @@
+package com.iterable.iterableapi;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import android.util.Log;
+
+import com.iterable.iterableapi.util.LogLevel;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+
+public class IterableLoggerTest extends BaseTest {
+
+    @Before
+    public void setUp() throws IOException {
+        IterableApi.sharedInstance = new IterableApi();
+    }
+
+    @Test
+    public void testIsLoggableLevelLogic() {
+        IterableTestUtils.createIterableApiNew(new IterableTestUtils.ConfigBuilderExtender() {
+            @Override
+            public IterableConfig.Builder run(IterableConfig.Builder builder) {
+                return builder.setLogLevel(LogLevel.WARN);
+            }
+        });
+
+        assertFalse(IterableLogger.isLoggableLevel(LogLevel.VERBOSE));
+        assertFalse(IterableLogger.isLoggableLevel(LogLevel.DEBUG));
+        assertFalse(IterableLogger.isLoggableLevel(LogLevel.INFO));
+        assertTrue(IterableLogger.isLoggableLevel(LogLevel.WARN));
+        assertTrue(IterableLogger.isLoggableLevel(LogLevel.ERROR));
+    }
+
+    @Test
+    public void testShouldDisableLogging() {
+        IterableTestUtils.createIterableApiNew(new IterableTestUtils.ConfigBuilderExtender() {
+            @Override
+            public IterableConfig.Builder run(IterableConfig.Builder builder) {
+                return builder.setLogLevel(LogLevel.NONE);
+            }
+        });
+
+        assertFalse(IterableLogger.isLoggableLevel(LogLevel.VERBOSE));
+        assertFalse(IterableLogger.isLoggableLevel(LogLevel.DEBUG));
+        assertFalse(IterableLogger.isLoggableLevel(LogLevel.INFO));
+        assertFalse(IterableLogger.isLoggableLevel(LogLevel.WARN));
+        assertFalse(IterableLogger.isLoggableLevel(LogLevel.ERROR));
+    }
+
+    @Test
+    public void testShouldLogAllInDebugMode() {
+        IterableTestUtils.createIterableApiNew(new IterableTestUtils.ConfigBuilderExtender() {
+            @Override
+            public IterableConfig.Builder run(IterableConfig.Builder builder) {
+                return builder.setLogLevel(Log.ERROR);
+            }
+        });
+
+        IterableApi.getInstance().setDebugMode(true);
+
+        assertTrue(IterableLogger.isLoggableLevel(LogLevel.VERBOSE));
+        assertTrue(IterableLogger.isLoggableLevel(LogLevel.DEBUG));
+        assertTrue(IterableLogger.isLoggableLevel(LogLevel.INFO));
+        assertTrue(IterableLogger.isLoggableLevel(LogLevel.WARN));
+        assertTrue(IterableLogger.isLoggableLevel(LogLevel.ERROR));
+        assertTrue(IterableLogger.isLoggableLevel(LogLevel.NONE));
+    }
+}

--- a/iterableapi/src/test/java/com/iterable/iterableapi/IterableLoggerTest.java
+++ b/iterableapi/src/test/java/com/iterable/iterableapi/IterableLoggerTest.java
@@ -56,7 +56,7 @@ public class IterableLoggerTest extends BaseTest {
         IterableTestUtils.createIterableApiNew(new IterableTestUtils.ConfigBuilderExtender() {
             @Override
             public IterableConfig.Builder run(IterableConfig.Builder builder) {
-                return builder.setLogLevel(Log.ERROR);
+                return builder.setLogLevel(LogLevel.ERROR);
             }
         });
 

--- a/iterableapi/src/test/java/com/iterable/iterableapi/LogLevelTest.java
+++ b/iterableapi/src/test/java/com/iterable/iterableapi/LogLevelTest.java
@@ -1,0 +1,25 @@
+package com.iterable.iterableapi;
+
+import static junit.framework.Assert.assertEquals;
+
+import android.util.Log;
+
+import com.iterable.iterableapi.unit.TestRunner;
+import com.iterable.iterableapi.util.LogLevel;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(TestRunner.class)
+public class LogLevelTest {
+
+    @Test
+    public void testLogLevelsHaveExpectedValues() {
+        assertEquals(Log.VERBOSE, LogLevel.VERBOSE);
+        assertEquals(Log.DEBUG, LogLevel.DEBUG);
+        assertEquals(Log.INFO, LogLevel.INFO);
+        assertEquals(Log.WARN, LogLevel.WARN);
+        assertEquals(Log.ERROR, LogLevel.ERROR);
+        assertEquals(Integer.MAX_VALUE, LogLevel.NONE);
+    }
+}


### PR DESCRIPTION
## 🔹 Jira Ticket(s) if any

* None

## ✏️ Description

Disables logging in production. Per official [Android's documentation](https://developer.android.com/studio/publish/preparing#turn-off-logging-and-debugging) all logging should be disabled in production. Additionally, current logger is not HIPAA compliant as errors are logged by default and sensitive information might leak by mistake. Example of this would be a code in the `IterableActionRunner.java` where is a code:
```
IterableLogger.e(TAG, "Could not find activities to handle deep link:" + uri);
```

In case a deep link contains user ID or other PHI that string will be logged onto the device and anyone can read it with LogCat or by observing logs.