### PR TITLE
[MOB-5989] remove redundant embedded manager call

### DIFF
--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
@@ -553,15 +553,6 @@ public class IterableApi {
     }
 
     @NonNull
-    public IterableEmbeddedManager getEmbeddedManager() {
-        if (embeddedManager == null) {
-            throw new RuntimeException("IterableApi must be initialized before calling getFlexManager(). " +
-                    "Make sure you call IterableApi#initialize() in Application#onCreate");
-        }
-        return embeddedManager;
-    }
-
-    @NonNull
     public IterableEmbeddedManager embeddedManager() {
         if (embeddedManager == null) {
             throw new RuntimeException("IterableApi must be initialized before calling getFlexManager(). " +

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableEmbeddedManager.kt
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableEmbeddedManager.kt
@@ -238,26 +238,6 @@ public class IterableEmbeddedManager: IterableActivityMonitor.AppStateCallback{
 
     // endregion
 
-    // region basic test methods
-
-    //For testing purpose only
-    fun getMessagesFromJson(): List<IterableEmbeddedMessage> {
-        val file = File("data.json")
-        val bufferedReader = file.bufferedReader()
-        val jsonString = bufferedReader.use { it.readText() }
-        val messageJson = JSONObject(jsonString)
-
-        val embeddedMessages = listOf(
-            IterableEmbeddedMessage.fromJSONObject(messageJson),
-            IterableEmbeddedMessage.fromJSONObject(messageJson),
-            IterableEmbeddedMessage.fromJSONObject(messageJson)
-        )
-
-        return embeddedMessages
-    }
-
-    // endregion
-
     // region IterableActivityMonitor.AppStateCallback
     override fun onSwitchToForeground() {
         IterableLogger.printInfo()


### PR DESCRIPTION
## 🔹 Jira Ticket(s) if any

* [MOB-5989](https://iterable.atlassian.net/browse/MOB-5989)

## ✏️ Description

This pull request removes the redundant embedded manager call from the IterableApi class and removes the test function to get embedded messages from a test JSON response from the embedded manager.


[MOB-5989]: https://iterable.atlassian.net/browse/MOB-5989?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ