### PR TITLE
MOB-5132: Fix deep link issue after app is opened from notification (…

### DIFF
--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableNotificationHelper.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableNotificationHelper.java
@@ -194,7 +194,7 @@ class IterableNotificationHelper {
             trampolineActivityIntent.setClass(context, IterableTrampolineActivity.class);
             trampolineActivityIntent.putExtras(extras);
             trampolineActivityIntent.putExtra(IterableConstants.ITERABLE_DATA_ACTION_IDENTIFIER, IterableConstants.ITERABLE_ACTION_DEFAULT);
-            trampolineActivityIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+            trampolineActivityIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
 
             // Action buttons
             if (notificationData.getActionButtons() != null) {


### PR DESCRIPTION
…#546)

## 🔹 Jira Ticket(s) if any

* [MOB-5132](https://iterable.atlassian.net/browse/MOB-5132)

## ✏️ Description

Resolves a part of 5132 bug where following behavior was noticed: 

> App Killed > Push notification > Tap on notificaiton > App starts for the first time > Minimize the app
> Send a notification with custom action > App starts > No custom action handler is called. 




[MOB-5132]: https://iterable.atlassian.net/browse/MOB-5132?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ