### PR TITLE
[MOB-9317] updates event threshold limit

### DIFF
--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableConfig.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableConfig.java
@@ -137,7 +137,7 @@ public class IterableConfig {
         private boolean encryptionEnforced = false;
         private boolean enableAnonTracking = false;
         private boolean enableEmbeddedMessaging = false;
-        private int eventThresholdLimit = 50;
+        private int eventThresholdLimit = 100;
 
         public Builder() {}
 


### PR DESCRIPTION
## 🔹 Jira Ticket(s) if any

* [MOB-9317](https://iterable.atlassian.net/browse/MOB-9317)

## ✏️ Description

> This pull request returns default event threshold limit back to 100.


[MOB-9317]: https://iterable.atlassian.net/browse/MOB-9317?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ