### PR TITLE
[MOB-7646] clean up of processing logic for new diff payload

### DIFF
--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableApiClient.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableApiClient.java
@@ -248,7 +248,7 @@ class IterableApiClient {
         }
     }
 
-    void getEmbeddedMessages(@Nullable List<String> messageIds, @Nullable List<Long> placementIds, @NonNull IterableHelper.SuccessHandler onSuccess, @NonNull IterableHelper.FailureHandler onFailure) {
+    void getEmbeddedMessages(@Nullable List<String> currentMessageIds, @Nullable List<Long> placementIds, @NonNull IterableHelper.SuccessHandler onSuccess, @NonNull IterableHelper.FailureHandler onFailure) {
         JSONObject requestJSON = new JSONObject();
 
         try {
@@ -258,9 +258,10 @@ class IterableApiClient {
             requestJSON.put(IterableConstants.ITBL_SYSTEM_VERSION, Build.VERSION.RELEASE);
             requestJSON.put(IterableConstants.KEY_PACKAGE_NAME, authProvider.getContext().getPackageName());
 
-            SharedPreferences sharedPreferences = IterableApi.sharedInstance.getMainActivityContext().getSharedPreferences(IterableConstants.SHARED_PREFS_FILE, Context.MODE_PRIVATE);
-            Set<String> retrievedIdsSet = sharedPreferences.getStringSet(IterableConstants.SHARED_PREFS_CURRENT_EMBEDDED_MSGS, new HashSet<>());
-            String[] currentMessageIds = retrievedIdsSet.toArray(new String[0]);
+//            SharedPreferences sharedPreferences = IterableApi.sharedInstance.getMainActivityContext().getSharedPreferences(IterableConstants.SHARED_PREFS_FILE, Context.MODE_PRIVATE);
+//            Set<String> retrievedIdsSet = sharedPreferences.getStringSet(IterableConstants.SHARED_PREFS_CURRENT_EMBEDDED_MSGS, new HashSet<>());
+//            String[] currentMessageIds = retrievedIdsSet.toArray(new String[0]);
+
             StringBuilder pathBuilder = new StringBuilder(IterableConstants.ENDPOINT_GET_EMBEDDED_MESSAGES + "?");
 
             if (placementIds != null) {
@@ -269,7 +270,7 @@ class IterableApiClient {
                 }
             }
 
-            if (currentMessageIds.length > 0) {
+            if (currentMessageIds != null && !currentMessageIds.isEmpty()) {
                 for (String currentMessageId : currentMessageIds) {
                     pathBuilder.append("&currentMessageIds=").append(currentMessageId);
                 }

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableApiClient.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableApiClient.java
@@ -258,17 +258,21 @@ class IterableApiClient {
             requestJSON.put(IterableConstants.ITBL_SYSTEM_VERSION, Build.VERSION.RELEASE);
             requestJSON.put(IterableConstants.KEY_PACKAGE_NAME, authProvider.getContext().getPackageName());
 
-            StringBuilder pathBuilder = new StringBuilder(IterableConstants.ENDPOINT_GET_EMBEDDED_MESSAGES + "?");
+            StringBuilder pathBuilder = new StringBuilder(IterableConstants.ENDPOINT_GET_EMBEDDED_MESSAGES);
 
-            if (placementIds != null) {
-                for (Long placementId : placementIds) {
-                    pathBuilder.append("&placementIds=").append(placementId);
+            if(placementIds != null || (currentMessageIds != null && !currentMessageIds.isEmpty())) {
+                pathBuilder.append("?");
+
+                if (placementIds != null) {
+                    for (Long placementId : placementIds) {
+                        pathBuilder.append("&placementIds=").append(placementId);
+                    }
                 }
-            }
 
-            if (currentMessageIds != null && !currentMessageIds.isEmpty()) {
-                for (String currentMessageId : currentMessageIds) {
-                    pathBuilder.append("&currentMessageIds=").append(currentMessageId);
+                if (currentMessageIds != null && !currentMessageIds.isEmpty()) {
+                    for (String currentMessageId : currentMessageIds) {
+                        pathBuilder.append("&currentMessageIds=").append(currentMessageId);
+                    }
                 }
             }
 

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableApiClient.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableApiClient.java
@@ -258,10 +258,6 @@ class IterableApiClient {
             requestJSON.put(IterableConstants.ITBL_SYSTEM_VERSION, Build.VERSION.RELEASE);
             requestJSON.put(IterableConstants.KEY_PACKAGE_NAME, authProvider.getContext().getPackageName());
 
-//            SharedPreferences sharedPreferences = IterableApi.sharedInstance.getMainActivityContext().getSharedPreferences(IterableConstants.SHARED_PREFS_FILE, Context.MODE_PRIVATE);
-//            Set<String> retrievedIdsSet = sharedPreferences.getStringSet(IterableConstants.SHARED_PREFS_CURRENT_EMBEDDED_MSGS, new HashSet<>());
-//            String[] currentMessageIds = retrievedIdsSet.toArray(new String[0]);
-
             StringBuilder pathBuilder = new StringBuilder(IterableConstants.ENDPOINT_GET_EMBEDDED_MESSAGES + "?");
 
             if (placementIds != null) {

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableEmbeddedManager.kt
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableEmbeddedManager.kt
@@ -13,7 +13,6 @@ public class IterableEmbeddedManager : IterableActivityMonitor.AppStateCallback 
 
     // region variables
     private var localPlacementMessagesMap = mutableMapOf<Long, MutableList<IterableEmbeddedMessage>>()
-    private var messageIdsMap = mutableMapOf<Long, MutableList<IterableEmbeddedMessage>>()
 
     private var placementIds = mutableListOf<Long>()
     private var messageIds = mutableListOf<String>()
@@ -25,7 +24,6 @@ public class IterableEmbeddedManager : IterableActivityMonitor.AppStateCallback 
     private var embeddedSessionManager = EmbeddedSessionManager()
 
     private var activityMonitor: IterableActivityMonitor? = null
-    //private var currentMessageIds: Array<String>  = arrayOf()
 
     // endregion
 
@@ -233,11 +231,6 @@ public class IterableEmbeddedManager : IterableActivityMonitor.AppStateCallback 
             }
         }
 
-//        val sharedPref = IterableApi.sharedInstance.mainActivityContext.getSharedPreferences(IterableConstants.SHARED_PREFS_FILE, Context.MODE_PRIVATE)
-//        val editor = sharedPref.edit()
-//        editor.putStringSet(IterableConstants.SHARED_PREFS_CURRENT_EMBEDDED_MSGS, currentMessageIds.toSet())
-//        editor.apply()
-
         // Compare the local list to remote list
         // if there are messages to remove, trigger a message update in UI
         val remoteMessageMap = mutableMapOf<String, IterableEmbeddedMessage>()
@@ -245,12 +238,14 @@ public class IterableEmbeddedManager : IterableActivityMonitor.AppStateCallback 
             remoteMessageMap[it.metadata.messageId] = it
         }
 
+        //iterate through current messages and remove the messages that are not in the remote list
         val iterator = localMessages?.iterator()
         while (iterator?.hasNext() == true) {
             val embeddedMessage = iterator.next()
             if (!remoteMessageMap.containsKey(embeddedMessage.metadata.messageId)) {
                 localMessagesChanged = true
                 iterator.remove()
+                //remove from local messages to allow message payload to be re-fetched
                 localMessages?.remove(embeddedMessage)
             }
         }

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableEmbeddedManager.kt
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableEmbeddedManager.kt
@@ -13,6 +13,8 @@ public class IterableEmbeddedManager : IterableActivityMonitor.AppStateCallback 
 
     // region variables
     private var localPlacementMessagesMap = mutableMapOf<Long, MutableList<IterableEmbeddedMessage>>()
+    private var messageIdsMap = mutableMapOf<Long, MutableList<IterableEmbeddedMessage>>()
+
     private var placementIds = mutableListOf<Long>()
     private var messageIds = mutableListOf<String>()
 
@@ -23,7 +25,7 @@ public class IterableEmbeddedManager : IterableActivityMonitor.AppStateCallback 
     private var embeddedSessionManager = EmbeddedSessionManager()
 
     private var activityMonitor: IterableActivityMonitor? = null
-    private var currentMessageIds: Array<String>  = arrayOf()
+    //private var currentMessageIds: Array<String>  = arrayOf()
 
     // endregion
 
@@ -74,6 +76,7 @@ public class IterableEmbeddedManager : IterableActivityMonitor.AppStateCallback 
 
     fun reset() {
         localPlacementMessagesMap = mutableMapOf()
+        messageIds = mutableListOf<String>()
     }
 
     fun getPlacementIds(): List<Long> {
@@ -248,6 +251,7 @@ public class IterableEmbeddedManager : IterableActivityMonitor.AppStateCallback 
             if (!remoteMessageMap.containsKey(embeddedMessage.metadata.messageId)) {
                 localMessagesChanged = true
                 iterator.remove()
+                localMessages?.remove(embeddedMessage)
             }
         }
 

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableFirebaseMessagingService.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableFirebaseMessagingService.java
@@ -81,7 +81,7 @@ public class IterableFirebaseMessagingService extends FirebaseMessagingService {
                         }
                         break;
                     case "UpdateEmbedded":
-                        IterableApi.getInstance().getEmbeddedManager().syncMessages();
+c                         IterableApi.getInstance().getEmbeddedManager().syncMessages();
                         break;
                     default:
                         break;

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableFirebaseMessagingService.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableFirebaseMessagingService.java
@@ -81,7 +81,7 @@ public class IterableFirebaseMessagingService extends FirebaseMessagingService {
                         }
                         break;
                     case "UpdateEmbedded":
-c                         IterableApi.getInstance().getEmbeddedManager().syncMessages();
+                         IterableApi.getInstance().getEmbeddedManager().syncMessages();
                         break;
                     default:
                         break;


### PR DESCRIPTION
## 🔹 Jira Ticket(s) if any

* [MOB-7646](https://iterable.atlassian.net/browse/MOB-7646)

## ✏️ Description

> This pull request adds logic to properly modify the local message list stored in the map based on the new payload. It also stores the current messages in a local list that is updated when messages are removed. The local message id list is also reset when the placements payload is empty. The use of shared preferences was removed since we want the full payload to be processed on every new app session. This was causing issues. 

I will need to add associated unit tests for the added logic which I will add on a separate PR due to time constraints.


[MOB-7646]: https://iterable.atlassian.net/browse/MOB-7646?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ