### PR TITLE
[MOB-10030] clears user update storage when consent is toggled

### DIFF
--- a/iterableapi/src/main/java/com/iterable/iterableapi/AnonymousUserManager.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/AnonymousUserManager.java
@@ -114,7 +114,7 @@ public class AnonymousUserManager {
             JSONObject newDataObject = new JSONObject();
             newDataObject.put(IterableConstants.KEY_TOKEN, token);
             newDataObject.put(IterableConstants.SHARED_PREFS_EVENT_TYPE, IterableConstants.TRACK_TOKEN_REGISTRATION);
-            storeEventListToLocalStorage(newDataObject, false);
+            storeEventListToLocalStorage(newDataObject);
         } catch (JSONException e) {
             e.printStackTrace();
         }
@@ -335,12 +335,6 @@ public class AnonymousUserManager {
     }
 
     private void storeEventListToLocalStorage(JSONObject newDataObject) {
-        if (iterableApi.getAnonymousUsageTracked()) {
-            storeEventListToLocalStorage(newDataObject, false);
-        }
-    }
-
-    private void storeEventListToLocalStorage(JSONObject newDataObject, boolean shouldOverWrite) {
         if (!iterableApi.getAnonymousUsageTracked()) {
             return;
         }

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
@@ -1544,6 +1544,7 @@ public class IterableApi {
         SharedPreferences.Editor editor = sharedPref.edit();
         editor.putString(IterableConstants.SHARED_PREFS_ANON_SESSIONS, "");
         editor.putString(IterableConstants.SHARED_PREFS_EVENT_LIST_KEY, "");
+        editor.putString(IterableConstants.SHARED_PREFS_USER_UPDATE_OBJECT_KEY, "");
         editor.putString(IterableConstants.SHARED_PREFS_CRITERIA, "");
         editor.putBoolean(SHARED_PREFS_ANONYMOUS_USAGE_TRACKED, isSetAnonymousUsageTracked);
         editor.apply();


### PR DESCRIPTION
## 🔹 Jira Ticket(s) if any

* [MOB-10030](https://iterable.atlassian.net/browse/MOB-10030)

## ✏️ Description

> This pull request clears the user update object when consent is toggled.


[MOB-10030]: https://iterable.atlassian.net/browse/MOB-10030?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ