### PR TITLE
[MOB-6135] - Check SDK initialization before API call

### DIFF
--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
@@ -223,6 +223,20 @@ public class IterableApi {
     }
 
     /**
+     * Gets a list of Embedded Messages from Iterable; passes the result to the callback.
+     * To get list of messages as a list of EmbeddedMessages, use
+     * {@link IterableEmbeddedManager#getEmbeddedMessages()} instead
+     *
+     * @param onCallback
+     */
+    void getEmbeddedMessages(@NonNull IterableHelper.IterableActionHandler onCallback) {
+        if (!checkSDKInitialization()) {
+            return;
+        }
+        apiClient.getEmbeddedMessages(onCallback);
+    }
+
+    /**
      * Tracks in-app delivery events (per in-app)
      * @param message the in-app message to be tracked as delivered */
     void trackInAppDelivery(@NonNull IterableInAppMessage message) {

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
@@ -223,8 +223,9 @@ public class IterableApi {
     }
 
     /**
-     * Gets a list of Embedded Messages from Iterable; passes the result to the callback.
-     * To get list of messages as a list of EmbeddedMessages, use
+     * A package-private method to get a list of Embedded Messages from Iterable;
+     * Passes the result to the callback.
+     * To get list of messages as a list of EmbeddedMessages in memory, use
      * {@link IterableEmbeddedManager#getEmbeddedMessages()} instead
      *
      * @param onCallback
@@ -253,7 +254,7 @@ public class IterableApi {
     }
 
     void trackEmbeddedMessageReceived(@NonNull IterableEmbeddedMessage message) {
-        if(!checkSDKInitialization()) {
+        if (!checkSDKInitialization()) {
             return;
         }
 

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableEmbeddedManager.kt
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableEmbeddedManager.kt
@@ -115,7 +115,7 @@ public class IterableEmbeddedManager: IterableActivityMonitor.AppStateCallback{
     private fun syncMessages() {
         IterableLogger.v(TAG, "Syncing messages...")
 
-        IterableApi.sharedInstance.apiClient.getEmbeddedMessages { payload ->
+        IterableApi.sharedInstance.getEmbeddedMessages { payload ->
             IterableLogger.v(TAG, "Got response from network call to get embedded messages")
             if (payload != null && !payload.isEmpty()) {
                 try {


### PR DESCRIPTION
## 🔹 Jira Ticket(s) if any

* [MOB-6135](https://iterable.atlassian.net/browse/MOB-6135)

## ✏️ Description

> Similar implementation to getInAppMessages where SDK initialization is checked before making a call to API


[MOB-6135]: https://iterable.atlassian.net/browse/MOB-6135?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ