### PR TITLE
[MOB-6216] implement impression tracking listeners

### DIFF
--- a/iterableapi/src/main/java/com/iterable/iterableapi/EmbeddedImpressionData.kt
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/EmbeddedImpressionData.kt
@@ -1,0 +1,16 @@
+package com.iterable.iterableapi
+
+import androidx.annotation.RestrictTo
+import java.util.Date
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+data class EmbeddedImpressionData(
+    val messageId: String,
+    var displayCount: Int = 0,
+    var duration: Float = 0.0f,
+    var start: Date? = null
+) {
+    constructor(
+        messageId: String
+    ) : this(messageId, 0, 0.0f, null)
+}

--- a/iterableapi/src/main/java/com/iterable/iterableapi/EmbeddedSessionManager.kt
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/EmbeddedSessionManager.kt
@@ -58,4 +58,15 @@ public class EmbeddedSessionManager {
         )
     }
 
+    fun onMessageImpressionStarted(message: IterableEmbeddedMessage) {
+        IterableLogger.printInfo()
+        val messageId = message.metadata.id
+        IterableLogger.d(TAG, "Impression Started: " + message.elements?.title)
+    }
+
+    fun onMessageImpressionEnded(message: IterableEmbeddedMessage) {
+        IterableLogger.printInfo()
+        val messageId = message.metadata.id
+        IterableLogger.d(TAG, "Impression Ended: " + message.elements?.title)
+    }
 }


### PR DESCRIPTION
## 🔹 Jira Ticket(s) if any

* [MOB-6216](https://iterable.atlassian.net/browse/MOB-6216)

## ✏️ Description

- Implements impression tracking listeners in the embedded session handler
- Associated changes to the tester app have been added and are located on the `embedded-session-tracking` branch
- The SDK currently prints a log statement when impressions start and end
- The next pull request will add the processing for this data


[MOB-6232]: https://iterable.atlassian.net/browse/MOB-6232?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[MOB-6216]: https://iterable.atlassian.net/browse/MOB-6216?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ