### PR TITLE
Ensure IterableTrampolineActivity always launched

### DIFF
--- a/iterableapi/src/main/AndroidManifest.xml
+++ b/iterableapi/src/main/AndroidManifest.xml
@@ -25,7 +25,8 @@
         <activity
             android:name=".IterableTrampolineActivity"
             android:exported="false"
-            android:launchMode="singleTop"
+            android:launchMode="singleInstance"
+            android:excludeFromRecents="true"
             android:theme="@style/TrampolineActivity.Transparent"/>
     </application>
 


### PR DESCRIPTION
## ✏️ Description

> Please provide a brief description of what this pull request does.

- Ensure `IterableTrampolineActivity` always launched to handle all notifications
- Reverts back to `launchMode="singleInstance"` to ensure that the activity is always launched
- Use `excludeFromRecents="true"` to ensure that the activity is not shown in the recent apps list

This originates from the current `launchModes` and `Intent` flags for `IterableTrampolineActivity`

When receiving a notification, the Iterable Android SDK builds up an `Intent` and stuffs it inside the notification. This intent is executed upon the user tapping the notification. This intent encapsulates the action to create a new Activity, `IterableTrampolineActivity`.

Without this code change, `IterableTrampolineActivity` will occasionally not be created as described in the linked issues. The `IterableTrampolineActivity` is the activity which handles passing off deep links to our application.

The `IterableTrampolineActivity` has a `launchMode="singleTop"`, which dictates to Android OS to only create a new activity if the activity doesn't exist on the top of our current back stack / task for our app. 

We can ensure `IterableTrampolineActivity` is created every time and thus links handled by having it's `launchMode` set to `singleInstance`. `singleInstance` tells Android OS to create a new activity, in a new task every time. 

This was actually how [Iterable Android SDK had functioned in the past, until someone filed a bug](https://github.com/Iterable/iterable-android-sdk/pull/434/files) that their app would show up twice in the recent apps. 

So to alleviate this issue as well, we simply add the `<activity>` attribute `excludeFromRecents` to tell Android OS to not show this activity in the list of recent apps ([your app tray](https://developer.android.com/guide/components/activities/recents))


https://github.com/Iterable/iterable-android-sdk/issues/470
https://github.com/Iterable/react-native-sdk/issues/394