### PR TITLE
[MOB-4986] - Stop redraw listener on webview load

### DIFF
--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableInAppFragmentHTMLNotification.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableInAppFragmentHTMLNotification.java
@@ -172,6 +172,10 @@ public class IterableInAppFragmentHTMLNotification extends DialogFragment implem
             @Override
             public boolean onPreDraw() {
                 runResizeScript();
+                // PreDraw may keep getting called even after the inapp is being displayed. Hence stopping the continuous predraw calls and resizeScript calls after webview is loaded and visible.
+                if (loaded && webView.getVisibility() == View.VISIBLE) {
+                    webView.getViewTreeObserver().removeOnPreDrawListener(this);
+                }
                 return true;
             }
         });


### PR DESCRIPTION
## 🔹 Jira Ticket(s) if any

* [MOB-4986](https://iterable.atlassian.net/browse/MOB-4986)

## ✏️ Description

> onPreDraw() may keep getting called even after the inapp is being displayed and loaded completely. In some instance, getHeight() returns different values after the page has loaded which makes it go to the top. Hence stopping the continuous predraw calls and resizeScript calls after webview is loaded and visible. Might not be a perfect solution but looks like a temporary work around for current implementation.

