### PR TITLE
[MOB-5664] - Revert channel name implementation

### DIFF
--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableConstants.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableConstants.java
@@ -143,7 +143,7 @@ public final class IterableConstants {
     public static final String NOTIFICATION_ICON_NAME   = "iterable_notification_icon";
     public static final String NOTIFICAION_BADGING      = "iterable_notification_badging";
     public static final String NOTIFICATION_COLOR       = "iterable_notification_color";
-    public static final String NOTIFICATION_CHANNEL_NAME = "Default";
+    public static final String NOTIFICATION_CHANNEL_NAME = "iterable_notification_channel_name";
     public static final String DEFAULT_SOUND            = "default";
     public static final String SOUND_FOLDER_IDENTIFIER  = "raw";
     public static final String ANDROID_RESOURCE_PATH    = "android.resource://";


### PR DESCRIPTION

## 🔹 Jira Ticket(s) if any

* [MOB-5664](https://iterable.atlassian.net/browse/MOB-5664)

## ✏️ Description

> Revert the code where the channel name was derived by reading value from Android Manifest. If not value is found, a default name "iterable channel" is provided. Now, with custom sound, if a soundURI exists from a provided custom sound, only then soundName is treated as a channel name. Otherwise, old way of handling the name still persists.



[MOB-5664]: https://iterable.atlassian.net/browse/MOB-5664?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ