### PR TITLE
Migrate from OSSRH to Sonatype Central publishing

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,3 +4,7 @@ root = true
 indent_style = space
 indent_size = 4
 tab_width = 4
+
+[*.{yml,yaml}]
+indent_size = 2
+tab_width = 2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,12 @@
-name: Publish to Maven Central
+name: Publish to Sonatype Central
 
 on:
   push:
+    branches:
+      - sonatype-publish # for testing the action
     tags:
-      - 'v*' # Trigger on version tags
+      - "*.*.*" # Match semantic version tags like 3.5.13
+      - "*.*.*-*" # Match pre-release tags like 3.6.0-beta1, 3.5.12-stg
   workflow_dispatch: # Allow manual trigger
 
 jobs:
@@ -15,30 +18,24 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
-          distribution: 'temurin'
+          java-version: "17"
+          distribution: "temurin"
           cache: gradle
 
-      - name: Import GPG Key
+      - name: Import GPG Key and Create Secring
         run: |
-          echo "${{ secrets.GPG_PRIVATE_KEY }}" | base64 -d > private.gpg
-          gpg --batch --import private.gpg
-          rm private.gpg
+          echo "${{ secrets.GPG_PRIVATE_KEY }}" | base64 -d | gpg --batch --import
+          # Create secring.gpg for Gradle signing plugin compatibility
+          gpg --batch --pinentry-mode loopback --passphrase "${{ secrets.GPG_PASSPHRASE }}" --export-secret-keys > ~/.gnupg/secring.gpg
+          # Extract last 8 characters for short format
+          GPG_KEY_ID="${{ secrets.GPG_KEY_ID }}"
+          echo "SHORT_GPG_KEY_ID=${GPG_KEY_ID: -8}" >> $GITHUB_ENV
 
-      - name: Build
-        run: ./gradlew clean build
+      - name: Build and Publish to Sonatype Central
+        run: ./gradlew clean assemble publishAllPublicationsToCentralPortal
         env:
-          ORG_GRADLE_PROJECT_SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
-          ORG_GRADLE_PROJECT_SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
-          ORG_GRADLE_PROJECT_SIGNING_SECRET_KEY_RING_FILE: ~/.gnupg/secring.gpg
-          ORG_GRADLE_PROJECT_NEXUS_USERNAME: ${{ secrets.NEXUS_USERNAME }}
-          ORG_GRADLE_PROJECT_NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
-
-      - name: Publish to Maven Central
-        run: ./gradlew uploadArchives
-        env:
-          ORG_GRADLE_PROJECT_SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
-          ORG_GRADLE_PROJECT_SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
-          ORG_GRADLE_PROJECT_SIGNING_SECRET_KEY_RING_FILE: ~/.gnupg/secring.gpg
-          ORG_GRADLE_PROJECT_NEXUS_USERNAME: ${{ secrets.NEXUS_USERNAME }}
-          ORG_GRADLE_PROJECT_NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }} 
+          ORG_GRADLE_PROJECT_SIGNING_KEY_ID: ${{ env.SHORT_GPG_KEY_ID }}
+          ORG_GRADLE_PROJECT_SIGNING_PASSWORD: ${{ secrets.GPG_PASSPHRASE }}
+          ORG_GRADLE_PROJECT_SIGNING_SECRET_KEY_RING_FILE: /home/runner/.gnupg/secring.gpg
+          ORG_GRADLE_PROJECT_SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+          ORG_GRADLE_PROJECT_SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}

--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,5 @@ pom.xml.next
 release.properties
 
 jacoco.exec
+# VSCode settings
+.vscode/

--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,7 @@ buildscript {
             exclude group: 'org.codehaus.groovy', module: 'groovy-all'
         }
         classpath "com.github.dcendents:android-maven-gradle-plugin:2.1"
+        classpath "com.gradleup.nmcp:nmcp:0.0.8"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/maven-push.gradle
+++ b/maven-push.gradle
@@ -16,50 +16,42 @@
 
 apply plugin: 'maven-publish'
 apply plugin: 'signing'
+apply plugin: 'com.gradleup.nmcp'
 
 Properties properties = new Properties()
-properties.load(project.rootProject.file('local.properties').newDataInputStream())
+if (project.rootProject.file('local.properties').exists()) {
+    properties.load(project.rootProject.file('local.properties').newDataInputStream())
+}
 
 def isReleaseBuild() {
     return libraryVersion.contains("SNAPSHOT") == false
 }
 
-def getReleaseRepositoryUrl() {
-    return hasProperty('RELEASE_REPOSITORY_URL') ? RELEASE_REPOSITORY_URL
-            : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
-}
+// Set the project version
+project.version = libraryVersion
 
-def getSnapshotRepositoryUrl() {
-    return hasProperty('SNAPSHOT_REPOSITORY_URL') ? SNAPSHOT_REPOSITORY_URL
-            : "https://oss.sonatype.org/content/repositories/snapshots/"
-}
-
-def getRepositoryUsername() {
-    return hasProperty('NEXUS_USERNAME') ? NEXUS_USERNAME : ""
-}
-
-def getRepositoryPassword() {
-    return hasProperty('NEXUS_PASSWORD') ? NEXUS_PASSWORD : ""
-}
-
-def keyID = properties.getProperty("signing.keyId")
-def signing_password = properties.getProperty("signing.password")
-def keyRingLocation = properties.getProperty("signing.secretKeyRingFile")
-def nexus_username = properties.getProperty("NEXUS_USERNAME")
-def nexus_password = properties.getProperty("NEXUS_PASSWORD")
+// Simple property lookup: local.properties first, then project properties (from ORG_GRADLE_PROJECT_* env vars)
+def keyID = properties.getProperty("signing.keyId") ?: findProperty('SIGNING_KEY_ID')
+def signing_password = properties.getProperty("signing.password") ?: findProperty('SIGNING_PASSWORD')
+def keyRingLocation = properties.getProperty("signing.secretKeyRingFile") ?: findProperty('SIGNING_SECRET_KEY_RING_FILE')
+def sonatype_username = properties.getProperty("SONATYPE_USERNAME") ?: findProperty('SONATYPE_USERNAME')
+def sonatype_password = properties.getProperty("SONATYPE_PASSWORD") ?: findProperty('SONATYPE_PASSWORD')
 
 ext."signing.keyId" = keyID
-ext."signing.secretKeyRingFile" = keyRingLocation
 ext."signing.password" = signing_password
+
+// Set secretKeyRingFile if provided
+if (keyRingLocation) {
+    ext."signing.secretKeyRingFile" = keyRingLocation
+}
 
 publishing {
     publications {
         release(MavenPublication) {
-            groupId = GROUP
-            artifactId = libraryName
-            version = libraryVersion
-
             afterEvaluate {
+                groupId = GROUP
+                artifactId = libraryName
+                version = libraryVersion
                 from components.release
             }
 
@@ -92,32 +84,17 @@ publishing {
             }
         }
     }
-    repositories {
-        maven {
-            name = "OSSRH"
-            url = isReleaseBuild() ? getReleaseRepositoryUrl() : getSnapshotRepositoryUrl()
-            credentials {
-                username = nexus_username
-                password = nexus_password
-            }
-        }
-    }
 }
 
 signing {
-    required { isReleaseBuild() }
+    required { isReleaseBuild() && keyID }
     sign publishing.publications.release
 }
 
-tasks.register('uploadArchives') {
-    dependsOn publishReleasePublicationToOSSRHRepository
-}
-
-tasks.register('androidSourcesJar', Jar) {
-    archiveClassifier = 'sources'
-    from android.sourceSets.main.java.sourceFiles
-}
-
-artifacts {
-    archives androidSourcesJar
+nmcp {
+    publishAllPublications {
+        username = sonatype_username
+        password = sonatype_password
+        publicationType = "AUTOMATIC"
+    }
 }


### PR DESCRIPTION
## 🔹 Jira Ticket(s) if any

N/A

## ✏️ Description

Migrates Android SDK publishing from legacy OSSRH to the new Sonatype Central publishing system using the NMCP plugin. This includes:

- Updated GitHub Actions workflow to use Sonatype Central authentication
- Configured NMCP plugin for automatic publishing
- Added GPG signing configuration for CI
- Simplified publishing tasks by removing legacy uploadArchives wrapper

The migration maintains backward compatibility while modernizing the publishing infrastructure.