### PR TITLE
[MOB-8948] sets anonymous user

### DIFF
--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
@@ -780,22 +780,23 @@ public class IterableApi {
 
     public void setAnonUser(@Nullable String userId) {
         _userIdAnon = userId;
+        setUserId(userId, null, null, null, true);
         storeAuthData();
     }
 
     public void setUserId(@Nullable String userId) {
-        setUserId(userId, null, null, null);
+        setUserId(userId, null, null, null, false);
     }
 
     public void setUserId(@Nullable String userId, @Nullable IterableHelper.SuccessHandler successHandler, @Nullable IterableHelper.FailureHandler failureHandler) {
-        setUserId(userId, null, successHandler, failureHandler);
+        setUserId(userId, null, successHandler, failureHandler, false);
     }
 
     public void setUserId(@Nullable String userId, @Nullable String authToken) {
-        setUserId(userId, authToken, null, null);
+        setUserId(userId, authToken, null, null, false);
     }
 
-    public void setUserId(@Nullable String userId, @Nullable String authToken, @Nullable IterableHelper.SuccessHandler successHandler, @Nullable IterableHelper.FailureHandler failureHandler) {
+    public void setUserId(@Nullable String userId, @Nullable String authToken, @Nullable IterableHelper.SuccessHandler successHandler, @Nullable IterableHelper.FailureHandler failureHandler, @Nullable Boolean isAnon) {
         anonymousUserMerge.tryMergeUser(apiClient, _userIdAnon, userId, false, (mergeResult, error) -> {
                 if (mergeResult == IterableConstants.MERGE_SUCCESSFUL || mergeResult == IterableConstants.MERGE_NOTREQUIRED) {
                     //If same non null userId is passed
@@ -811,7 +812,11 @@ public class IterableApi {
                     }
 
                     logoutPreviousUser();
-                    _userIdAnon = null;
+
+                    if (!isAnon) {
+                        _userIdAnon = null;
+                    }
+
                     _email = null;
                     _userId = userId;
                     anonymousUserManager.syncEvents();

--- a/iterableapi/src/test/java/com/iterable/iterableapi/IterableApiTest.java
+++ b/iterableapi/src/test/java/com/iterable/iterableapi/IterableApiTest.java
@@ -200,7 +200,7 @@ public class IterableApiTest extends BaseTest {
             public void onFailure(@NonNull String reason, @Nullable JSONObject data) {
                 assertTrue(false); // callback should be called with failure
             }
-        });
+        }, false);
     }
 
     @Test


### PR DESCRIPTION
## 🔹 Jira Ticket(s) if any

* [MOB-8948](https://iterable.atlassian.net/browse/MOB-8948)

## ✏️ Description

> This pull request introduces a flag that indicates if a user is anonymous which determines if stored user id is cleared or not .

[MOB-8946]: https://iterable.atlassian.net/browse/MOB-8946?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[MOB-8948]: https://iterable.atlassian.net/browse/MOB-8948?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ