### PR TITLE
Catching Error along with Exception

### DIFF
--- a/iterableapi/build.gradle
+++ b/iterableapi/build.gradle
@@ -42,7 +42,7 @@ dependencies {
     api 'androidx.appcompat:appcompat:1.0.0'
     api 'androidx.annotation:annotation:1.0.0'
     api 'com.google.firebase:firebase-messaging:20.3.0'
-    implementation "androidx.security:security-crypto:1.1.0-alpha04"
+    implementation "androidx.security:security-crypto:1.1.0-alpha06"
 
     testImplementation 'junit:junit:4.12'
     testImplementation 'androidx.test:runner:1.3.0'

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableKeychain.kt
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableKeychain.kt
@@ -43,15 +43,30 @@ class IterableKeychain {
                     EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
                 )
                 encryptionEnabled = true
-            } catch (e: Exception) {
+            } catch (e: Throwable) {
+                if (e is Error) {
+                    IterableLogger.e(
+                        TAG,
+                        "EncryptionSharedPreference creation failed with Error. Attempting to continue"
+                    )
+                }
+
                 if (encryptionEnforced) {
-                    //TODO: In memory Or similar solution needs to be implemented in future.
-                    IterableLogger.e(TAG, "Error creating EncryptedSharedPreferences", e)
+                    //TODO: In-memory or similar solution needs to be implemented in the future.
+                    IterableLogger.w(
+                        TAG,
+                        "Encryption is enforced. PII will not be persisted due to EncryptionSharedPreference failure. Email/UserId and Auth token will have to be passed for every app session.",
+                        e
+                    )
                     throw e.fillInStackTrace()
                 } else {
                     sharedPrefs = context.getSharedPreferences(
                         IterableConstants.SHARED_PREFS_FILE,
                         Context.MODE_PRIVATE
+                    )
+                    IterableLogger.w(
+                        TAG,
+                        "Using SharedPreference as EncryptionSharedPreference creation failed."
                     )
                     encryptionEnabled = false
                 }


### PR DESCRIPTION
## 🔹 Jira Ticket(s) if any

Continuation on 6865. Add on changes

## ✏️ Description

1. Checking for Throwable which will collect both Exception and Error if at all Security library is crashing with a Error and not exception.
2. Updating the dependency to use latest alpha version. Alpha version 5 also seems to fix race condition during creation process. Reference - https://developer.android.com/jetpack/androidx/releases/security#1.1.0-alpha05
3. Added some warning logs if this situation arrives so developers can take some action if it occurs during debugging
