### PR TITLE
[Feature] Allow merge user profiles on update email call.

### DIFF
--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
@@ -925,25 +925,72 @@ public class IterableApi {
      * @param newEmail New email
      */
     public void updateEmail(final @NonNull String newEmail) {
-        updateEmail(newEmail, null, null, null);
+        updateEmail(newEmail, null, null, null, null);
     }
 
+    /**
+     * Updates the current user's email.
+     * Also updates the current email in this IterableAPI instance if the API call was successful.
+     * @param newEmail New email
+     * @param merge Merge user profiles in email-based projects if set.
+     */
+    public void updateEmail(final @NonNull String newEmail, final @Nullable Boolean merge) {
+        updateEmail(newEmail, merge, null, null, null);
+    }
+
+    /**
+     * Updates the current user's email.
+     * Also updates the current email in this IterableAPI instance if the API call was successful.
+     * @param newEmail New email
+     * @param authToken Authentication token
+     */
     public void updateEmail(final @NonNull String newEmail, final @NonNull String authToken) {
-        updateEmail(newEmail, authToken, null, null);
+        updateEmail(newEmail, null, authToken, null, null);
     }
 
+    /**
+     * Updates the current user's email.
+     * Also updates the current email in this IterableAPI instance if the API call was successful.
+     * @param newEmail New email
+     * @param merge Merge user profiles in email-based projects if set.
+     * @param authToken Authentication token
+     */
+    public void updateEmail(final @NonNull String newEmail, final @Nullable Boolean merge, final @NonNull String authToken) {
+        updateEmail(newEmail, merge, authToken, null, null);
+    }
+
+    /**
+     * Updates the current user's email.
+     * Also updates the current email in this IterableAPI instance if the API call was successful.
+     * @param newEmail New email
+     * @param successHandler Success handler. Called when the server returns a success code.
+     * @param failureHandler Failure handler. Called when the server call failed.
+     */
     public void updateEmail(final @NonNull String newEmail, final @Nullable IterableHelper.SuccessHandler successHandler, @Nullable IterableHelper.FailureHandler failureHandler) {
-        updateEmail(newEmail, null, successHandler, failureHandler);
+        updateEmail(newEmail, null, null, successHandler, failureHandler);
+    }
+
+    /**
+     * Updates the current user's email.
+     * Also updates the current email in this IterableAPI instance if the API call was successful.
+     * @param newEmail New email
+     * @param merge Merge user profiles in email-based projects if set.
+     * @param successHandler Success handler. Called when the server returns a success code.
+     * @param failureHandler Failure handler. Called when the server call failed.
+     */
+    public void updateEmail(final @NonNull String newEmail, final @Nullable Boolean merge, final @Nullable IterableHelper.SuccessHandler successHandler, @Nullable IterableHelper.FailureHandler failureHandler) {
+        updateEmail(newEmail, merge, null, successHandler, failureHandler);
     }
 
     /**
      * Updates the current user's email.
      * Also updates the current email and authToken in this IterableAPI instance if the API call was successful.
      * @param newEmail New email
+     * @param merge Optional. Merge user profiles in email-based projects if set.
      * @param successHandler Success handler. Called when the server returns a success code.
      * @param failureHandler Failure handler. Called when the server call failed.
      */
-    public void updateEmail(final @NonNull String newEmail, final @Nullable String authToken, final @Nullable IterableHelper.SuccessHandler successHandler, @Nullable IterableHelper.FailureHandler failureHandler) {
+    public void updateEmail(final @NonNull String newEmail, final @Nullable Boolean merge, final @Nullable String authToken, final @Nullable IterableHelper.SuccessHandler successHandler, @Nullable IterableHelper.FailureHandler failureHandler) {
         if (!checkSDKInitialization()) {
             IterableLogger.e(TAG, "The Iterable SDK must be initialized with email or userId before " +
                     "calling updateEmail");
@@ -955,7 +1002,7 @@ public class IterableApi {
             return;
         }
 
-        apiClient.updateEmail(newEmail, new IterableHelper.SuccessHandler() {
+        apiClient.updateEmail(newEmail, merge, new IterableHelper.SuccessHandler() {
             @Override
             public void onSuccess(@NonNull JSONObject data) {
                 if (_email != null) {

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableApiClient.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableApiClient.java
@@ -142,7 +142,7 @@ class IterableApiClient {
         }
     }
 
-    public void updateEmail(final @NonNull String newEmail, final @Nullable IterableHelper.SuccessHandler successHandler, @Nullable IterableHelper.FailureHandler failureHandler) {
+    public void updateEmail(final @NonNull String newEmail, final @Nullable Boolean merge, final @Nullable IterableHelper.SuccessHandler successHandler, @Nullable IterableHelper.FailureHandler failureHandler) {
         JSONObject requestJSON = new JSONObject();
 
         try {
@@ -151,7 +151,12 @@ class IterableApiClient {
             } else {
                 requestJSON.put(IterableConstants.KEY_CURRENT_USERID, authProvider.getUserId());
             }
+
             requestJSON.put(IterableConstants.KEY_NEW_EMAIL, newEmail);
+
+            if (merge != null) {
+                requestJSON.put(IterableConstants.KEY_MERGE, merge);
+            }
 
             sendPostRequest(IterableConstants.ENDPOINT_UPDATE_EMAIL, requestJSON, successHandler, failureHandler);
         } catch (JSONException e) {

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableConstants.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableConstants.java
@@ -34,6 +34,7 @@ public final class IterableConstants {
     public static final String KEY_EVENT_NAME           = "eventName";
     public static final String KEY_ITEMS                = "items";
     public static final String KEY_NEW_EMAIL            = "newEmail";
+    public static final String KEY_MERGE                = "merge";
     public static final String KEY_PACKAGE_NAME         = "packageName";
     public static final String KEY_PLATFORM             = "platform";
     public static final String KEY_PREFER_USER_ID       = "preferUserId";

--- a/iterableapi/src/test/java/com/iterable/iterableapi/IterableApiAuthTests.java
+++ b/iterableapi/src/test/java/com/iterable/iterableapi/IterableApiAuthTests.java
@@ -371,7 +371,7 @@ public class IterableApiAuthTests extends BaseTest {
 //        assertEquals(HEADER_SDK_AUTH_FORMAT + expiredJWT, getMessagesAuthenticatedRequest2.getHeader("Authorization"));
 
         doReturn(validJWT).when(authHandler).onAuthTokenRequested();
-        IterableApi.getInstance().updateEmail("newEmail@gmail.com", null, null);
+        IterableApi.getInstance().updateEmail("newEmail@gmail.com", null, null, null);
         shadowOf(getMainLooper()).runToEndOfTasks();
         shadowOf(getMainLooper()).idle();
         RecordedRequest updateEmailRequest = server.takeRequest(1, TimeUnit.SECONDS);

--- a/iterableapi/src/test/java/com/iterable/iterableapi/IterableApiTest.java
+++ b/iterableapi/src/test/java/com/iterable/iterableapi/IterableApiTest.java
@@ -155,7 +155,7 @@ public class IterableApiTest extends BaseTest {
 
         IterableApi.getInstance().updateEmail(newEmail);
         shadowOf(getMainLooper()).idle();
-        verify(mockApiClient).updateEmail(eq(newEmail), nullable(IterableHelper.SuccessHandler.class), nullable(IterableHelper.FailureHandler.class));
+        verify(mockApiClient).updateEmail(eq(newEmail), nullable(Boolean.class), nullable(IterableHelper.SuccessHandler.class), nullable(IterableHelper.FailureHandler.class));
         server.takeRequest(1, TimeUnit.SECONDS);
         assertEquals("new@email.com", IterableApi.getInstance().getEmail());
 
@@ -213,6 +213,23 @@ public class IterableApiTest extends BaseTest {
         JSONObject requestJson = new JSONObject(updateEmailRequest.getBody().readUtf8());
         assertEquals("test@email.com", requestJson.getString(IterableConstants.KEY_CURRENT_EMAIL));
         assertEquals("new@email.com", requestJson.getString(IterableConstants.KEY_NEW_EMAIL));
+        assertFalse(requestJson.has(IterableConstants.KEY_MERGE));
+    }
+
+    @Test
+    public void testUpdateEmailWithMergeUserProfiles() throws Exception {
+        server.enqueue(new MockResponse().setResponseCode(200).setBody("{}"));
+        IterableApi.initialize(getContext(), "apiKey");
+        IterableApi.getInstance().setEmail("test@email.com");
+        IterableApi.getInstance().updateEmail("new@email.com", true);
+
+        RecordedRequest updateEmailRequest = server.takeRequest(1, TimeUnit.SECONDS);
+        assertNotNull(updateEmailRequest);
+        assertEquals("/" + IterableConstants.ENDPOINT_UPDATE_EMAIL, updateEmailRequest.getPath());
+        JSONObject requestJson = new JSONObject(updateEmailRequest.getBody().readUtf8());
+        assertEquals("test@email.com", requestJson.getString(IterableConstants.KEY_CURRENT_EMAIL));
+        assertEquals("new@email.com", requestJson.getString(IterableConstants.KEY_NEW_EMAIL));
+        assertTrue(requestJson.getBoolean(IterableConstants.KEY_MERGE));
     }
 
     @Test
@@ -230,6 +247,7 @@ public class IterableApiTest extends BaseTest {
         assertEquals("new@email.com", requestJson.getString(IterableConstants.KEY_NEW_EMAIL));
         assertNull(IterableApi.getInstance().getEmail());
         assertEquals("testUserId", IterableApi.getInstance().getUserId());
+        assertFalse(requestJson.has(IterableConstants.KEY_MERGE));
     }
 
     @Ignore


### PR DESCRIPTION
Add support to allow merge user profile when updating the user email. Add and update test coverage.

## 🔹 Jira Ticket(s) if any

> None: add support for an endpoint parameter based on ongoing Iterable implementation

## ✏️ Description

> Add support to allow merge user profile when updating the user email.
> Add and update test coverage.
