### PR TITLE
updates display duration to a double rounded to two decimal places

### DIFF
--- a/iterableapi/src/main/java/com/iterable/iterableapi/EmbeddedImpressionData.kt
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/EmbeddedImpressionData.kt
@@ -7,10 +7,10 @@ import java.util.Date
 data class EmbeddedImpressionData(
     val messageId: String,
     var displayCount: Int = 0,
-    var duration: Float = 0.0f,
+    var duration: Double = 0.00,
     var start: Date? = null
 ) {
     constructor(
         messageId: String
-    ) : this(messageId, 0, 0.0f, null)
+    ) : this(messageId, 0, 0.00, null)
 }

--- a/iterableapi/src/main/java/com/iterable/iterableapi/EmbeddedSessionManager.kt
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/EmbeddedSessionManager.kt
@@ -1,6 +1,7 @@
 package com.iterable.iterableapi
 
 import androidx.annotation.RestrictTo
+import java.lang.Math.round
 import java.util.Date
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -101,7 +102,7 @@ public class EmbeddedSessionManager {
                 IterableEmbeddedImpression(
                     impressionData.messageId,
                     impressionData.displayCount,
-                    impressionData.duration
+                    round(impressionData.duration * 100) / 100.00
                 )
             )
         }
@@ -111,7 +112,8 @@ public class EmbeddedSessionManager {
     private fun updateDisplayCountAndDuration(impressionData: EmbeddedImpressionData): EmbeddedImpressionData {
         if(impressionData.start != null) {
             impressionData.displayCount = impressionData.displayCount?.plus(1)
-            impressionData.duration = impressionData.duration?.plus((Date().time - impressionData.start!!.time) / 1000.0).toFloat()
+            impressionData.duration =
+                impressionData.duration?.plus((Date().time - impressionData.start!!.time) / 1000.0).toDouble()
             impressionData.start = null
         }
         return impressionData

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableEmbeddedSession.kt
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableEmbeddedSession.kt
@@ -23,5 +23,5 @@ public data class IterableEmbeddedSession(
 class IterableEmbeddedImpression(
     val messageId: String,
     val displayCount: Int,
-    val duration: Float
+    val duration: Double
 )


### PR DESCRIPTION
## 🔹 Jira Ticket(s) if any

* [MOB-6436](https://iterable.atlassian.net/browse/MOB-6436)

## ✏️ Description

This pull request updates the display duration for impressions to be rounded to two decimal places. This aligns with the display duration for inbox session tracking.
