### PR TITLE
[MOB-9111] - Inbox overlap on Android 35

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Configure JDK
         uses: actions/setup-java@d202f5dbf7256730fb690ec59f6381650114feb2 # v1.4.3
         with:
-          java-version: 11
+          java-version: 17
 
       - run: touch local.properties
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,7 @@ jobs:
 
   instrumentation-tests:
     name: Instrumentation tests
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1

--- a/iterableapi-ui/src/main/java/com/iterable/iterableapi/ui/inbox/IterableInboxFragment.java
+++ b/iterableapi-ui/src/main/java/com/iterable/iterableapi/ui/inbox/IterableInboxFragment.java
@@ -1,10 +1,13 @@
 package com.iterable.iterableapi.ui.inbox;
 
 import android.content.Intent;
+import android.graphics.Insets;
+import android.os.Build;
 import android.os.Bundle;
 import androidx.annotation.LayoutRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.core.view.ViewCompat;
 import androidx.fragment.app.Fragment;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
@@ -182,6 +185,33 @@ public class IterableInboxFragment extends Fragment implements IterableInAppMana
         ItemTouchHelper itemTouchHelper = new ItemTouchHelper(new IterableInboxTouchHelper(getContext(), adapter));
         itemTouchHelper.attachToRecyclerView(recyclerView);
         return relativeLayout;
+    }
+
+    @Override
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+        // Use ViewCompat to handle insets dynamically
+        ViewCompat.setOnApplyWindowInsetsListener(view, (v, insets) -> {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                // For API 30 and above: Use WindowInsetsCompat to handle insets
+                Insets systemBarsInsets = insets.getSystemGestureInsets().toPlatformInsets();
+                v.setPadding(
+                        0,
+                        systemBarsInsets.top,  // Padding for status bar and cutout
+                        0,
+                        systemBarsInsets.bottom // Padding for navigation bar
+                );
+            } else {
+                // For older Android versions: Use legacy methods
+                v.setPadding(
+                        0,
+                        insets.getSystemWindowInsetTop(),  // Padding for status bar and cutout
+                        0,
+                        insets.getSystemWindowInsetBottom() // Padding for navigation bar
+                );
+            }
+            return insets;
+        });
     }
 
     @Override


### PR DESCRIPTION
## 🔹 Jira Ticket(s) if any

* [MOB-9111](https://iterable.atlassian.net/browse/MOB-9111)

## ✏️ Description

> This fix makes the IterableInboxFragment adjust with window insets allowing full screen apps to take advantage of IterableInboxActivity or IterableInboxFragment. As IterableInboxActivity internally launches IterableFragment, the changes in Fragment is sufficient to make up for cut outs and notches on displays



[MOB-9111]: https://iterable.atlassian.net/browse/MOB-9111?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ