### PR TITLE
[MOB-5698] adds data center to config and associated unit tests

### DIFF
--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableConfig.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableConfig.java
@@ -71,6 +71,11 @@ public class IterableConfig {
      */
     final String[] allowedProtocols;
 
+    /**
+     * Data region determining which data center and endpoints are used by the SDK.
+     */
+    final IterableDataRegion dataRegion;
+
     private IterableConfig(Builder builder) {
         pushIntegrationName = builder.pushIntegrationName;
         urlHandler = builder.urlHandler;
@@ -83,6 +88,7 @@ public class IterableConfig {
         authHandler = builder.authHandler;
         expiringAuthTokenRefreshPeriod = builder.expiringAuthTokenRefreshPeriod;
         allowedProtocols = builder.allowedProtocols;
+        dataRegion = builder.dataRegion;
     }
 
     public static class Builder {
@@ -97,6 +103,7 @@ public class IterableConfig {
         private IterableAuthHandler authHandler;
         private long expiringAuthTokenRefreshPeriod = 60000L;
         private String[] allowedProtocols = new String[0];
+        private IterableDataRegion dataRegion = IterableDataRegion.US;
         public Builder() {}
 
         /**
@@ -214,6 +221,16 @@ public class IterableConfig {
         @NonNull
         public Builder setAllowedProtocols(@NonNull String[] allowedProtocols) {
             this.allowedProtocols = allowedProtocols;
+            return this;
+        }
+
+        /**
+         * Set the data region used by the SDK
+         * @param dataRegion enum value that determines which endpoint to use, defaults to IterableDataRegion.US
+         */
+        @NonNull
+        public Builder setDataRegion(@NonNull IterableDataRegion dataRegion) {
+            this.dataRegion = dataRegion;
             return this;
         }
 

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableDataRegion.kt
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableDataRegion.kt
@@ -1,0 +1,6 @@
+package com.iterable.iterableapi
+
+enum class IterableDataRegion(val endpoint: String) {
+    US("https://api.iterable.com/api/"),
+    EU("https://api.eu.iterable.com/api/")
+}

--- a/iterableapi/src/test/java/com/iterable/iterableapi/IterableConfigTest.kt
+++ b/iterableapi/src/test/java/com/iterable/iterableapi/IterableConfigTest.kt
@@ -1,0 +1,25 @@
+package com.iterable.iterableapi
+
+import org.hamcrest.Matchers.`is`
+import org.junit.Assert.*
+import org.junit.Test
+
+class IterableConfigTest {
+
+    @Test
+    fun defaultDataRegion() {
+        val configBuilder: IterableConfig.Builder = IterableConfig.Builder()
+        val config: IterableConfig = configBuilder.build()
+        assertThat(config.dataRegion, `is`(IterableDataRegion.US))
+        assertThat(config.dataRegion.endpoint, `is`("https://api.iterable.com/api/"))
+    }
+
+    @Test
+    fun setDataRegionToEU() {
+        val configBuilder: IterableConfig.Builder = IterableConfig.Builder()
+            .setDataRegion(IterableDataRegion.EU)
+        val config: IterableConfig = configBuilder.build()
+        assertThat(config.dataRegion, `is`(IterableDataRegion.EU))
+        assertThat(config.dataRegion.endpoint, `is`("https://api.eu.iterable.com/api/"))
+    }
+}


### PR DESCRIPTION
## 🔹 Jira Ticket(s) if any

* [MOB-5698](https://iterable.atlassian.net/browse/MOB-5698)

## ✏️ Description

- creates the IterableDataRegion enum which contains the associated endpoint
- adds the dataRegion value to the IterableConfig class and builder
- adds unit tests for testing the IterableConfig builder


[MOB-5698]: https://iterable.atlassian.net/browse/MOB-5698?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
