### PR TITLE
[MOB-9078] - Reset timer when logging out

### DIFF
--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableAuthManager.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableAuthManager.java
@@ -248,6 +248,7 @@ public class IterableAuthManager {
         if (timer != null) {
             timer.cancel();
             timer = null;
+            isTimerScheduled = false;
         }
     }
 }


### PR DESCRIPTION
## 🔹 Jira Ticket(s) if any

* [MOB-9078](https://iterable.atlassian.net/browse/MOB-9078)

## ✏️ Description

> Reset timer and flags completely when logging out. Looks like the timers were cleared but the flag was still not flipped back to `false`.
 
Fixes #757

[MOB-9078]: https://iterable.atlassian.net/browse/MOB-9078?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ