### PR TITLE
[MOB-9211] - InApp resizing fix

### DIFF
--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableInAppFragmentHTMLNotification.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableInAppFragmentHTMLNotification.java
@@ -22,7 +22,6 @@ import android.view.LayoutInflater;
 import android.view.OrientationEventListener;
 import android.view.View;
 import android.view.ViewGroup;
-import android.view.ViewTreeObserver;
 import android.view.Window;
 import android.view.WindowManager;
 import android.view.animation.Animation;
@@ -167,14 +166,6 @@ public class IterableInAppFragmentHTMLNotification extends DialogFragment implem
         webView = new IterableWebView(getContext());
         webView.setId(R.id.webView);
         webView.createWithHtml(this, htmlString);
-
-        webView.getViewTreeObserver().addOnPreDrawListener(new ViewTreeObserver.OnPreDrawListener() {
-            @Override
-            public boolean onPreDraw() {
-                runResizeScript();
-                return true;
-            }
-        });
 
         if (orientationListener == null) {
             orientationListener = new OrientationEventListener(getContext(), SensorManager.SENSOR_DELAY_NORMAL) {

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableWebViewClient.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableWebViewClient.java
@@ -19,6 +19,6 @@ class IterableWebViewClient extends WebViewClient {
     @Override
     public void onPageFinished(WebView view, String url) {
         inAppHTMLNotification.setLoaded(true);
-        inAppHTMLNotification.runResizeScript();
+        view.postDelayed(inAppHTMLNotification::runResizeScript, 100);
     }
 }


### PR DESCRIPTION

## 🔹 Jira Ticket(s) if any

* [MOB-9211](https://iterable.atlassian.net/browse/MOB-9211)

## ✏️ Description

> Removing treeobserver as the html would keep calling this callback even after the page was finished loading. This method was used as an additional measure to make sure inapps are resized in situation when inapps were still not displayed after finished loading. This fix adds delay of 100ms which seems to resolve inapps on Pixel 6pro and still making it all work on Pixel 8 device, needing the SDK to not rely on tree observers.


[MOB-9211]: https://iterable.atlassian.net/browse/MOB-9211?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ