### PR TITLE
[MOB-5365] update to set custom sound at notification channel

### DIFF
--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableNotificationHelper.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableNotificationHelper.java
@@ -280,6 +280,7 @@ class IterableNotificationHelper {
         private NotificationChannel createNotificationChannel(String channelId, String channelName, String channelDescription, Context context, String soundName) {
             NotificationChannel notificationChannel = null;
             Uri soundUri = null;
+            AudioAttributes audioAttributes = null;
 
             if (soundName != null) {
                 //Removes the file type from the name
@@ -292,12 +293,14 @@ class IterableNotificationHelper {
                 }
             }
 
-            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
-                AudioAttributes audioAttributes =  new AudioAttributes.Builder()
+            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.LOLLIPOP) {
+                audioAttributes = new AudioAttributes.Builder()
                         .setUsage(AudioAttributes.USAGE_NOTIFICATION)
                         .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
                         .build();
+            }
 
+            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
                 notificationChannel = new NotificationChannel(channelId, channelName, NotificationManager.IMPORTANCE_HIGH);
                 notificationChannel.setDescription(channelDescription);
                 notificationChannel.enableLights(true);

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableNotificationHelper.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableNotificationHelper.java
@@ -115,8 +115,6 @@ class IterableNotificationHelper {
                 return null;
             }
 
-            removeUnusedChannel(context);
-            registerChannelIfEmpty(context, getChannelId(context), channelName, channelDescription);
             IterableNotificationBuilder notificationBuilder = new IterableNotificationBuilder(context, getChannelId(context));
             JSONObject iterableJson = null;
             title = extras.getString(IterableConstants.ITERABLE_DATA_TITLE, applicationName);
@@ -154,23 +152,6 @@ class IterableNotificationHelper {
             }
             notificationBuilder.setImageUrl(pushImage);
             notificationBuilder.setExpandedContent(notificationBody);
-
-            if (soundName != null) {
-                //Removes the file type from the name
-                String[] soundFile = soundName.split("\\.");
-                soundName = soundFile[0];
-
-                if (!soundName.equalsIgnoreCase(IterableConstants.DEFAULT_SOUND)) {
-                    int soundID = context.getResources().getIdentifier(soundName, IterableConstants.SOUND_FOLDER_IDENTIFIER, context.getPackageName());
-                    Uri soundUri = Uri.parse(IterableConstants.ANDROID_RESOURCE_PATH + context.getPackageName() + "/" + soundID);
-                    notificationBuilder.setSound(soundUri);
-                } else {
-                    notifPermissions.defaults |= Notification.DEFAULT_SOUND;
-                }
-
-            } else {
-                notifPermissions.defaults |= Notification.DEFAULT_SOUND;
-            }
 
             // The notification doesn't cancel properly if requestCode is negative
             notificationBuilder.requestCode = Math.abs((int) System.currentTimeMillis());
@@ -223,6 +204,9 @@ class IterableNotificationHelper {
 
             notificationBuilder.setDefaults(notifPermissions.defaults);
 
+            removeUnusedChannel(context);
+            registerChannelIfEmpty(context, getChannelId(context), channelName, channelDescription, soundName);
+
             return notificationBuilder;
         }
 
@@ -255,7 +239,7 @@ class IterableNotificationHelper {
          * @param channelName        Sets the channel name that is shown to the user.
          * @param channelDescription Sets the channel description that is shown to the user.
          */
-        private void registerChannelIfEmpty(Context context, String channelId, String channelName, String channelDescription) {
+        private void registerChannelIfEmpty(Context context, String channelId, String channelName, String channelDescription, String soundName) {
             NotificationManager mNotificationManager = (NotificationManager)
                     context.getApplicationContext().getSystemService(Context.NOTIFICATION_SERVICE);
             if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O
@@ -264,7 +248,7 @@ class IterableNotificationHelper {
                 if (existingChannel == null || !existingChannel.getName().equals(channelName)) {
                     IterableLogger.d(IterableNotificationBuilder.TAG, "Creating notification: channelId = " + channelId + " channelName = "
                             + channelName + " channelDescription = " + channelDescription);
-                    mNotificationManager.createNotificationChannel(createNotificationChannel(channelId, channelName, channelDescription, context));
+                    mNotificationManager.createNotificationChannel(createNotificationChannel(channelId, channelName, channelDescription, context, soundName));
                 }
             }
         }
@@ -292,13 +276,29 @@ class IterableNotificationHelper {
             }
         }
 
-        private NotificationChannel createNotificationChannel(String channelId, String channelName, String channelDescription, Context context) {
+        private NotificationChannel createNotificationChannel(String channelId, String channelName, String channelDescription, Context context, String soundName) {
             NotificationChannel notificationChannel = null;
+            Uri soundUri = null;
+
+            if (soundName != null) {
+                //Removes the file type from the name
+                String[] soundFile = soundName.split("\\.");
+                soundName = soundFile[0];
+
+                if (!soundName.equalsIgnoreCase(IterableConstants.DEFAULT_SOUND)) {
+                    int soundID = context.getResources().getIdentifier(soundName, IterableConstants.SOUND_FOLDER_IDENTIFIER, context.getPackageName());
+                    soundUri = Uri.parse(IterableConstants.ANDROID_RESOURCE_PATH + context.getPackageName() + "/" + soundID);
+                }
+            }
+
+
+
             if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
                 notificationChannel = new NotificationChannel(channelId, channelName, NotificationManager.IMPORTANCE_HIGH);
                 notificationChannel.setDescription(channelDescription);
                 notificationChannel.enableLights(true);
                 notificationChannel.setShowBadge(isNotificationBadgingEnabled(context));
+                notificationChannel.setSound(soundUri, );
             }
             return notificationChannel;
         }

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableNotificationHelper.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableNotificationHelper.java
@@ -9,6 +9,7 @@ import android.content.Intent;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
 import android.content.res.Resources;
+import android.media.AudioAttributes;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
@@ -291,14 +292,17 @@ class IterableNotificationHelper {
                 }
             }
 
-
-
             if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
+                AudioAttributes audioAttributes =  new AudioAttributes.Builder()
+                        .setUsage(AudioAttributes.USAGE_NOTIFICATION)
+                        .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
+                        .build();
+
                 notificationChannel = new NotificationChannel(channelId, channelName, NotificationManager.IMPORTANCE_HIGH);
                 notificationChannel.setDescription(channelDescription);
                 notificationChannel.enableLights(true);
                 notificationChannel.setShowBadge(isNotificationBadgingEnabled(context));
-                notificationChannel.setSound(soundUri, );
+                notificationChannel.setSound(soundUri, audioAttributes);
             }
             return notificationChannel;
         }

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableNotificationHelper.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableNotificationHelper.java
@@ -282,23 +282,8 @@ class IterableNotificationHelper {
             Uri soundUri = null;
             AudioAttributes audioAttributes = null;
 
-            if (soundName != null) {
-                //Removes the file type from the name
-                String[] soundFile = soundName.split("\\.");
-                soundName = soundFile[0];
-
-                if (!soundName.equalsIgnoreCase(IterableConstants.DEFAULT_SOUND)) {
-                    int soundID = context.getResources().getIdentifier(soundName, IterableConstants.SOUND_FOLDER_IDENTIFIER, context.getPackageName());
-                    soundUri = Uri.parse(IterableConstants.ANDROID_RESOURCE_PATH + context.getPackageName() + "/" + soundID);
-                }
-            }
-
-            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.LOLLIPOP) {
-                audioAttributes = new AudioAttributes.Builder()
-                        .setUsage(AudioAttributes.USAGE_NOTIFICATION)
-                        .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
-                        .build();
-            }
+            soundUri = getSoundUri(context, soundName, soundUri);
+            audioAttributes = getAudioAttributes(audioAttributes);
 
             if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
                 notificationChannel = new NotificationChannel(channelId, channelName, NotificationManager.IMPORTANCE_HIGH);
@@ -439,6 +424,30 @@ class IterableNotificationHelper {
 
             return notificationBody.isEmpty();
         }
+    }
+
+    private static AudioAttributes getAudioAttributes(AudioAttributes audioAttributes) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            audioAttributes = new AudioAttributes.Builder()
+                    .setUsage(AudioAttributes.USAGE_NOTIFICATION)
+                    .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
+                    .build();
+        }
+        return audioAttributes;
+    }
+
+    private static Uri getSoundUri(Context context, String soundName, Uri soundUri) {
+        if (soundName != null) {
+            //Removes the file type from the name
+            String[] soundFile = soundName.split("\\.");
+            soundName = soundFile[0];
+
+            if (!soundName.equalsIgnoreCase(IterableConstants.DEFAULT_SOUND)) {
+                int soundID = context.getResources().getIdentifier(soundName, IterableConstants.SOUND_FOLDER_IDENTIFIER, context.getPackageName());
+                soundUri = Uri.parse(IterableConstants.ANDROID_RESOURCE_PATH + context.getPackageName() + "/" + soundID);
+            }
+        }
+        return soundUri;
     }
 
 }

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterablePushRegistrationTask.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterablePushRegistrationTask.java
@@ -6,7 +6,8 @@ import android.os.AsyncTask;
 /**
  * Created by David Truong dt@iterable.com
  */
-class IterablePushRegistrationTask extends AsyncTask<IterablePushRegistrationData, Void, Void> {
+class
+IterablePushRegistrationTask extends AsyncTask<IterablePushRegistrationData, Void, Void> {
     static final String TAG = "IterablePushRegistration";
     IterablePushRegistrationData iterablePushRegistrationData;
 

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterablePushRegistrationTask.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterablePushRegistrationTask.java
@@ -6,8 +6,7 @@ import android.os.AsyncTask;
 /**
  * Created by David Truong dt@iterable.com
  */
-class
-IterablePushRegistrationTask extends AsyncTask<IterablePushRegistrationData, Void, Void> {
+class IterablePushRegistrationTask extends AsyncTask<IterablePushRegistrationData, Void, Void> {
     static final String TAG = "IterablePushRegistration";
     IterablePushRegistrationData iterablePushRegistrationData;
 


### PR DESCRIPTION
## 🔹 Jira Ticket(s) if any

* [MOB-5365](https://iterable.atlassian.net/browse/MOB-5365)

## ✏️ Description

This pull request updates the custom sound to be set at the notification channel rather than at the notification builder. See [here](https://developer.android.com/reference/android/app/NotificationChannel#setSound(android.net.Uri,%20android.media.AudioAttributes)) for the documentation. This resolves a part of the issue, but further logic needs to be implemented to address the situation for when the custom sound is updated for the push notification template.


[MOB-5365]: https://iterable.atlassian.net/browse/MOB-5365?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ