### PR TITLE
MOB-10857 fix encryption crash

### DIFF
--- a/iterableapi/src/test/java/com/iterable/iterableapi/IterableDataEncryptorTest.java
+++ b/iterableapi/src/test/java/com/iterable/iterableapi/IterableDataEncryptorTest.java
@@ -1,6 +1,5 @@
 package com.iterable.iterableapi;
 
-import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.Build;
 import android.util.Base64;
@@ -10,8 +9,13 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.fail;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -26,16 +30,13 @@ import java.util.concurrent.atomic.AtomicBoolean;
 public class IterableDataEncryptorTest extends BaseTest {
 
     private IterableDataEncryptor encryptor;
-    private IterableKeychain keychain;
 
     @Mock
     private SharedPreferences sharedPreferences;
-    @Mock
-    private SharedPreferences.Editor editor;
 
     @Before
     public void setUp() {
-        MockitoAnnotations.openMocks(this);
+        MockitoAnnotations.initMocks(this);
         encryptor = new IterableDataEncryptor();
     }
 

--- a/iterableapi/src/test/java/com/iterable/iterableapi/IterableDataEncryptorTest.java
+++ b/iterableapi/src/test/java/com/iterable/iterableapi/IterableDataEncryptorTest.java
@@ -491,6 +491,7 @@ public class IterableDataEncryptorTest extends BaseTest {
         String testData = "test data for encryption failure";
         IterableDataEncryptor failingEncryptor = mock(IterableDataEncryptor.class);
         when(failingEncryptor.encrypt(anyString())).thenThrow(new RuntimeException("Simulated encryption failure"));
+        when(failingEncryptor.decrypt(anyString())).thenThrow(new RuntimeException("Simulated decryption failure"));
         
         // Create keychain with failing encryptor through reflection
         keychain = new IterableKeychain(mockContext);
@@ -502,6 +503,13 @@ public class IterableDataEncryptorTest extends BaseTest {
         // Verify plaintext save operations
         verify(editor).putString(eq(IterableKeychain.KEY_USER_ID), eq(testData));
         verify(editor).putBoolean(eq(IterableKeychain.KEY_USER_ID + "_plaintext"), eq(true));
+
+        // Mock SharedPreferences to return the saved data
+        when(sharedPreferences.getString(eq(IterableKeychain.KEY_USER_ID), isNull())).thenReturn(testData);
+        when(sharedPreferences.getBoolean(eq(IterableKeychain.KEY_USER_ID + "_plaintext"), eq(false))).thenReturn(true);
+
+        // Verify data can be retrieved
+        assertEquals(testData, keychain.getUserId());
 
         // Test null handling
         clearInvocations(editor);

--- a/iterableapi/src/test/java/com/iterable/iterableapi/IterableKeychainTest.kt
+++ b/iterableapi/src/test/java/com/iterable/iterableapi/IterableKeychainTest.kt
@@ -25,6 +25,7 @@ import org.mockito.Mockito.doThrow
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.clearInvocations
 import org.mockito.ArgumentMatchers.matches
+import org.mockito.Mockito.never
 
 class IterableKeychainTest {
 
@@ -311,10 +312,18 @@ class IterableKeychainTest {
         // Verify data can be retrieved
         assertEquals(testData, keychain.getUserId())
 
+        // Verify encryption was attempted and failed
+        verify(mockEncryptor).encrypt(eq(testData))
+        verify(mockEncryptor, never()).decrypt(any()) // Should not attempt decryption for plaintext
+
         // Test null handling
         clearInvocations(mockEditor)
         keychain.saveUserId(null)
         verify(mockEditor).remove(eq("iterable-user-id"))
         verify(mockEditor).remove(eq("iterable-user-id_plaintext"))
+
+        // Verify no more encryption attempts for null
+        verify(mockEncryptor, never()).encrypt(isNull())
+        verify(mockEncryptor, never()).decrypt(isNull())
     }
 } 


### PR DESCRIPTION
## 🔹 Jira Ticket(s) if any

* [MOB-XXXX](https://iterable.atlassian.net/browse/MOB-XXXX)

## ✏️ Description

Added plaintext fallback for data storage when encryption fails:
- Modified `IterableKeychain` to handle encryption failures gracefully
- Data is stored in plaintext with a flag when encryption fails
- Added unit tests to verify fallback behavior
- Maintains backward compatibility with existing encrypted data

Key changes:
1. Added plaintext flag to track unencrypted data
2. Implemented fallback mechanism in `secureSave`
3. Updated `secureGet` to handle plaintext data
4. Added comprehensive test coverage

