### PR TITLE
[MOB-6134] - Prepare for 3.5.0-alpha2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 #### Fixed
 - nothing yet
 
+## [3.5.0-alpha2](https://github.com/Iterable/iterable-android-sdk/releases/tag/3.5.0-alpha2)
+
 ## [3.5.0-alpha1](https://github.com/Iterable/iterable-android-sdk/releases/tag/3.5.0-alpha1)
 
 

--- a/iterableapi-ui/build.gradle
+++ b/iterableapi-ui/build.gradle
@@ -48,7 +48,7 @@ ext {
     siteUrl = 'https://github.com/Iterable/iterable-android-sdk'
     gitUrl = 'https://github.com/Iterable/iterable-android-sdk.git'
 
-    libraryVersion = '3.5.0-alpha1'
+    libraryVersion = '3.5.0-alpha2'
 
     developerId = 'davidtruong'
     developerName = 'David Truong'

--- a/iterableapi/build.gradle
+++ b/iterableapi/build.gradle
@@ -11,7 +11,7 @@ android {
         minSdkVersion 16
         targetSdkVersion 27
 
-        buildConfigField "String", "ITERABLE_SDK_VERSION", "\"3.5.0-alpha1\""
+        buildConfigField "String", "ITERABLE_SDK_VERSION", "\"3.5.0-alpha2\""
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -77,7 +77,7 @@ ext {
     siteUrl = 'https://github.com/Iterable/iterable-android-sdk'
     gitUrl = 'https://github.com/Iterable/iterable-android-sdk.git'
 
-    libraryVersion = '3.5.0-alpha1'
+    libraryVersion = '3.5.0-alpha2'
 
     developerId = 'davidtruong'
     developerName = 'David Truong'

--- a/sample-apps/inbox-customization/app/build.gradle
+++ b/sample-apps/inbox-customization/app/build.gradle
@@ -33,8 +33,8 @@ dependencies {
     implementation 'androidx.navigation:navigation-ui-ktx:2.1.0'
     implementation 'com.google.android.material:material:1.1.0'
 
-    implementation 'com.iterable:iterableapi:3.5.0-alpha1'
-    implementation 'com.iterable:iterableapi-ui:3.5.0-alpha1'
+    implementation 'com.iterable:iterableapi:3.5.0-alpha2'
+    implementation 'com.iterable:iterableapi-ui:3.5.0-alpha2'
     implementation 'com.squareup.okhttp3:mockwebserver:4.2.2'
 
     testImplementation 'junit:junit:4.12'


### PR DESCRIPTION
## 🔹 Jira Ticket(s) if any

* [MOB-6134](https://iterable.atlassian.net/browse/MOB-6134)

## ✏️ Description

> Prepare for 3.5.0-alpha2


[MOB-6134]: https://iterable.atlassian.net/browse/MOB-6134?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ