### PR TITLE
[MOB-4641] - Add success and failure callback to AuthHandler

### DIFF
--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
@@ -351,7 +351,9 @@ private static final String TAG = "IterableApi";
     }
 
     public void setEmail(@Nullable String email, @Nullable String authToken) {
+        //Only if passed in same non-null email
         if (_email != null && _email.equals(email)) {
+            checkAndUpdateAuthToken(authToken);
             return;
         }
 
@@ -380,7 +382,9 @@ private static final String TAG = "IterableApi";
     }
 
     public void setUserId(@Nullable String userId, @Nullable String authToken) {
+        //If same non null userId is passed
         if (_userId != null && _userId.equals(userId)) {
+            checkAndUpdateAuthToken(authToken);
             return;
         }
 
@@ -395,6 +399,13 @@ private static final String TAG = "IterableApi";
         storeAuthData();
 
         onLogin(authToken);
+    }
+
+    private void checkAndUpdateAuthToken(@Nullable String authToken) {
+        // If authHandler exists and if authToken is new, it will be considered as a call to update the authToken.
+        if (config.authHandler != null && authToken != null && authToken != _authToken) {
+            setAuthToken(authToken);
+        }
     }
 
     /**

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
@@ -220,7 +220,7 @@ private static final String TAG = "IterableApi";
         }
     }
 
-    void setAuthToken(String authToken) {
+    public void setAuthToken(String authToken) {
         setAuthToken(authToken, false);
     }
 

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableAuthHandler.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableAuthHandler.java
@@ -2,4 +2,6 @@ package com.iterable.iterableapi;
 
 public interface IterableAuthHandler {
     String onAuthTokenRequested();
+    void onTokenRegistrationSuccessful(String authToken);
+    void onTokenRegistrationFailed(Throwable object);
 }

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableAuthManager.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableAuthManager.java
@@ -2,7 +2,6 @@ package com.iterable.iterableapi;
 
 import android.util.Base64;
 
-import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 
 import com.iterable.iterableapi.util.Future;
@@ -35,10 +34,6 @@ public class IterableAuthManager {
     }
 
     public synchronized void requestNewAuthToken(boolean hasFailedPriorAuth) {
-        requestNewAuthToken(hasFailedPriorAuth, null);
-    }
-
-    public synchronized void requestNewAuthToken(boolean hasFailedPriorAuth, @Nullable final IterableHelper.SuccessAuthHandler onSuccess) {
         if (authHandler != null) {
             if (!pendingAuth) {
                 if (!(this.hasFailedPriorAuth && hasFailedPriorAuth)) {


### PR DESCRIPTION

## 🔹 Jira Ticket(s) if any

* [MOB-4641](https://iterable.atlassian.net/browse/MOB-4641)

## ✏️ Description

1. Added Success and Failure method to AuthHandler interface.
2. SuccessCallback is called when SDK receives the `authToken`. The success callback passes back the received authToken which developers can verify to see if its the correct one.
3. Failure callback is called when nothing is returned with possible throwable object which can be useful to understand the cause.

