### PR TITLE
[MOB-4447] feature/MOB-4447-protocol-fix

### DIFF
--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableUtil.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableUtil.java
@@ -285,7 +285,7 @@ class IterableUtil {
             return true;
         }
 
-        for (String allowedProtocol : IterableApi.getInstance().config.allowedProtocols) {
+        for (String allowedProtocol : IterableApi.sharedInstance.config.allowedProtocols) {
             if (urlProtocol.equals(allowedProtocol)) {
                 return true;
             }


### PR DESCRIPTION
## 🔹 Jira Ticket(s) if any

* [MOB-4447](https://iterable.atlassian.net/browse/MOB-4447)

## ✏️ Description

> The list of protocols doesn't work on mParticle because it creates a new instance.
Changes the reference to use the shared instance.
