### PR TITLE
[MOB-6832] - AuthDecode crash fix

### DIFF
--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableAuthManager.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableAuthManager.java
@@ -158,7 +158,7 @@ public class IterableAuthManager {
             String[] split = encodedJWT.split("\\.");
             //Check if jwt is valid
             if (split.length != 3) {
-                throw new Exception("Invalid JWT");
+                throw new IllegalArgumentException("Invalid JWT");
             }
             String body = getJson(split[1]);
             JSONObject jObj = new JSONObject(body);

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableAuthManager.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableAuthManager.java
@@ -156,6 +156,10 @@ public class IterableAuthManager {
     private static long decodedExpiration(String encodedJWT) throws Exception {
         long exp = 0;
             String[] split = encodedJWT.split("\\.");
+            //Check if jwt is valid
+            if (split.length != 3) {
+                throw new Exception("Invalid JWT");
+            }
             String body = getJson(split[1]);
             JSONObject jObj = new JSONObject(body);
             exp = jObj.getLong(expirationString);


### PR DESCRIPTION
## 🔹 Jira Ticket(s) if any

* [MOB-6832](https://iterable.atlassian.net/browse/MOB-6832)

## ✏️ Description

> Prevents crash by checking if the three components of auth token are present before decoding the expiration time. If not the SDK will throw an Exception continuing with retry mechanism and invoking failure callbacks.


[MOB-6832]: https://iterable.atlassian.net/browse/MOB-6832?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ