### PR TITLE
[MOB-6035] upgrades Glide library to latest stable version

### DIFF
--- a/iterableapi-ui/build.gradle
+++ b/iterableapi-ui/build.gradle
@@ -40,7 +40,7 @@ dependencies {
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     implementation 'com.google.android.flexbox:flexbox:3.0.0'
     implementation 'androidx.cardview:cardview:1.0.0'
-    implementation "com.github.bumptech.glide:glide:4.8.0"
+    implementation "com.github.bumptech.glide:glide:4.16.0"
     implementation 'com.google.android.material:material:1.2.0'
 
     testImplementation 'junit:junit:4.13.2'


### PR DESCRIPTION
## 🔹 Jira Ticket(s) if any

* [MOB-6035](https://iterable.atlassian.net/browse/MOB-6035)

## ✏️ Description

This pull request updates the Glide library to the latest stable release [4.16.0](https://github.com/bumptech/glide/releases/tag/v4.16.0).


[MOB-6035]: https://iterable.atlassian.net/browse/MOB-6035?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ