### PR TITLE
[MOB-10098] updates user update parsing

### DIFF
--- a/iterableapi/src/main/java/com/iterable/iterableapi/AnonymousUserManager.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/AnonymousUserManager.java
@@ -310,7 +310,7 @@ public class AnonymousUserManager {
     }
 
     private void handleUpdateUser(JSONObject event) throws JSONException {
-        iterableApi.apiClient.updateUser(event.getJSONObject(IterableConstants.KEY_DATA_FIELDS), false);
+        iterableApi.apiClient.updateUser(event.getJSONObject(IterableConstants.KEY_DATA_FIELDS), true);
     }
 
     private String getStringValue(JSONObject event) throws JSONException {

--- a/iterableapi/src/main/java/com/iterable/iterableapi/AnonymousUserManager.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/AnonymousUserManager.java
@@ -310,7 +310,7 @@ public class AnonymousUserManager {
     }
 
     private void handleUpdateUser(JSONObject event) throws JSONException {
-        iterableApi.apiClient.updateUser(event.getJSONObject(IterableConstants.KEY_DATA_FIELDS), true);
+        iterableApi.apiClient.updateUser(event.getJSONObject(IterableConstants.KEY_DATA_FIELDS), false);
     }
 
     private String getStringValue(JSONObject event) throws JSONException {

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableApiClient.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableApiClient.java
@@ -789,7 +789,7 @@ class IterableApiClient {
         sendGetRequest(IterableConstants.ENDPOINT_CRITERIA_LIST, new JSONObject(), actionHandler);
     }
 
-    void trackAnonSession(long createdAt, String userId, @NonNull JSONObject requestJson, JSONObject updateUserTrack, @NonNull IterableHelper.SuccessHandler onSuccess, @NonNull IterableHelper.FailureHandler onFailure) {
+    void trackAnonSession(long createdAt, String userId, @NonNull JSONObject requestJson, JSONObject updateUserObj, @NonNull IterableHelper.SuccessHandler onSuccess, @NonNull IterableHelper.FailureHandler onFailure) {
         try {
             JSONObject requestObject = new JSONObject();
 
@@ -798,8 +798,8 @@ class IterableApiClient {
             userObject.put(IterableConstants.KEY_PREFER_USER_ID, true);
             userObject.put(IterableConstants.KEY_MERGE_NESTED_OBJECTS, true);
             userObject.put(IterableConstants.KEY_CREATE_NEW_FIELDS, true);
-            if (updateUserTrack != null) {
-                userObject.put(IterableConstants.KEY_DATA_FIELDS, updateUserTrack);
+            if (updateUserObj != null) {
+                userObject.put(IterableConstants.KEY_DATA_FIELDS, updateUserObj.getJSONObject(IterableConstants.KEY_DATA_FIELDS));
             }
             requestObject.put(IterableConstants.KEY_USER, userObject);
             requestObject.put(IterableConstants.KEY_CREATED_AT, createdAt);


### PR DESCRIPTION
## 🔹 Jira Ticket(s) if any

* [MOB-10098](https://iterable.atlassian.net/browse/MOB-10098)

## ✏️ Description

> This pull request updates the user update to be properly passed by as part of the anonymous session. We were not parsing the user update object to pass back the contents of data fields and sending the data fields key along improperly.


[MOB-10098]: https://iterable.atlassian.net/browse/MOB-10098?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ