### PR TITLE
Full qualified name for style resource

### DIFF
--- a/iterableapi-ui/build.gradle
+++ b/iterableapi-ui/build.gradle
@@ -7,7 +7,7 @@ android {
     namespace 'com.iterable.iterableapi.ui'
 
     defaultConfig {
-        minSdkVersion 15
+        minSdkVersion 16
         targetSdkVersion 28
         vectorDrawables.useSupportLibrary = true
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableInAppFragmentHTMLNotification.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableInAppFragmentHTMLNotification.java
@@ -104,7 +104,7 @@ public class IterableInAppFragmentHTMLNotification extends DialogFragment implem
         this.backgroundAlpha = 0;
         this.messageId = "";
         insetPadding = new Rect();
-        this.setStyle(DialogFragment.STYLE_NO_FRAME, R.style.Theme_AppCompat_NoActionBar);
+        this.setStyle(DialogFragment.STYLE_NO_FRAME, androidx.appcompat.R.style.Theme_AppCompat_NoActionBar);
     }
 
     @Override


### PR DESCRIPTION

## 🔹 Jira Ticket(s) if any

* [MOB-?](https://iterable.atlassian.net/browse/MOB-?)

## ✏️ Description

> Fiterable app was throwing error as resource not found. Making the resource with full name is making it work. Probably would be helpful in all projects having such conflicts in finding the resource. Also bumping up the minSdkversion in api-ui
