### PR TITLE
Update Robolectric usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This SDK helps you integrate your Android apps with Iterable.
 
 ## Supported Android versions
 
-Iterable's Android SDK supports Android versions 4.1.2 (API level 16) and higher.
+Iterable's Android SDK supports Android versions 5.0 (API level 21) and higher.
 
 ## Installation
 
@@ -66,7 +66,7 @@ Questions? Contact your Iterable customer success manager.
 
 ## License
 
-This SDK is released under the MIT License. For more information, read [LICENSE](LICENSE.md).
+This SDK is released under the MIT License. For more information, read [LICENSE](LICENSE).
 
 ## Want to contribute?
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -61,7 +61,6 @@ dependencies {
     testImplementation 'androidx.test:rules:1.6.1'
     testImplementation 'org.mockito:mockito-core:4.8.0'
     testImplementation 'org.robolectric:robolectric:4.14.1'
-    testImplementation 'org.robolectric:shadows-playservices:4.14.1'
     testImplementation 'com.squareup.okhttp3:mockwebserver:4.9.3'
     androidTestImplementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     androidTestImplementation 'androidx.test:runner:1.6.2'

--- a/iterableapi/build.gradle
+++ b/iterableapi/build.gradle
@@ -71,7 +71,6 @@ dependencies {
     testImplementation 'org.mockito:mockito-core:4.8.0'
     testImplementation 'org.mockito:mockito-inline:4.8.0'
     testImplementation 'org.robolectric:robolectric:4.14.1'
-    testImplementation 'org.robolectric:shadows-playservices:4.14.1'
     testImplementation 'org.khronos:opengl-api:gl1.1-android-2.1_r1'
     testImplementation 'com.squareup.okhttp3:mockwebserver:4.9.3'
     testImplementation 'org.skyscreamer:jsonassert:1.5.0'

--- a/iterableapi/src/test/java/com/iterable/iterableapi/IterablePushActionReceiverTest.java
+++ b/iterableapi/src/test/java/com/iterable/iterableapi/IterablePushActionReceiverTest.java
@@ -1,17 +1,18 @@
 package com.iterable.iterableapi;
 
+import android.app.Application;
 import android.content.ClipData;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
 import androidx.core.app.RemoteInput;
+import androidx.test.core.app.ApplicationProvider;
 
 import org.json.JSONObject;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
-import org.robolectric.RuntimeEnvironment;
 
 import java.util.concurrent.TimeUnit;
 
@@ -63,11 +64,12 @@ public class IterablePushActionReceiverTest extends BaseTest {
         intent.putExtra(IterableConstants.ITERABLE_DATA_KEY, IterableTestUtils.getResourceString("push_payload_silent_action.json"));
 
         // This must not crash
-        iterablePushActionReceiver.onReceive(RuntimeEnvironment.application, intent);
+        iterablePushActionReceiver.onReceive(ApplicationProvider.getApplicationContext(), intent);
     }
 
     @Test
     public void testTrackPushOpenWithCustomAction() throws Exception {
+        Application application = ApplicationProvider.getApplicationContext();
         final JSONObject responseData = new JSONObject("{\"key\":\"value\"}");
         stubAnyRequestReturningStatusCode(server, 200, responseData);
 
@@ -76,7 +78,7 @@ public class IterablePushActionReceiverTest extends BaseTest {
         intent.putExtra(IterableConstants.ITERABLE_DATA_ACTION_IDENTIFIER, IterableConstants.ITERABLE_ACTION_DEFAULT);
         intent.putExtra(IterableConstants.ITERABLE_DATA_KEY, IterableTestUtils.getResourceString("push_payload_custom_action.json"));
 
-        iterablePushActionReceiver.onReceive(RuntimeEnvironment.application, intent);
+        iterablePushActionReceiver.onReceive(application, intent);
 
         // Verify that IterableActionRunner was called with the proper action
         ArgumentCaptor<IterableAction> capturedAction = ArgumentCaptor.forClass(IterableAction.class);
@@ -84,7 +86,7 @@ public class IterablePushActionReceiverTest extends BaseTest {
         assertEquals("customAction", capturedAction.getValue().getType());
 
         // Verify that the main app activity was launched
-        Intent activityIntent = shadowOf(RuntimeEnvironment.application).peekNextStartedActivity();
+        Intent activityIntent = shadowOf(application).peekNextStartedActivity();
         assertNotNull(activityIntent);
         assertEquals(Intent.ACTION_MAIN, activityIntent.getAction());
 
@@ -102,16 +104,17 @@ public class IterablePushActionReceiverTest extends BaseTest {
 
     @Test
     public void testPushActionWithSilentAction() throws Exception {
+        Application application = ApplicationProvider.getApplicationContext();
         stubAnyRequestReturningStatusCode(server, 200, "{}");
         IterablePushActionReceiver iterablePushActionReceiver = new IterablePushActionReceiver();
         Intent intent = new Intent(IterableConstants.ACTION_PUSH_ACTION);
         intent.putExtra(IterableConstants.ITERABLE_DATA_ACTION_IDENTIFIER, "silentButton");
         intent.putExtra(IterableConstants.ITERABLE_DATA_KEY, IterableTestUtils.getResourceString("push_payload_silent_action.json"));
 
-        iterablePushActionReceiver.onReceive(RuntimeEnvironment.application, intent);
+        iterablePushActionReceiver.onReceive(application, intent);
 
         // Verify that the main app activity was NOT launched
-        Intent activityIntent = shadowOf(RuntimeEnvironment.application).peekNextStartedActivity();
+        Intent activityIntent = shadowOf(application).peekNextStartedActivity();
         assertNull(activityIntent);
     }
 
@@ -129,7 +132,7 @@ public class IterablePushActionReceiverTest extends BaseTest {
         clipDataIntent.putExtra(RemoteInput.EXTRA_RESULTS_DATA, resultsBundle);
         intent.setClipData(ClipData.newIntent(RESULTS_CLIP_LABEL, clipDataIntent));
 
-        iterablePushActionReceiver.onReceive(RuntimeEnvironment.application, intent);
+        iterablePushActionReceiver.onReceive(ApplicationProvider.getApplicationContext(), intent);
 
         // Verify that IterableActionRunner was called with the proper action
         ArgumentCaptor<IterableAction> actionCaptor = ArgumentCaptor.forClass(IterableAction.class);
@@ -147,7 +150,7 @@ public class IterablePushActionReceiverTest extends BaseTest {
         intent.putExtras(IterableTestUtils.getBundleFromJsonResource("push_payload_legacy_deep_link.json"));
         intent.putExtra(IterableConstants.ITERABLE_DATA_ACTION_IDENTIFIER, IterableConstants.ITERABLE_ACTION_DEFAULT);
 
-        iterablePushActionReceiver.onReceive(RuntimeEnvironment.application, intent);
+        iterablePushActionReceiver.onReceive(ApplicationProvider.getApplicationContext(), intent);
 
         // Verify that IterableActionRunner was called with openUrl action
         ArgumentCaptor<IterableAction> capturedAction = ArgumentCaptor.forClass(IterableAction.class);

--- a/iterableapi/src/test/java/com/iterable/iterableapi/IterableTestUtils.java
+++ b/iterableapi/src/test/java/com/iterable/iterableapi/IterableTestUtils.java
@@ -2,9 +2,10 @@ package com.iterable.iterableapi;
 
 import android.os.Bundle;
 
+import androidx.test.core.app.ApplicationProvider;
+
 import org.json.JSONException;
 import org.json.JSONObject;
-import org.robolectric.RuntimeEnvironment;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -48,7 +49,7 @@ public class IterableTestUtils {
             builder = extender.run(builder);
         }
 
-        IterableApi.initialize(RuntimeEnvironment.application, apiKey, builder.build());
+        IterableApi.initialize(ApplicationProvider.getApplicationContext(), apiKey, builder.build());
         IterableApi.getInstance().setEmail(email);
     }
 
@@ -60,7 +61,7 @@ public class IterableTestUtils {
         InputStream inputStream = IterableTestUtils.class.getClassLoader().getResourceAsStream(fileName);
         InputStreamReader inputStreamReader = new InputStreamReader(inputStream);
         BufferedReader bufferedReader = new BufferedReader(inputStreamReader);
-        String receiveString = "";
+        String receiveString;
         StringBuilder stringBuilder = new StringBuilder();
 
         while ((receiveString = bufferedReader.readLine()) != null) {


### PR DESCRIPTION
## 🔹 Jira Ticket(s) if any

N/A

## ✏️ Description

This PR contains multiple commits to update your usage of Robolectric:
- Remove declarations of `org.robolectric:shadows-playservices`, since it doesn't seem to be needed.
- Replace usages of `RuntimeEnvironment.application` with `ApplicationProvider.getApplicationContext()`. The former is deprecated, and the recommended alternative is either `RuntimeEnvironment.getApplication()` or `ApplicationProvider.getApplicationContext()` (provided by AndroidX Test). I went with the AndroidX Test alternative, as it makes the test less Robolectric-dependent (i.e. it may be run on a device too).

A couple of small fixes were also made in the `README.md` file to use the correct min SDK version and fix the link to the license file.