### PR TITLE
[MOB - 5874] - Schedule auth refresh when auth null

### DIFF
--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
@@ -347,8 +347,13 @@ public class IterableApi {
             _email = prefs.getString(IterableConstants.SHARED_PREFS_EMAIL_KEY, null);
             _userId = prefs.getString(IterableConstants.SHARED_PREFS_USERID_KEY, null);
             _authToken = prefs.getString(IterableConstants.SHARED_PREFS_AUTH_TOKEN_KEY, null);
-            if (_authToken != null) {
-                getAuthManager().queueExpirationRefresh(_authToken);
+            if (config.authHandler != null) {
+                if (_authToken != null) {
+                    getAuthManager().queueExpirationRefresh(_authToken);
+                } else {
+                    IterableLogger.d(TAG, "Auth token found as null. Scheduling token refresh in 10 seconds...");
+                    getAuthManager().scheduleAuthTokenRefresh(10000);
+                }
             }
         } catch (Exception e) {
             IterableLogger.e(TAG, "Error while retrieving email/userId/authToken", e);

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableAuthManager.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableAuthManager.java
@@ -49,6 +49,12 @@ public class IterableAuthManager {
                         public void onSuccess(String authToken) {
                             if (authToken != null) {
                                 queueExpirationRefresh(authToken);
+                            } else {
+                                IterableLogger.w(TAG, "Auth token received as null. Calling the handler in 10 seconds");
+                                //TODO: Make this time configurable and in sync with SDK initialization flow for auth null scenario
+                                scheduleAuthTokenRefresh(10000);
+                                authHandler.onTokenRegistrationFailed(new Throwable("Auth token null"));
+                                return;
                             }
                             IterableApi.getInstance().setAuthToken(authToken);
                             pendingAuth = false;
@@ -88,6 +94,9 @@ public class IterableAuthManager {
             }
         } catch (Exception e) {
             IterableLogger.e(TAG, "Error while parsing JWT for the expiration", e);
+            authHandler.onTokenRegistrationFailed(new Throwable("Auth token decode failure. Scheduling auth token refresh in 10 seconds..."));
+            //TODO: Sync with configured time duration once feature is available.
+            scheduleAuthTokenRefresh(10000);
         }
     }
 
@@ -102,7 +111,7 @@ public class IterableAuthManager {
         }
     }
 
-    private void scheduleAuthTokenRefresh(long timeDuration) {
+    void scheduleAuthTokenRefresh(long timeDuration) {
         timer = new Timer(true);
         try {
             timer.schedule(new TimerTask() {


### PR DESCRIPTION
## 🔹 Jira Ticket(s) if any

* [MOB-5874](https://iterable.atlassian.net/browse/MOB-5874)

## ✏️ Description

>Schedule a 10 second auto refresh for auth handler if auth token is found null when initializing. Also, when authHandler receives a authToken from handler in its handler, a similar null check will schedule 10 second refresh throwing a onTokenRegistrationFailure. This callback should allow them to refresh authToken.


[MOB-5874]: https://iterable.atlassian.net/browse/MOB-5874?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ