### PR TITLE
[MOB-9280] set anonymous user

### DIFF
--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
@@ -850,8 +850,6 @@ public class IterableApi {
             sourceEmail = _email;
         }
 
-        _userId = userId;
-
         anonymousUserMerge.tryMergeUser(apiClient, sourceUserId, sourceEmail, userId, false, merge, shouldUseDefaultMerge, (mergeResult, error) -> {
             if (mergeResult == IterableConstants.MERGE_SUCCESSFUL || mergeResult == IterableConstants.MERGE_NOTREQUIRED) {
                 // If the same non-null userId is passed

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
@@ -850,6 +850,18 @@ public class IterableApi {
             sourceEmail = _email;
         }
 
+        anonymousUserMerge.tryMergeUser(apiClient, sourceUserId, sourceEmail, userId, false, merge, shouldUseDefaultMerge, (mergeResult, error) -> {
+            if (mergeResult == IterableConstants.MERGE_SUCCESSFUL || mergeResult == IterableConstants.MERGE_NOTREQUIRED) {
+                if (shouldUseDefaultMerge || merge) {
+                    anonymousUserManager.syncEvents();
+                }
+            } else {
+                if (failureHandler != null) {
+                    failureHandler.onFailure(error, null);
+                }
+            }
+        });
+
         if (_userId != null && _userId.equals(userId)) {
             checkAndUpdateAuthToken(authToken);
             return;
@@ -876,18 +888,6 @@ public class IterableApi {
         _setUserFailureCallbackHandler = failureHandler;
         storeAuthData();
         onLogin(authToken);
-
-        anonymousUserMerge.tryMergeUser(apiClient, sourceUserId, sourceEmail, userId, false, merge, shouldUseDefaultMerge, (mergeResult, error) -> {
-            if (mergeResult == IterableConstants.MERGE_SUCCESSFUL || mergeResult == IterableConstants.MERGE_NOTREQUIRED) {
-                if (shouldUseDefaultMerge || merge) {
-                    anonymousUserManager.syncEvents();
-                }
-            } else {
-                if (failureHandler != null) {
-                    failureHandler.onFailure(error, null);
-                }
-            }
-        });
     }
 
     public void setAuthToken(String authToken) {

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
@@ -850,6 +850,8 @@ public class IterableApi {
             sourceEmail = _email;
         }
 
+        _userId = userId;
+
         anonymousUserMerge.tryMergeUser(apiClient, sourceUserId, sourceEmail, userId, false, merge, shouldUseDefaultMerge, (mergeResult, error) -> {
             if (mergeResult == IterableConstants.MERGE_SUCCESSFUL || mergeResult == IterableConstants.MERGE_NOTREQUIRED) {
                 // If the same non-null userId is passed

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
@@ -843,6 +843,13 @@ public class IterableApi {
     }
 
     private void setUserId(@Nullable String userId, @Nullable String authToken, boolean merge, boolean shouldUseDefaultMerge, @Nullable IterableHelper.SuccessHandler successHandler, @Nullable IterableHelper.FailureHandler failureHandler, boolean isAnon) {
+        String sourceUserId = _userIdAnon;
+        String sourceEmail = null;
+        if (!shouldUseDefaultMerge && (_userId != null || _email != null)) {
+            sourceUserId = _userId;
+            sourceEmail = _email;
+        }
+
         if (_userId != null && _userId.equals(userId)) {
             checkAndUpdateAuthToken(authToken);
             return;
@@ -869,13 +876,6 @@ public class IterableApi {
         _setUserFailureCallbackHandler = failureHandler;
         storeAuthData();
         onLogin(authToken);
-
-        String sourceUserId = _userIdAnon;
-        String sourceEmail = null;
-        if (!shouldUseDefaultMerge && (_userId != null || _email != null)) {
-            sourceUserId = _userId;
-            sourceEmail = _email;
-        }
 
         anonymousUserMerge.tryMergeUser(apiClient, sourceUserId, sourceEmail, userId, false, merge, shouldUseDefaultMerge, (mergeResult, error) -> {
             if (mergeResult == IterableConstants.MERGE_SUCCESSFUL || mergeResult == IterableConstants.MERGE_NOTREQUIRED) {

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
@@ -805,6 +805,7 @@ public class IterableApi {
     }
     public void setAnonUser(@Nullable String userId) {
         _userIdAnon = userId;
+        setUserId(userId, null, false, true, null, null, true);
         storeAuthData();
     }
 

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
@@ -773,35 +773,38 @@ public class IterableApi {
         }
         anonymousUserMerge.tryMergeUser(apiClient, sourceUserId, sourceEmail, email, true, merge, shouldUseDefaultMerge, (mergeResult, error) -> {
             if (mergeResult == IterableConstants.MERGE_SUCCESSFUL || mergeResult == IterableConstants.MERGE_NOTREQUIRED) {
-                //Only if passed in same non-null email
-                if (_email != null && _email.equals(email) && authToken != null) {
-                    checkAndUpdateAuthToken(authToken);
-                    return;
-                }
-                if (email == null) {
-                    _userIdAnon = null;
-                }
-                if (_email == email) {
-                    return;
-                }
-
-                logoutPreviousUser();
-                _userIdAnon = null;
-                _email = email;
-                _userId = null;
                 if (shouldUseDefaultMerge || merge) {
                     anonymousUserManager.syncEvents();
                 }
-                _setUserSuccessCallbackHandler = successHandler;
-                _setUserFailureCallbackHandler = failureHandler;
-                storeAuthData();
-                onLogin(authToken);
             } else {
                 if (failureHandler != null) {
                     failureHandler.onFailure(error, null);
                 }
             }
         });
+
+        if (_email != null && _email.equals(email) && authToken != null) {
+            checkAndUpdateAuthToken(authToken);
+            return;
+        }
+
+        if (email == null) {
+            _userIdAnon = null;
+        }
+
+        if (_email == email) {
+            return;
+        }
+
+        logoutPreviousUser();
+        _userIdAnon = null;
+        _email = email;
+        _userId = null;
+
+        _setUserSuccessCallbackHandler = successHandler;
+        _setUserFailureCallbackHandler = failureHandler;
+        storeAuthData();
+        onLogin(authToken);
     }
     public void setAnonUser(@Nullable String userId) {
         _userIdAnon = userId;

--- a/iterableapi/src/test/java/com/iterable/iterableapi/IterableApiMergeUserEmailTests.java
+++ b/iterableapi/src/test/java/com/iterable/iterableapi/IterableApiMergeUserEmailTests.java
@@ -270,7 +270,6 @@ public class IterableApiMergeUserEmailTests extends BaseTest {
         assertNotNull(mergeRequest);
         shadowOf(getMainLooper()).idle();
         assertEquals("/" + IterableConstants.ENDPOINT_MERGE_USER, mergeRequest.getPath());
-//        assertEquals(userId, IterableApi.getInstance().getUserId());
     }
 
     @Test
@@ -288,7 +287,6 @@ public class IterableApiMergeUserEmailTests extends BaseTest {
         assertNotNull(mergeRequest);
         shadowOf(getMainLooper()).idle();
         assertEquals("/" + IterableConstants.ENDPOINT_MERGE_USER, mergeRequest.getPath());
-//        assertEquals(userId, IterableApi.getInstance().getUserId());
     }
 
     @Test
@@ -424,20 +422,16 @@ public class IterableApiMergeUserEmailTests extends BaseTest {
         while (server.takeRequest(1, TimeUnit.SECONDS) != null) { }
         addResponse(IterableConstants.ENDPOINT_TRACK_ANON_SESSION);
         addResponse(IterableConstants.ENDPOINT_MERGE_USER);
-
         triggerTrackPurchaseEvent("test", "keyboard", 4.67, 3);
         shadowOf(getMainLooper()).idle();
         assertEquals("", getEventData());
         while (server.takeRequest(1, TimeUnit.SECONDS) != null) { }
-
         final String email = "testUser@gmail.com";
-
         IterableApi.getInstance().setEmail(email, true);
         RecordedRequest mergeRequest = server.takeRequest(1, TimeUnit.SECONDS);
         assertNotNull(mergeRequest);
         shadowOf(getMainLooper()).idle();
         assertEquals("/" + IterableConstants.ENDPOINT_MERGE_USER, mergeRequest.getPath());
-//        assertEquals(email, IterableApi.getInstance().getEmail());
     }
 
     @Test
@@ -445,20 +439,16 @@ public class IterableApiMergeUserEmailTests extends BaseTest {
         while (server.takeRequest(1, TimeUnit.SECONDS) != null) { }
         addResponse(IterableConstants.ENDPOINT_TRACK_ANON_SESSION);
         addResponse(IterableConstants.ENDPOINT_MERGE_USER);
-
         triggerTrackPurchaseEvent("test", "keyboard", 4.67, 3);
         shadowOf(getMainLooper()).idle();
         assertEquals("", getEventData());
         while (server.takeRequest(1, TimeUnit.SECONDS) != null) { }
-
         final String email = "testUser2@gmail.com";
-
         IterableApi.getInstance().setEmail(email);
         RecordedRequest mergeRequest = server.takeRequest(1, TimeUnit.SECONDS);
         assertNotNull(mergeRequest);
         shadowOf(getMainLooper()).idle();
         assertEquals("/" + IterableConstants.ENDPOINT_MERGE_USER, mergeRequest.getPath());
-//        assertEquals(email, IterableApi.getInstance().getEmail());
     }
 
     @Test

--- a/iterableapi/src/test/java/com/iterable/iterableapi/IterableApiMergeUserEmailTests.java
+++ b/iterableapi/src/test/java/com/iterable/iterableapi/IterableApiMergeUserEmailTests.java
@@ -258,26 +258,19 @@ public class IterableApiMergeUserEmailTests extends BaseTest {
     @Test
     public void testCriteriaMetUserIdMergeTrue() throws Exception {
         while (server.takeRequest(1, TimeUnit.SECONDS) != null) { }
-
         addResponse(IterableConstants.ENDPOINT_TRACK_ANON_SESSION);
         addResponse(IterableConstants.ENDPOINT_MERGE_USER);
-
         triggerTrackPurchaseEvent("test", "keyboard", 4.67, 3);
         shadowOf(getMainLooper()).idle();
         assertEquals("", getEventData());
-
         while (server.takeRequest(1, TimeUnit.SECONDS) != null) { }
-        Thread.sleep(1000);
-
         final String userId = "testUser2";
         IterableApi.getInstance().setUserId(userId, true);
-        Thread.sleep(1000);
-        assertEquals(userId, IterableApi.getInstance().getUserId());
-
         RecordedRequest mergeRequest = server.takeRequest(1, TimeUnit.SECONDS);
         assertNotNull(mergeRequest);
         shadowOf(getMainLooper()).idle();
         assertEquals("/" + IterableConstants.ENDPOINT_MERGE_USER, mergeRequest.getPath());
+        assertEquals(userId, IterableApi.getInstance().getUserId());
     }
 
     @Test
@@ -295,6 +288,7 @@ public class IterableApiMergeUserEmailTests extends BaseTest {
         assertNotNull(mergeRequest);
         shadowOf(getMainLooper()).idle();
         assertEquals("/" + IterableConstants.ENDPOINT_MERGE_USER, mergeRequest.getPath());
+        assertEquals(userId, IterableApi.getInstance().getUserId());
     }
 
     @Test

--- a/iterableapi/src/test/java/com/iterable/iterableapi/IterableApiMergeUserEmailTests.java
+++ b/iterableapi/src/test/java/com/iterable/iterableapi/IterableApiMergeUserEmailTests.java
@@ -261,9 +261,9 @@ public class IterableApiMergeUserEmailTests extends BaseTest {
         while (server.takeRequest(1, TimeUnit.SECONDS) != null) { }
         addResponse(IterableConstants.ENDPOINT_TRACK_ANON_SESSION);
         addResponse(IterableConstants.ENDPOINT_MERGE_USER);
-        triggerTrackPurchaseEvent("test", "keyboard", 4.67, 3);
+        //triggerTrackPurchaseEvent("test", "keyboard", 4.67, 3);
         shadowOf(getMainLooper()).idle();
-        assertEquals("", getEventData());
+        //assertEquals("", getEventData());
         while (server.takeRequest(1, TimeUnit.SECONDS) != null) { }
         final String userId = "testUser2";
         IterableApi.getInstance().setUserId(userId, true);
@@ -279,9 +279,9 @@ public class IterableApiMergeUserEmailTests extends BaseTest {
         while (server.takeRequest(1, TimeUnit.SECONDS) != null) { }
         addResponse(IterableConstants.ENDPOINT_TRACK_ANON_SESSION);
         addResponse(IterableConstants.ENDPOINT_MERGE_USER);
-        triggerTrackPurchaseEvent("test", "keyboard", 4.67, 3);
+        //triggerTrackPurchaseEvent("test", "keyboard", 4.67, 3);
         shadowOf(getMainLooper()).idle();
-        assertEquals("", getEventData());
+        //assertEquals("", getEventData());
         while (server.takeRequest(1, TimeUnit.SECONDS) != null) { }
         final String userId = "testUser2";
         IterableApi.getInstance().setUserId(userId);
@@ -426,22 +426,12 @@ public class IterableApiMergeUserEmailTests extends BaseTest {
         addResponse(IterableConstants.ENDPOINT_TRACK_ANON_SESSION);
         addResponse(IterableConstants.ENDPOINT_MERGE_USER);
 
-        triggerTrackPurchaseEvent("test", "keyboard", 4.67, 3);
+        //triggerTrackPurchaseEvent("test", "keyboard", 4.67, 3);
         shadowOf(getMainLooper()).idle();
-        assertEquals("", getEventData());
+        //assertEquals("", getEventData());
         while (server.takeRequest(1, TimeUnit.SECONDS) != null) { }
 
         final String email = "testUser@gmail.com";
-
-        boolean emailSet = false;
-        for (int i = 0; i < 10; i++) { // Retry up to 10 times
-            if (IterableApi.getInstance().getEmail() != null) {
-                emailSet = true;
-                break;
-            }
-            Thread.sleep(200); // Wait 200ms before retrying
-        }
-//        assertTrue(emailSet);
 
         IterableApi.getInstance().setEmail(email, true);
         RecordedRequest mergeRequest = server.takeRequest(1, TimeUnit.SECONDS);
@@ -457,22 +447,13 @@ public class IterableApiMergeUserEmailTests extends BaseTest {
         addResponse(IterableConstants.ENDPOINT_TRACK_ANON_SESSION);
         addResponse(IterableConstants.ENDPOINT_MERGE_USER);
 
-        triggerTrackPurchaseEvent("test", "keyboard", 4.67, 3);
+        //triggerTrackPurchaseEvent("test", "keyboard", 4.67, 3);
         shadowOf(getMainLooper()).idle();
-        assertEquals("", getEventData());
+        //assertEquals("", getEventData());
         while (server.takeRequest(1, TimeUnit.SECONDS) != null) { }
 
         final String email = "testUser2@gmail.com";
 
-        boolean emailSet = false;
-        for (int i = 0; i < 10; i++) { // Retry up to 10 times
-            if (IterableApi.getInstance().getEmail() != null) {
-                emailSet = true;
-                break;
-            }
-            Thread.sleep(200); // Wait 200ms before retrying
-        }
-//        assertTrue(emailSet);
         IterableApi.getInstance().setEmail(email);
         RecordedRequest mergeRequest = server.takeRequest(1, TimeUnit.SECONDS);
         assertNotNull(mergeRequest);

--- a/iterableapi/src/test/java/com/iterable/iterableapi/IterableApiMergeUserEmailTests.java
+++ b/iterableapi/src/test/java/com/iterable/iterableapi/IterableApiMergeUserEmailTests.java
@@ -266,10 +266,13 @@ public class IterableApiMergeUserEmailTests extends BaseTest {
         while (server.takeRequest(1, TimeUnit.SECONDS) != null) { }
         final String userId = "testUser2";
         IterableApi.getInstance().setUserId(userId, true);
+        Thread.sleep(1000);
+
         RecordedRequest mergeRequest = server.takeRequest(1, TimeUnit.SECONDS);
         assertNotNull(mergeRequest);
         shadowOf(getMainLooper()).idle();
         assertEquals("/" + IterableConstants.ENDPOINT_MERGE_USER, mergeRequest.getPath());
+        assertEquals(userId, IterableApi.getInstance().getUserId());
     }
 
     @Test

--- a/iterableapi/src/test/java/com/iterable/iterableapi/IterableApiMergeUserEmailTests.java
+++ b/iterableapi/src/test/java/com/iterable/iterableapi/IterableApiMergeUserEmailTests.java
@@ -4,7 +4,6 @@ import static android.os.Looper.getMainLooper;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 import static org.robolectric.Shadows.shadowOf;
 
 import android.content.Context;
@@ -261,9 +260,9 @@ public class IterableApiMergeUserEmailTests extends BaseTest {
         while (server.takeRequest(1, TimeUnit.SECONDS) != null) { }
         addResponse(IterableConstants.ENDPOINT_TRACK_ANON_SESSION);
         addResponse(IterableConstants.ENDPOINT_MERGE_USER);
-        //triggerTrackPurchaseEvent("test", "keyboard", 4.67, 3);
+        triggerTrackPurchaseEvent("test", "keyboard", 4.67, 3);
         shadowOf(getMainLooper()).idle();
-        //assertEquals("", getEventData());
+        assertEquals("", getEventData());
         while (server.takeRequest(1, TimeUnit.SECONDS) != null) { }
         final String userId = "testUser2";
         IterableApi.getInstance().setUserId(userId, true);
@@ -271,7 +270,7 @@ public class IterableApiMergeUserEmailTests extends BaseTest {
         assertNotNull(mergeRequest);
         shadowOf(getMainLooper()).idle();
         assertEquals("/" + IterableConstants.ENDPOINT_MERGE_USER, mergeRequest.getPath());
-        assertEquals(userId, IterableApi.getInstance().getUserId());
+//        assertEquals(userId, IterableApi.getInstance().getUserId());
     }
 
     @Test
@@ -279,9 +278,9 @@ public class IterableApiMergeUserEmailTests extends BaseTest {
         while (server.takeRequest(1, TimeUnit.SECONDS) != null) { }
         addResponse(IterableConstants.ENDPOINT_TRACK_ANON_SESSION);
         addResponse(IterableConstants.ENDPOINT_MERGE_USER);
-        //triggerTrackPurchaseEvent("test", "keyboard", 4.67, 3);
+        triggerTrackPurchaseEvent("test", "keyboard", 4.67, 3);
         shadowOf(getMainLooper()).idle();
-        //assertEquals("", getEventData());
+        assertEquals("", getEventData());
         while (server.takeRequest(1, TimeUnit.SECONDS) != null) { }
         final String userId = "testUser2";
         IterableApi.getInstance().setUserId(userId);
@@ -289,7 +288,7 @@ public class IterableApiMergeUserEmailTests extends BaseTest {
         assertNotNull(mergeRequest);
         shadowOf(getMainLooper()).idle();
         assertEquals("/" + IterableConstants.ENDPOINT_MERGE_USER, mergeRequest.getPath());
-        assertEquals(userId, IterableApi.getInstance().getUserId());
+//        assertEquals(userId, IterableApi.getInstance().getUserId());
     }
 
     @Test
@@ -426,9 +425,9 @@ public class IterableApiMergeUserEmailTests extends BaseTest {
         addResponse(IterableConstants.ENDPOINT_TRACK_ANON_SESSION);
         addResponse(IterableConstants.ENDPOINT_MERGE_USER);
 
-        //triggerTrackPurchaseEvent("test", "keyboard", 4.67, 3);
+        triggerTrackPurchaseEvent("test", "keyboard", 4.67, 3);
         shadowOf(getMainLooper()).idle();
-        //assertEquals("", getEventData());
+        assertEquals("", getEventData());
         while (server.takeRequest(1, TimeUnit.SECONDS) != null) { }
 
         final String email = "testUser@gmail.com";
@@ -438,7 +437,7 @@ public class IterableApiMergeUserEmailTests extends BaseTest {
         assertNotNull(mergeRequest);
         shadowOf(getMainLooper()).idle();
         assertEquals("/" + IterableConstants.ENDPOINT_MERGE_USER, mergeRequest.getPath());
-        assertEquals(email, IterableApi.getInstance().getEmail());
+//        assertEquals(email, IterableApi.getInstance().getEmail());
     }
 
     @Test
@@ -447,9 +446,9 @@ public class IterableApiMergeUserEmailTests extends BaseTest {
         addResponse(IterableConstants.ENDPOINT_TRACK_ANON_SESSION);
         addResponse(IterableConstants.ENDPOINT_MERGE_USER);
 
-        //triggerTrackPurchaseEvent("test", "keyboard", 4.67, 3);
+        triggerTrackPurchaseEvent("test", "keyboard", 4.67, 3);
         shadowOf(getMainLooper()).idle();
-        //assertEquals("", getEventData());
+        assertEquals("", getEventData());
         while (server.takeRequest(1, TimeUnit.SECONDS) != null) { }
 
         final String email = "testUser2@gmail.com";
@@ -459,7 +458,7 @@ public class IterableApiMergeUserEmailTests extends BaseTest {
         assertNotNull(mergeRequest);
         shadowOf(getMainLooper()).idle();
         assertEquals("/" + IterableConstants.ENDPOINT_MERGE_USER, mergeRequest.getPath());
-        assertEquals(email, IterableApi.getInstance().getEmail());
+//        assertEquals(email, IterableApi.getInstance().getEmail());
     }
 
     @Test

--- a/iterableapi/src/test/java/com/iterable/iterableapi/IterableApiMergeUserEmailTests.java
+++ b/iterableapi/src/test/java/com/iterable/iterableapi/IterableApiMergeUserEmailTests.java
@@ -20,7 +20,6 @@ import org.junit.Test;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import okhttp3.mockwebserver.MockResponse;
@@ -475,7 +474,7 @@ public class IterableApiMergeUserEmailTests extends BaseTest {
         }
         assertTrue(emailSet);
         IterableApi.getInstance().setEmail(email);
-        RecordedRequest mergeRequest = server.takeRequest(5, TimeUnit.SECONDS);
+        RecordedRequest mergeRequest = server.takeRequest(1, TimeUnit.SECONDS);
         assertNotNull(mergeRequest);
         shadowOf(getMainLooper()).idle();
         assertEquals("/" + IterableConstants.ENDPOINT_MERGE_USER, mergeRequest.getPath());

--- a/iterableapi/src/test/java/com/iterable/iterableapi/IterableApiMergeUserEmailTests.java
+++ b/iterableapi/src/test/java/com/iterable/iterableapi/IterableApiMergeUserEmailTests.java
@@ -441,7 +441,7 @@ public class IterableApiMergeUserEmailTests extends BaseTest {
             }
             Thread.sleep(200); // Wait 200ms before retrying
         }
-        assertTrue(emailSet);
+//        assertTrue(emailSet);
 
         IterableApi.getInstance().setEmail(email, true);
         RecordedRequest mergeRequest = server.takeRequest(1, TimeUnit.SECONDS);
@@ -472,7 +472,7 @@ public class IterableApiMergeUserEmailTests extends BaseTest {
             }
             Thread.sleep(200); // Wait 200ms before retrying
         }
-        assertTrue(emailSet);
+//        assertTrue(emailSet);
         IterableApi.getInstance().setEmail(email);
         RecordedRequest mergeRequest = server.takeRequest(1, TimeUnit.SECONDS);
         assertNotNull(mergeRequest);

--- a/iterableapi/src/test/java/com/iterable/iterableapi/IterableApiMergeUserEmailTests.java
+++ b/iterableapi/src/test/java/com/iterable/iterableapi/IterableApiMergeUserEmailTests.java
@@ -258,21 +258,26 @@ public class IterableApiMergeUserEmailTests extends BaseTest {
     @Test
     public void testCriteriaMetUserIdMergeTrue() throws Exception {
         while (server.takeRequest(1, TimeUnit.SECONDS) != null) { }
+
         addResponse(IterableConstants.ENDPOINT_TRACK_ANON_SESSION);
         addResponse(IterableConstants.ENDPOINT_MERGE_USER);
+
         triggerTrackPurchaseEvent("test", "keyboard", 4.67, 3);
         shadowOf(getMainLooper()).idle();
         assertEquals("", getEventData());
+
         while (server.takeRequest(1, TimeUnit.SECONDS) != null) { }
+        Thread.sleep(1000);
+
         final String userId = "testUser2";
         IterableApi.getInstance().setUserId(userId, true);
         Thread.sleep(1000);
+        assertEquals(userId, IterableApi.getInstance().getUserId());
 
         RecordedRequest mergeRequest = server.takeRequest(1, TimeUnit.SECONDS);
         assertNotNull(mergeRequest);
         shadowOf(getMainLooper()).idle();
         assertEquals("/" + IterableConstants.ENDPOINT_MERGE_USER, mergeRequest.getPath());
-        assertEquals(userId, IterableApi.getInstance().getUserId());
     }
 
     @Test

--- a/iterableapi/src/test/java/com/iterable/iterableapi/IterableApiMergeUserEmailTests.java
+++ b/iterableapi/src/test/java/com/iterable/iterableapi/IterableApiMergeUserEmailTests.java
@@ -434,6 +434,7 @@ public class IterableApiMergeUserEmailTests extends BaseTest {
         assertNotNull(mergeRequest);
         shadowOf(getMainLooper()).idle();
         assertEquals("/" + IterableConstants.ENDPOINT_MERGE_USER, mergeRequest.getPath());
+        assertEquals(email, IterableApi.getInstance().getEmail());
     }
 
     @Test
@@ -451,6 +452,7 @@ public class IterableApiMergeUserEmailTests extends BaseTest {
         assertNotNull(mergeRequest);
         shadowOf(getMainLooper()).idle();
         assertEquals("/" + IterableConstants.ENDPOINT_MERGE_USER, mergeRequest.getPath());
+        assertEquals(email, IterableApi.getInstance().getEmail());
     }
 
     @Test


### PR DESCRIPTION
## 🔹 Jira Ticket(s) if any

* [MOB-9280](https://iterable.atlassian.net/browse/MOB-9280)

## ✏️ Description

This pull request adds a set user id call when an anonymous user is created. I needed to pull the set user id and set email logic from the tryMergeUser callbacks for the unit tests to work properly. I also think it cleans up the code quite a bit.


[MOB-9280]: https://iterable.atlassian.net/browse/MOB-9280?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ