### PR TITLE
[MOB-11168] - Revert minifyEnabled

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,7 +23,7 @@ android {
 
     buildTypes {
         release {
-            minifyEnabled true
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
 

--- a/iterableapi-ui/build.gradle
+++ b/iterableapi-ui/build.gradle
@@ -32,7 +32,7 @@ android {
 
     buildTypes {
         release {
-            minifyEnabled true
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
 


### PR DESCRIPTION
## 🔹 Jira Ticket(s) if any

* [MOB-XXXX](https://iterable.atlassian.net/browse/MOB-11168)

## ✏️ Description

> Reverting this change as the obfuscation is preventing us to refer embedded ui files while in staging. And thinking this could affect in release builds as well. Good that we caught this here. In fact all the release should be tested against staging is what I am getting now.
