### PR TITLE
[MOB - 6865] - Keychain null crash fix

### DIFF
--- a/iterableapi/build.gradle
+++ b/iterableapi/build.gradle
@@ -42,7 +42,7 @@ dependencies {
     api 'androidx.appcompat:appcompat:1.0.0'
     api 'androidx.annotation:annotation:1.0.0'
     api 'com.google.firebase:firebase-messaging:20.3.0'
-    implementation "androidx.security:security-crypto:1.1.0-alpha04"
+    implementation "androidx.security:security-crypto:1.1.0-alpha06"
 
     testImplementation 'junit:junit:4.12'
     testImplementation 'androidx.test:runner:1.3.0'

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
@@ -135,7 +135,7 @@ public class IterableApi {
         return authManager;
     }
 
-    @NonNull
+    @Nullable
     IterableKeychain getKeychain() {
         if (keychain == null) {
             try {
@@ -350,15 +350,25 @@ public class IterableApi {
     }
 
     private void storeAuthData() {
-        getKeychain().saveEmail(_email);
-        getKeychain().saveUserId(_userId);
-        getKeychain().saveAuthToken(_authToken);
+        IterableKeychain iterableKeychain = getKeychain();
+        if (iterableKeychain != null) {
+            iterableKeychain.saveEmail(_email);
+            iterableKeychain.saveUserId(_userId);
+            iterableKeychain.saveAuthToken(_authToken);
+        } else {
+            IterableLogger.e(TAG, "Shared preference creation failed. ");
+        }
     }
 
     private void retrieveEmailAndUserId() {
-        _email = getKeychain().getEmail();
-        _userId = getKeychain().getUserId();
-        _authToken = getKeychain().getAuthToken();
+        IterableKeychain iterableKeychain = getKeychain();
+        if (iterableKeychain != null) {
+            _email = iterableKeychain.getEmail();
+            _userId = iterableKeychain.getUserId();
+            _authToken = iterableKeychain.getAuthToken();
+        } else {
+            IterableLogger.e(TAG, "retrieveEmailAndUserId: Shared preference creation failed. Could not retrieve email/userId");
+        }
 
         if (config.authHandler != null) {
             if (_authToken != null) {
@@ -368,10 +378,6 @@ public class IterableApi {
                 getAuthManager().scheduleAuthTokenRefresh(10000);
             }
         }
-    }
-
-    private void updateSDKVersion() {
-
     }
 
     private class IterableApiAuthProvider implements IterableApiClient.AuthProvider {
@@ -506,8 +512,6 @@ public class IterableApi {
         if (sharedInstance.config == null) {
             sharedInstance.config = new IterableConfig.Builder().build();
         }
-
-        sharedInstance.updateSDKVersion();
 
         sharedInstance.retrieveEmailAndUserId();
 

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableConfig.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableConfig.java
@@ -237,6 +237,12 @@ public class IterableConfig {
             return this;
         }
 
+        /**
+         * Set whether the SDK should enforce encryption. If set to `true`, the SDK will not use fallback mechanism
+         * of storing data in un-encrypted shared preferences if encrypted database is not available. Set this to `true`
+         * if PII confidentiality is a concern for your app.
+         * @param encryptionEnforced `true` will have the SDK enforce encryption.
+         */
         public Builder setEncryptionEnforced(boolean encryptionEnforced) {
             this.encryptionEnforced = encryptionEnforced;
             return this;

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableKeychain.kt
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableKeychain.kt
@@ -26,7 +26,8 @@ class IterableKeychain {
             encryptionEnabled = false
             sharedPrefs = context.getSharedPreferences(
                 IterableConstants.SHARED_PREFS_FILE,
-                Context.MODE_PRIVATE)
+                Context.MODE_PRIVATE
+            )
             IterableLogger.v(TAG, "SharedPreferences being used")
         } else {
             // See if EncryptedSharedPreferences can be created successfully
@@ -39,7 +40,8 @@ class IterableKeychain {
                     encryptedSharedPrefsFileName,
                     masterKeyAlias,
                     EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
-                    EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM)
+                    EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+                )
                 encryptionEnabled = true
             } catch (e: Exception) {
                 if (encryptionEnforced) {
@@ -49,34 +51,15 @@ class IterableKeychain {
                 } else {
                     sharedPrefs = context.getSharedPreferences(
                         IterableConstants.SHARED_PREFS_FILE,
-                        Context.MODE_PRIVATE)
+                        Context.MODE_PRIVATE
+                    )
                     encryptionEnabled = false
                 }
             }
 
             //Try to migrate data from SharedPreferences to EncryptedSharedPreferences
-            if(encryptionEnabled) {
+            if (encryptionEnabled) {
                 migrateAuthDataFromSharedPrefsToKeychain(context)
-            }
-
-        }
-        val masterKeyAlias = MasterKey.Builder(context)
-            .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
-            .build()
-        sharedPrefs = try {
-            EncryptedSharedPreferences.create(
-                context,
-                encryptedSharedPrefsFileName,
-                masterKeyAlias,
-                EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
-                EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
-            )
-        } catch (e: Exception) {
-            if (encryptionEnforced) {
-                IterableLogger.e(TAG, "Error creating EncryptedSharedPreferences", e)
-                throw e.fillInStackTrace()
-            } else {
-                context.getSharedPreferences(encryptedSharedPrefsFileName, Context.MODE_PRIVATE)
             }
         }
     }
@@ -113,17 +96,20 @@ class IterableKeychain {
 
     @RequiresApi(api = Build.VERSION_CODES.M)
     private fun migrateAuthDataFromSharedPrefsToKeychain(context: Context) {
-        val oldPrefs: SharedPreferences =  context.getSharedPreferences(
+        val oldPrefs: SharedPreferences = context.getSharedPreferences(
             IterableConstants.SHARED_PREFS_FILE,
-            Context.MODE_PRIVATE)
+            Context.MODE_PRIVATE
+        )
         val sharedPrefsEmail = oldPrefs.getString(IterableConstants.SHARED_PREFS_EMAIL_KEY, null)
         val sharedPrefsUserId = oldPrefs.getString(IterableConstants.SHARED_PREFS_USERID_KEY, null)
-        val sharedPrefsAuthToken = oldPrefs.getString(IterableConstants.SHARED_PREFS_AUTH_TOKEN_KEY, null)
+        val sharedPrefsAuthToken =
+            oldPrefs.getString(IterableConstants.SHARED_PREFS_AUTH_TOKEN_KEY, null)
         val editor: SharedPreferences.Editor = oldPrefs.edit()
         if (getEmail() == null && sharedPrefsEmail != null) {
             saveEmail(sharedPrefsEmail)
             editor.remove(IterableConstants.SHARED_PREFS_EMAIL_KEY)
-            IterableLogger.v(TAG,
+            IterableLogger.v(
+                TAG,
                 "UPDATED: migrated email from SharedPreferences to IterableKeychain"
             )
         } else if (sharedPrefsEmail != null) {
@@ -132,7 +118,8 @@ class IterableKeychain {
         if (getUserId() == null && sharedPrefsUserId != null) {
             saveUserId(sharedPrefsUserId)
             editor.remove(IterableConstants.SHARED_PREFS_USERID_KEY)
-            IterableLogger.v(TAG,
+            IterableLogger.v(
+                TAG,
                 "UPDATED: migrated userId from SharedPreferences to IterableKeychain"
             )
         } else if (sharedPrefsUserId != null) {
@@ -141,7 +128,8 @@ class IterableKeychain {
         if (getAuthToken() == null && sharedPrefsAuthToken != null) {
             saveAuthToken(sharedPrefsAuthToken)
             editor.remove(IterableConstants.SHARED_PREFS_AUTH_TOKEN_KEY)
-            IterableLogger.v(TAG,
+            IterableLogger.v(
+                TAG,
                 "UPDATED: migrated authToken from SharedPreferences to IterableKeychain"
             )
         } else if (sharedPrefsAuthToken != null) {

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableKeychain.kt
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableKeychain.kt
@@ -43,15 +43,30 @@ class IterableKeychain {
                     EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
                 )
                 encryptionEnabled = true
-            } catch (e: Exception) {
+            } catch (e: Throwable) {
+                if (e is Error) {
+                    IterableLogger.e(
+                        TAG,
+                        "EncryptionSharedPreference creation failed with Error. Attempting to continue"
+                    )
+                }
+
                 if (encryptionEnforced) {
-                    //TODO: In memory Or similar solution needs to be implemented in future.
-                    IterableLogger.e(TAG, "Error creating EncryptedSharedPreferences", e)
+                    //TODO: In-memory or similar solution needs to be implemented in the future.
+                    IterableLogger.w(
+                        TAG,
+                        "Encryption is enforced. PII will not be persisted due to EncryptionSharedPreference failure. Email/UserId and Auth token will have to be passed for every app session.",
+                        e
+                    )
                     throw e.fillInStackTrace()
                 } else {
                     sharedPrefs = context.getSharedPreferences(
                         IterableConstants.SHARED_PREFS_FILE,
                         Context.MODE_PRIVATE
+                    )
+                    IterableLogger.w(
+                        TAG,
+                        "Using SharedPreference as EncryptionSharedPreference creation failed."
                     )
                     encryptionEnabled = false
                 }


### PR DESCRIPTION
## 🔹 Jira Ticket(s) if any

* [MOB-6865](https://iterable.atlassian.net/browse/MOB-6865)

## ✏️ Description

- Handles condition where IterableKeychain creation returns null to Iterable API. SDK will continue to process without crashing.
There will be no email fetched from sharedPreferences in this rare case. No email will be persisted and the app will have to setEmail/setUserId on every app session for it to have email in memory than having it persisted for consequent app sessions

- Fixed indentation on IterableKeychain file. Using cmd+l on Android Studio

- Added method description in IterableConfig class so developers have more context on what `setEncryptionEnforced` means

- getKeychain is now annotated @nullable for future kotlin migration purpose

Fixes - #616 
Fixes - #631 


[MOB-6865]: https://iterable.atlassian.net/browse/MOB-6865?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ