### PR TITLE
[MOB - 11292] - Process Pending Action First

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- SDK now retries `trackPushOpen` call when JWT is missing or expired, ensuring reliable push tracking after token acquisition.
 
 ## [3.5.12]
 

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
@@ -618,6 +618,7 @@ public class IterableApi {
 
         sharedInstance.retrieveEmailAndUserId();
 
+        IterablePushNotificationUtil.processPendingAction(context);
         IterableActivityMonitor.getInstance().registerLifecycleCallbacks(context);
         IterableActivityMonitor.getInstance().addCallback(sharedInstance.activityMonitorListener);
 
@@ -636,7 +637,6 @@ public class IterableApi {
         }
 
         loadLastSavedConfiguration(context);
-        IterablePushNotificationUtil.processPendingAction(context);
         if (DeviceInfoUtils.isFireTV(context.getPackageManager())) {
             try {
                 JSONObject dataFields = new JSONObject();


### PR DESCRIPTION

## 🔹 Jira Ticket(s) if any

* [MOB-11292](https://iterable.atlassian.net/browse/MOB-11292)

## ✏️ Description

SDK calls getMessages, registerDevice Apis when initializing. When push track happens, initialization also includes push track in the sequence. However, in current sequence, process pending actions which lead to push tracking was done after lifecycle handling was done where getMessages and registerDevice happens.

JWT mechanism only retries the first failed call. Thus push track open would not get retried as the first failing call would be getMessages and that would be retried when JWT failure occurred.

This PR will change the sequence and make sure Push related APIs are first in line so they are retried instead of getMessages. This solution is better than current one as the sequence of api calls will more align with iOS behavior and we will retain a tracking metric by retrying those instead of getMessages which anyways a lesser important API call.

A true caching mechanism still doesn't not exist where all the requests are cached and retried but this definitely should unblock the customer



[MOB-11292]: https://iterable.atlassian.net/browse/MOB-11292?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ