### PR TITLE
[MOB-11677] consent logging

### DIFF
--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
@@ -919,7 +919,6 @@ public class IterableApi {
                 _userIdUnknown = null;
             }
 
-            // Track consent for the newly identified user (known user = true since they're signing in)
             trackConsentForUser(isEmail ? emailOrUserId : null, isEmail ? null : emailOrUserId, true);
             unknownUserManager.clearVisitorEventsAndUserData();
         }
@@ -1477,17 +1476,15 @@ public class IterableApi {
      * @param userId User ID (if available)
      * @param isUserKnown true if user is signing in (known user), false if user meets criteria and ID is generated
      */
-    private void trackConsentForUser(@Nullable String email, @Nullable String userId, boolean isUserKnown) {
+    void trackConsentForUser(@Nullable String email, @Nullable String userId, boolean isUserKnown) {
         if (!config.enableUnknownUserActivation || !getVisitorUsageTracked()) {
             return;
         }
         
         SharedPreferences sharedPref = getMainActivityContext().getSharedPreferences(IterableConstants.SHARED_PREFS_FILE, Context.MODE_PRIVATE);
         Long timeOfConsent = sharedPref.getLong(IterableConstants.SHARED_PREFS_VISITOR_USAGE_TRACKED_TIME, 0);
-        
-        if (timeOfConsent > 0) {
-            apiClient.trackConsent(userId, email, timeOfConsent, isUserKnown);
-        }
+
+        apiClient.trackConsent(userId, email, timeOfConsent, isUserKnown);
     }
 
 //endregion

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
@@ -17,6 +17,8 @@ import com.iterable.iterableapi.util.DeviceInfoUtils;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import java.time.Instant;
+import java.util.Calendar;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Objects;
@@ -1445,6 +1447,28 @@ public class IterableApi {
         apiClient.trackEmbeddedClick(message, buttonIdentifier, clickedUrl);
     }
 
+    public void setVisitorUsageTracked(@NonNull Boolean isSetVisitorUsageTracked) {
+        SharedPreferences sharedPref = sharedInstance.getMainActivityContext().getSharedPreferences(IterableConstants.SHARED_PREFS_FILE, Context.MODE_PRIVATE);
+        SharedPreferences.Editor editor = sharedPref.edit();
+        editor.putString(IterableConstants.SHARED_PREFS_UNKNOWN_SESSIONS, "");
+        editor.putString(IterableConstants.SHARED_PREFS_EVENT_LIST_KEY, "");
+        editor.putString(IterableConstants.SHARED_PREFS_USER_UPDATE_OBJECT_KEY, "");
+        editor.putString(IterableConstants.SHARED_PREFS_CRITERIA, "");
+        editor.putBoolean(IterableConstants.SHARED_PREFS_VISITOR_USAGE_TRACKED, isSetVisitorUsageTracked);
+        editor.putLong(IterableConstants.SHARED_PREFS_VISITOR_USAGE_TRACKED_TIME, IterableUtil.currentTimeMillis());
+        editor.apply();
+
+        if (isSetVisitorUsageTracked && config.enableUnknownUserActivation) {
+            unknownUserManager.updateUnknownSession();
+            unknownUserManager.getCriteria();
+        }
+    }
+
+    public boolean getVisitorUsageTracked() {
+        SharedPreferences sharedPreferences = sharedInstance.getMainActivityContext().getSharedPreferences(IterableConstants.SHARED_PREFS_FILE, Context.MODE_PRIVATE);
+        return sharedPreferences.getBoolean(IterableConstants.SHARED_PREFS_VISITOR_USAGE_TRACKED, false);
+    }
+
 //endregion
 
 //region DEPRECATED - API public functions
@@ -1577,27 +1601,6 @@ public class IterableApi {
         }
 
         apiClient.trackEmbeddedSession(session);
-    }
-
-    public void setVisitorUsageTracked(@NonNull Boolean isSetVisitorUsageTracked) {
-        SharedPreferences sharedPref = sharedInstance.getMainActivityContext().getSharedPreferences(IterableConstants.SHARED_PREFS_FILE, Context.MODE_PRIVATE);
-        SharedPreferences.Editor editor = sharedPref.edit();
-        editor.putString(IterableConstants.SHARED_PREFS_UNKNOWN_SESSIONS, "");
-        editor.putString(IterableConstants.SHARED_PREFS_EVENT_LIST_KEY, "");
-        editor.putString(IterableConstants.SHARED_PREFS_USER_UPDATE_OBJECT_KEY, "");
-        editor.putString(IterableConstants.SHARED_PREFS_CRITERIA, "");
-        editor.putBoolean(IterableConstants.SHARED_PREFS_VISITOR_USAGE_TRACKED, isSetVisitorUsageTracked);
-        editor.apply();
-
-        if (isSetVisitorUsageTracked && config.enableUnknownUserActivation) {
-            unknownUserManager.updateUnknownSession();
-            unknownUserManager.getCriteria();
-        }
-    }
-
-    public boolean getVisitorUsageTracked() {
-        SharedPreferences sharedPreferences = sharedInstance.getMainActivityContext().getSharedPreferences(IterableConstants.SHARED_PREFS_FILE, Context.MODE_PRIVATE);
-        return sharedPreferences.getBoolean(IterableConstants.SHARED_PREFS_VISITOR_USAGE_TRACKED, false);
     }
 //endregion
 }

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
@@ -17,8 +17,6 @@ import com.iterable.iterableapi.util.DeviceInfoUtils;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import java.time.Instant;
-import java.util.Calendar;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Objects;

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
@@ -1470,7 +1470,7 @@ public class IterableApi {
         editor.putString(IterableConstants.SHARED_PREFS_CRITERIA, "");
         editor.putBoolean(IterableConstants.SHARED_PREFS_VISITOR_USAGE_TRACKED, isSetVisitorUsageTracked);
 
-        if(isSetVisitorUsageTracked) {
+        if (isSetVisitorUsageTracked) {
             editor.putLong(IterableConstants.SHARED_PREFS_VISITOR_USAGE_TRACKED_TIME, IterableUtil.currentTimeMillis());
         } else {
             editor.putLong(IterableConstants.SHARED_PREFS_VISITOR_USAGE_TRACKED_TIME, 0);

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
@@ -913,13 +913,13 @@ public class IterableApi {
 
             if (replay && (_userId != null || _email != null)) {
                 unknownUserManager.syncEventsAndUserUpdate();
+//                trackConsentForUser(isEmail ? emailOrUserId : null, isEmail ? null : emailOrUserId, true);
             }
 
             if (!isUnknown) {
                 _userIdUnknown = null;
             }
 
-            trackConsentForUser(isEmail ? emailOrUserId : null, isEmail ? null : emailOrUserId, true);
             unknownUserManager.clearVisitorEventsAndUserData();
         }
     }

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
@@ -913,7 +913,7 @@ public class IterableApi {
 
             if (replay && (_userId != null || _email != null)) {
                 unknownUserManager.syncEventsAndUserUpdate();
-//                trackConsentForUser(isEmail ? emailOrUserId : null, isEmail ? null : emailOrUserId, true);
+                trackConsentForUser(isEmail ? emailOrUserId : null, isEmail ? null : emailOrUserId, !isUnknown);
             }
 
             if (!isUnknown) {

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
@@ -826,6 +826,7 @@ public class IterableApi {
 
         if(email == null) {
             unknownUserManager.setCriteriaMatched(false);
+            setEventReplayHandled(false);
         }
 
         _setUserSuccessCallbackHandler = successHandler;
@@ -894,6 +895,7 @@ public class IterableApi {
 
         if(userId == null) {
             unknownUserManager.setCriteriaMatched(false);
+            setEventReplayHandled(false);
         }
 
         _setUserSuccessCallbackHandler = successHandler;
@@ -911,6 +913,10 @@ public class IterableApi {
         return (iterableIdentityResolution != null) ? iterableIdentityResolution.getReplayOnVisitorToKnown() : config.identityResolution.getReplayOnVisitorToKnown();
     }
 
+    void setEventReplayHandled(boolean eventReplayHandled) {
+        this._eventReplayHandled = eventReplayHandled;
+    }
+
     private void attemptMergeAndEventReplay(@Nullable String emailOrUserId, boolean isEmail, boolean merge, boolean replay, boolean isUnknown, IterableHelper.FailureHandler failureHandler) {
         if (config.enableUnknownUserActivation && getVisitorUsageTracked()) {
 
@@ -921,12 +927,11 @@ public class IterableApi {
             if (replay && !_eventReplayHandled && (_userId != null || _email != null)) {
                 unknownUserManager.syncEventsAndUserUpdate();
                 trackConsentForUser(isEmail ? emailOrUserId : null, isEmail ? null : emailOrUserId, !isUnknown);
-                _eventReplayHandled = true;
+                setEventReplayHandled(true);
             }
 
             if (!isUnknown) {
                 _userIdUnknown = null;
-                _eventReplayHandled = false;
             }
 
             unknownUserManager.clearVisitorEventsAndUserData();

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
@@ -1469,7 +1469,13 @@ public class IterableApi {
         editor.putString(IterableConstants.SHARED_PREFS_USER_UPDATE_OBJECT_KEY, "");
         editor.putString(IterableConstants.SHARED_PREFS_CRITERIA, "");
         editor.putBoolean(IterableConstants.SHARED_PREFS_VISITOR_USAGE_TRACKED, isSetVisitorUsageTracked);
-        editor.putLong(IterableConstants.SHARED_PREFS_VISITOR_USAGE_TRACKED_TIME, IterableUtil.currentTimeMillis());
+
+        if(isSetVisitorUsageTracked) {
+            editor.putLong(IterableConstants.SHARED_PREFS_VISITOR_USAGE_TRACKED_TIME, IterableUtil.currentTimeMillis());
+        } else {
+            editor.putLong(IterableConstants.SHARED_PREFS_VISITOR_USAGE_TRACKED_TIME, 0);
+        }
+
         editor.apply();
 
         if (isSetVisitorUsageTracked && config.enableUnknownUserActivation) {

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
@@ -920,7 +920,7 @@ public class IterableApi {
             if (replay && (_userId != null || _email != null)) {
                 unknownUserManager.syncEventsAndUserUpdate();
 
-                if(_userIdUnknown == null) {
+                if (_userIdUnknown == null) {
                     trackConsentForUser(isEmail ? emailOrUserId : null, isEmail ? null : emailOrUserId, true);
                 }
             }

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
@@ -43,6 +43,7 @@ public class IterableApi {
     private IterableNotificationData _notificationData;
     private String _deviceId;
     private boolean _firstForegroundHandled;
+    private boolean _eventReplayHandled = false;
     private IterableHelper.SuccessHandler _setUserSuccessCallbackHandler;
     private IterableHelper.FailureHandler _setUserFailureCallbackHandler;
 
@@ -823,6 +824,10 @@ public class IterableApi {
             attemptMergeAndEventReplay(email, true, merge, replay, false, failureHandler);
         }
 
+        if(email == null) {
+            unknownUserManager.setCriteriaMatched(false);
+        }
+
         _setUserSuccessCallbackHandler = successHandler;
         _setUserFailureCallbackHandler = failureHandler;
         storeAuthData();
@@ -887,6 +892,10 @@ public class IterableApi {
             attemptMergeAndEventReplay(userId, false, merge, replay, isUnknown, failureHandler);
         }
 
+        if(userId == null) {
+            unknownUserManager.setCriteriaMatched(false);
+        }
+
         _setUserSuccessCallbackHandler = successHandler;
         _setUserFailureCallbackHandler = failureHandler;
         storeAuthData();
@@ -909,13 +918,15 @@ public class IterableApi {
                 attemptAndProcessMerge(emailOrUserId, isEmail, merge, failureHandler, _userIdUnknown);
             }
 
-            if (replay && (_userId != null || _email != null)) {
+            if (replay && !_eventReplayHandled && (_userId != null || _email != null)) {
                 unknownUserManager.syncEventsAndUserUpdate();
                 trackConsentForUser(isEmail ? emailOrUserId : null, isEmail ? null : emailOrUserId, !isUnknown);
+                _eventReplayHandled = true;
             }
 
             if (!isUnknown) {
                 _userIdUnknown = null;
+                _eventReplayHandled = false;
             }
 
             unknownUserManager.clearVisitorEventsAndUserData();

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
@@ -824,7 +824,7 @@ public class IterableApi {
             attemptMergeAndEventReplay(email, true, merge, replay, false, failureHandler);
         }
 
-        if(email == null) {
+        if (email == null) {
             unknownUserManager.setCriteriaMatched(false);
             setEventReplayHandled(false);
         }
@@ -893,7 +893,7 @@ public class IterableApi {
             attemptMergeAndEventReplay(userId, false, merge, replay, isUnknown, failureHandler);
         }
 
-        if(userId == null) {
+        if (userId == null) {
             unknownUserManager.setCriteriaMatched(false);
             setEventReplayHandled(false);
         }
@@ -1494,7 +1494,7 @@ public class IterableApi {
         if (!config.enableUnknownUserActivation || !getVisitorUsageTracked()) {
             return;
         }
-        
+
         SharedPreferences sharedPref = getMainActivityContext().getSharedPreferences(IterableConstants.SHARED_PREFS_FILE, Context.MODE_PRIVATE);
         Long timeOfConsent = sharedPref.getLong(IterableConstants.SHARED_PREFS_VISITOR_USAGE_TRACKED_TIME, 0);
 

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableApiClient.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableApiClient.java
@@ -829,4 +829,26 @@ class IterableApiClient {
             e.printStackTrace();
         }
     }
+
+    void trackConsent(String userId, String email, @NonNull Long timestamp, boolean isUserKnown) {
+        JSONObject requestJSON = new JSONObject();
+        
+        try {
+            requestJSON.put(IterableConstants.KEY_CONSENT_TIMESTAMP, timestamp);
+            
+            if (email != null) {
+                requestJSON.put(IterableConstants.KEY_EMAIL, email);
+            }
+            if (userId != null) {
+                requestJSON.put(IterableConstants.KEY_USER_ID, userId);
+            }
+            
+            requestJSON.put(IterableConstants.KEY_IS_USER_KNOWN, isUserKnown);
+            requestJSON.put(IterableConstants.KEY_DEVICE_INFO, getDeviceInfoJson());
+            
+            sendPostRequest(IterableConstants.ENDPOINT_TRACK_CONSENT, requestJSON);
+        } catch (JSONException e) {
+            e.printStackTrace();
+        }
+    }
 }

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableApiClient.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableApiClient.java
@@ -830,7 +830,7 @@ class IterableApiClient {
         }
     }
 
-    void trackConsent(String userId, String email, @NonNull Long timestamp, boolean isUserKnown) {
+    void trackConsent(@Nullable String userId, @Nullable String email, @NonNull Long timestamp, boolean isUserKnown) {
         JSONObject requestJSON = new JSONObject();
 
         try {

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableApiClient.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableApiClient.java
@@ -835,17 +835,14 @@ class IterableApiClient {
 
         try {
             requestJSON.put(IterableConstants.KEY_CONSENT_TIMESTAMP, timestamp);
-
             if (email != null) {
                 requestJSON.put(IterableConstants.KEY_EMAIL, email);
             }
             if (userId != null) {
                 requestJSON.put(IterableConstants.KEY_USER_ID, userId);
             }
-
             requestJSON.put(IterableConstants.KEY_IS_USER_KNOWN, isUserKnown);
             requestJSON.put(IterableConstants.KEY_DEVICE_INFO, getDeviceInfoJson());
-            
             sendPostRequest(IterableConstants.ENDPOINT_TRACK_CONSENT, requestJSON);
         } catch (JSONException e) {
             e.printStackTrace();

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableApiClient.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableApiClient.java
@@ -832,17 +832,17 @@ class IterableApiClient {
 
     void trackConsent(String userId, String email, @NonNull Long timestamp, boolean isUserKnown) {
         JSONObject requestJSON = new JSONObject();
-        
+
         try {
             requestJSON.put(IterableConstants.KEY_CONSENT_TIMESTAMP, timestamp);
-            
+
             if (email != null) {
                 requestJSON.put(IterableConstants.KEY_EMAIL, email);
             }
             if (userId != null) {
                 requestJSON.put(IterableConstants.KEY_USER_ID, userId);
             }
-            
+
             requestJSON.put(IterableConstants.KEY_IS_USER_KNOWN, isUserKnown);
             requestJSON.put(IterableConstants.KEY_DEVICE_INFO, getDeviceInfoJson());
             

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableConstants.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableConstants.java
@@ -59,6 +59,8 @@ public final class IterableConstants {
     public static final String KEY_FIRETV = "FireTV";
     public static final String KEY_CREATE_NEW_FIELDS    = "createNewFields";
     public static final String KEY_ANON_SESSION_CONTEXT = "anonSessionContext";
+    public static final String KEY_IS_USER_KNOWN = "isUserKnown";
+    public static final String KEY_CONSENT_TIMESTAMP = "consentTimestamp";
 
     //API Endpoint Key Constants
     public static final String ENDPOINT_DISABLE_DEVICE          = "users/disableDevice";
@@ -87,7 +89,8 @@ public final class IterableConstants {
     public static final String ENDPOINT_GET_USER_BY_EMAIL       = "users/getByEmail";
     public static final String ENDPOINT_MERGE_USER              = "users/merge";
     public static final String ENDPOINT_CRITERIA_LIST           = "anonymoususer/list";
-    public static final String ENDPOINT_TRACK_ANON_SESSION = "anonymoususer/events/session";
+    public static final String ENDPOINT_TRACK_ANON_SESSION      = "anonymoususer/events/session";
+    public static final String ENDPOINT_TRACK_CONSENT      = "unknownuser/consent";
 
     public static final String PUSH_APP_ID                      = "IterableAppId";
     public static final String PUSH_GCM_PROJECT_NUMBER          = "GCMProjectNumber";

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableConstants.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableConstants.java
@@ -138,6 +138,7 @@ public final class IterableConstants {
     public static final String SHARED_PREFS_CRITERIA_ID = "matchedCriteriaId";
     public static final String SHARED_PREFS_PUSH_OPT_IN = "mobilePushOptIn";
     public static final String SHARED_PREFS_VISITOR_USAGE_TRACKED = "itbl_visitor_usage_track";
+    public static final String SHARED_PREFS_VISITOR_USAGE_TRACKED_TIME = "itbl_visitor_usage_track_time";
     public static final String SHARED_PREFS_DEVICE_NOTIFICATIONS_ENABLED = "itbl_notifications_enabled";
 
     //Action buttons

--- a/iterableapi/src/main/java/com/iterable/iterableapi/UnknownUserManager.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/UnknownUserManager.java
@@ -215,8 +215,9 @@ public class UnknownUserManager implements IterableActivityMonitor.AppStateCallb
         SharedPreferences sharedPref = IterableApi.getInstance().getMainActivityContext().getSharedPreferences(IterableConstants.SHARED_PREFS_FILE, Context.MODE_PRIVATE);
         updateUnknownSession();
 
-        //get session data
+        //get session data and stored time of consent
         String userData = sharedPref.getString(IterableConstants.SHARED_PREFS_UNKNOWN_SESSIONS, "");
+        Long timeOfConsent = sharedPref.getLong(IterableConstants.SHARED_PREFS_VISITOR_USAGE_TRACKED_TIME, 0);
 
         //generate unknown user id
         String userId = UUID.randomUUID().toString();
@@ -244,6 +245,10 @@ public class UnknownUserManager implements IterableActivityMonitor.AppStateCallb
                         IterableApi.getInstance().config.iterableUnknownUserHandler.onUnknownUserCreated(userId);
                     }
                     IterableApi.getInstance().setUnknownUser(userId);
+                    // Track consent for the newly created unknown user (unknown user = false since ID is generated)
+                    if (timeOfConsent > 0) {
+                        iterableApi.apiClient.trackConsent(userId, null, timeOfConsent, false);
+                    }
                 }, (reason, data) -> handleTrackFailure(data));
             }
 
@@ -251,6 +256,10 @@ public class UnknownUserManager implements IterableActivityMonitor.AppStateCallb
             isCriteriaMatched = false;
             e.printStackTrace();
         }
+    }
+
+    private void handleTrackSuccess() {
+
     }
 
     private void handleTrackFailure(JSONObject data) {

--- a/iterableapi/src/main/java/com/iterable/iterableapi/UnknownUserManager.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/UnknownUserManager.java
@@ -244,7 +244,6 @@ public class UnknownUserManager implements IterableActivityMonitor.AppStateCallb
                         IterableApi.getInstance().config.iterableUnknownUserHandler.onUnknownUserCreated(userId);
                     }
                     IterableApi.getInstance().setUnknownUser(userId);
-//                    IterableApi.getInstance().trackConsentForUser(null, userId, false);
                 }, (reason, data) -> handleTrackFailure(data));
             }
 

--- a/iterableapi/src/main/java/com/iterable/iterableapi/UnknownUserManager.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/UnknownUserManager.java
@@ -244,10 +244,7 @@ public class UnknownUserManager implements IterableActivityMonitor.AppStateCallb
                         IterableApi.getInstance().config.iterableUnknownUserHandler.onUnknownUserCreated(userId);
                     }
                     IterableApi.getInstance().setUnknownUser(userId);
-                    // Track consent for the newly created unknown user (unknown user = false since ID is generated)
-                    if (timeOfConsent > 0) {
-                        iterableApi.apiClient.trackConsent(userId, null, timeOfConsent, false);
-                    }
+                    IterableApi.getInstance().trackConsentForUser(null, userId, false);
                 }, (reason, data) -> handleTrackFailure(data));
             }
 

--- a/iterableapi/src/main/java/com/iterable/iterableapi/UnknownUserManager.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/UnknownUserManager.java
@@ -214,9 +214,8 @@ public class UnknownUserManager implements IterableActivityMonitor.AppStateCallb
         SharedPreferences sharedPref = IterableApi.getInstance().getMainActivityContext().getSharedPreferences(IterableConstants.SHARED_PREFS_FILE, Context.MODE_PRIVATE);
         updateUnknownSession();
 
-        //get session data and stored time of consent
+        //get session data
         String userData = sharedPref.getString(IterableConstants.SHARED_PREFS_UNKNOWN_SESSIONS, "");
-        Long timeOfConsent = sharedPref.getLong(IterableConstants.SHARED_PREFS_VISITOR_USAGE_TRACKED_TIME, 0);
 
         //generate unknown user id
         String userId = UUID.randomUUID().toString();

--- a/iterableapi/src/main/java/com/iterable/iterableapi/UnknownUserManager.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/UnknownUserManager.java
@@ -367,10 +367,14 @@ public class UnknownUserManager implements IterableActivityMonitor.AppStateCallb
         Log.i("TEST_USER", "criteriaId::" + String.valueOf(criteriaId));
 
         if (criteriaId != null && !isCriteriaMatched) {
-            isCriteriaMatched = true;
+            setCriteriaMatched(true);
             createUnknownUser(criteriaId);
         }
         Log.i("criteriaId::", String.valueOf(criteriaId != null));
+    }
+
+    void setCriteriaMatched(boolean isCriteriaMatched) {
+        this.isCriteriaMatched = isCriteriaMatched;
     }
 
     private void storeUserUpdateToLocalStorage(JSONObject newDataObject) throws JSONException {

--- a/iterableapi/src/main/java/com/iterable/iterableapi/UnknownUserManager.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/UnknownUserManager.java
@@ -251,7 +251,7 @@ public class UnknownUserManager implements IterableActivityMonitor.AppStateCallb
             e.printStackTrace();
         }
     }
-    
+
     private void handleTrackFailure(JSONObject data) {
         isCriteriaMatched = false;
         if (data != null && data.has(IterableConstants.HTTP_STATUS_CODE)) {

--- a/iterableapi/src/main/java/com/iterable/iterableapi/UnknownUserManager.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/UnknownUserManager.java
@@ -257,11 +257,7 @@ public class UnknownUserManager implements IterableActivityMonitor.AppStateCallb
             e.printStackTrace();
         }
     }
-
-    private void handleTrackSuccess() {
-
-    }
-
+    
     private void handleTrackFailure(JSONObject data) {
         isCriteriaMatched = false;
         if (data != null && data.has(IterableConstants.HTTP_STATUS_CODE)) {

--- a/iterableapi/src/main/java/com/iterable/iterableapi/UnknownUserManager.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/UnknownUserManager.java
@@ -243,6 +243,7 @@ public class UnknownUserManager implements IterableActivityMonitor.AppStateCallb
                         IterableApi.getInstance().config.iterableUnknownUserHandler.onUnknownUserCreated(userId);
                     }
                     IterableApi.getInstance().setUnknownUser(userId);
+                    IterableApi.getInstance().trackConsentForUser(null, userId, false);
                 }, (reason, data) -> handleTrackFailure(data));
             }
 

--- a/iterableapi/src/main/java/com/iterable/iterableapi/UnknownUserManager.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/UnknownUserManager.java
@@ -244,7 +244,7 @@ public class UnknownUserManager implements IterableActivityMonitor.AppStateCallb
                         IterableApi.getInstance().config.iterableUnknownUserHandler.onUnknownUserCreated(userId);
                     }
                     IterableApi.getInstance().setUnknownUser(userId);
-                    IterableApi.getInstance().trackConsentForUser(null, userId, false);
+//                    IterableApi.getInstance().trackConsentForUser(null, userId, false);
                 }, (reason, data) -> handleTrackFailure(data));
             }
 

--- a/iterableapi/src/test/java/com/iterable/iterableapi/IterableApiAuthTests.java
+++ b/iterableapi/src/test/java/com/iterable/iterableapi/IterableApiAuthTests.java
@@ -492,7 +492,7 @@ public class IterableApiAuthTests extends BaseTest {
         shadowOf(getMainLooper()).runToEndOfTasks();
 
         // Request auth token which should set a timer for expiration refresh
-        authManager.requestNewAuthToken(false);
+        authManager.requestNewAuthToken(false, null);
         shadowOf(getMainLooper()).runToEndOfTasks();
 
         // The timer might be null if the token is considered expired, so let's test the behavior

--- a/iterableapi/src/test/java/com/iterable/iterableapi/IterableApiMergeUserEmailTests.java
+++ b/iterableapi/src/test/java/com/iterable/iterableapi/IterableApiMergeUserEmailTests.java
@@ -351,6 +351,7 @@ public class IterableApiMergeUserEmailTests extends BaseTest {
         // mock unknown user session response and track purchase response
         addResponse(IterableConstants.ENDPOINT_TRACK_UNKNOWN_SESSION);
         addResponse(IterableConstants.ENDPOINT_TRACK_PURCHASE);
+        addResponse(IterableConstants.ENDPOINT_GET_INAPP_MESSAGES);
         addResponse(IterableConstants.ENDPOINT_TRACK_CONSENT);
 
         // trigger track purchase event
@@ -366,6 +367,12 @@ public class IterableApiMergeUserEmailTests extends BaseTest {
         RecordedRequest purchaseRequest = server.takeRequest(1, TimeUnit.SECONDS);
         assertNotNull("Purchase request should not be null", purchaseRequest);
         assertEquals("/" + IterableConstants.ENDPOINT_TRACK_PURCHASE, purchaseRequest.getPath());
+
+        // check if request was sent to getInAppMessages endpoint (triggered by completeUserLogin)
+        RecordedRequest inAppRequest = server.takeRequest(1, TimeUnit.SECONDS);
+        assertNotNull("InApp messages request should be sent", inAppRequest);
+        assertTrue("InApp messages request path should start with correct endpoint", 
+            inAppRequest.getPath().startsWith("/" + IterableConstants.ENDPOINT_GET_INAPP_MESSAGES));
 
         // check if request was sent to track consent endpoint
         RecordedRequest consentRequest = server.takeRequest(1, TimeUnit.SECONDS);
@@ -405,6 +412,7 @@ public class IterableApiMergeUserEmailTests extends BaseTest {
         // mock unknown user session response and track purchase response
         addResponse(IterableConstants.ENDPOINT_TRACK_UNKNOWN_SESSION);
         addResponse(IterableConstants.ENDPOINT_TRACK_PURCHASE);
+        addResponse(IterableConstants.ENDPOINT_GET_INAPP_MESSAGES);
         addResponse(IterableConstants.ENDPOINT_TRACK_CONSENT);
 
         // trigger track purchase event
@@ -420,6 +428,12 @@ public class IterableApiMergeUserEmailTests extends BaseTest {
         RecordedRequest purchaseRequest = server.takeRequest(1, TimeUnit.SECONDS);
         assertNotNull("Purchase request should not be null", purchaseRequest);
         assertEquals("/" + IterableConstants.ENDPOINT_TRACK_PURCHASE, purchaseRequest.getPath());
+
+        // check if request was sent to getInAppMessages endpoint (triggered by completeUserLogin)
+        RecordedRequest inAppRequest = server.takeRequest(1, TimeUnit.SECONDS);
+        assertNotNull("InApp messages request should be sent", inAppRequest);
+        assertTrue("InApp messages request path should start with correct endpoint", 
+            inAppRequest.getPath().startsWith("/" + IterableConstants.ENDPOINT_GET_INAPP_MESSAGES));
 
         // check if request was sent to track consent endpoint
         RecordedRequest consentRequest = server.takeRequest(1, TimeUnit.SECONDS);
@@ -456,6 +470,7 @@ public class IterableApiMergeUserEmailTests extends BaseTest {
         // mock unknown user session response and track purchase response
         addResponse(IterableConstants.ENDPOINT_TRACK_UNKNOWN_SESSION);
         addResponse(IterableConstants.ENDPOINT_TRACK_PURCHASE);
+        addResponse(IterableConstants.ENDPOINT_GET_INAPP_MESSAGES);
         addResponse(IterableConstants.ENDPOINT_TRACK_CONSENT);
 
         // trigger track purchase event
@@ -471,6 +486,12 @@ public class IterableApiMergeUserEmailTests extends BaseTest {
         RecordedRequest purchaseRequest = server.takeRequest(1, TimeUnit.SECONDS);
         assertNotNull("Purchase request should not be null", purchaseRequest);
         assertEquals("/" + IterableConstants.ENDPOINT_TRACK_PURCHASE, purchaseRequest.getPath());
+
+        // check if request was sent to getInAppMessages endpoint (triggered by completeUserLogin)
+        RecordedRequest inAppRequest = server.takeRequest(1, TimeUnit.SECONDS);
+        assertNotNull("InApp messages request should be sent", inAppRequest);
+        assertTrue("InApp messages request path should start with correct endpoint", 
+            inAppRequest.getPath().startsWith("/" + IterableConstants.ENDPOINT_GET_INAPP_MESSAGES));
 
         // check if request was sent to track consent endpoint
         RecordedRequest consentRequest = server.takeRequest(1, TimeUnit.SECONDS);
@@ -784,6 +805,7 @@ public class IterableApiMergeUserEmailTests extends BaseTest {
         // mock unknown user session response and track purchase response
         addResponse(IterableConstants.ENDPOINT_TRACK_UNKNOWN_SESSION);
         addResponse(IterableConstants.ENDPOINT_TRACK_PURCHASE);
+        addResponse(IterableConstants.ENDPOINT_GET_INAPP_MESSAGES);
         addResponse(IterableConstants.ENDPOINT_TRACK_CONSENT);
 
         // trigger track purchase event
@@ -799,6 +821,12 @@ public class IterableApiMergeUserEmailTests extends BaseTest {
         RecordedRequest purchaseRequest = server.takeRequest(1, TimeUnit.SECONDS);
         assertNotNull("Purchase request should not be null", purchaseRequest);
         assertEquals("/" + IterableConstants.ENDPOINT_TRACK_PURCHASE, purchaseRequest.getPath());
+
+        // check if request was sent to getInAppMessages endpoint (triggered by completeUserLogin)
+        RecordedRequest inAppRequest = server.takeRequest(1, TimeUnit.SECONDS);
+        assertNotNull("InApp messages request should be sent", inAppRequest);
+        assertTrue("InApp messages request path should start with correct endpoint", 
+            inAppRequest.getPath().startsWith("/" + IterableConstants.ENDPOINT_GET_INAPP_MESSAGES));
 
         // check if request was sent to track consent endpoint
         RecordedRequest consentRequest = server.takeRequest(1, TimeUnit.SECONDS);
@@ -841,6 +869,7 @@ public class IterableApiMergeUserEmailTests extends BaseTest {
         // mock unknown user session response and track purchase response
         addResponse(IterableConstants.ENDPOINT_TRACK_UNKNOWN_SESSION);
         addResponse(IterableConstants.ENDPOINT_TRACK_PURCHASE);
+        addResponse(IterableConstants.ENDPOINT_GET_INAPP_MESSAGES);
         addResponse(IterableConstants.ENDPOINT_TRACK_CONSENT);
 
         // trigger track purchase event
@@ -856,6 +885,12 @@ public class IterableApiMergeUserEmailTests extends BaseTest {
         RecordedRequest purchaseRequest = server.takeRequest(1, TimeUnit.SECONDS);
         assertNotNull("Purchase request should not be null", purchaseRequest);
         assertEquals("/" + IterableConstants.ENDPOINT_TRACK_PURCHASE, purchaseRequest.getPath());
+
+        // check if request was sent to getInAppMessages endpoint (triggered by completeUserLogin)
+        RecordedRequest inAppRequest = server.takeRequest(1, TimeUnit.SECONDS);
+        assertNotNull("InApp messages request should be sent", inAppRequest);
+        assertTrue("InApp messages request path should start with correct endpoint", 
+            inAppRequest.getPath().startsWith("/" + IterableConstants.ENDPOINT_GET_INAPP_MESSAGES));
 
         // check if request was sent to track consent endpoint
         RecordedRequest consentRequest = server.takeRequest(1, TimeUnit.SECONDS);
@@ -895,6 +930,7 @@ public class IterableApiMergeUserEmailTests extends BaseTest {
         // mock unknown user session response and track purchase response
         addResponse(IterableConstants.ENDPOINT_TRACK_UNKNOWN_SESSION);
         addResponse(IterableConstants.ENDPOINT_TRACK_PURCHASE);
+        addResponse(IterableConstants.ENDPOINT_GET_INAPP_MESSAGES);
         addResponse(IterableConstants.ENDPOINT_TRACK_CONSENT);
 
         // trigger track purchase event
@@ -910,6 +946,12 @@ public class IterableApiMergeUserEmailTests extends BaseTest {
         RecordedRequest purchaseRequest = server.takeRequest(1, TimeUnit.SECONDS);
         assertNotNull("Purchase request should not be null", purchaseRequest);
         assertEquals("/" + IterableConstants.ENDPOINT_TRACK_PURCHASE, purchaseRequest.getPath());
+
+        // check if request was sent to getInAppMessages endpoint (triggered by completeUserLogin)
+        RecordedRequest inAppRequest = server.takeRequest(1, TimeUnit.SECONDS);
+        assertNotNull("InApp messages request should be sent", inAppRequest);
+        assertTrue("InApp messages request path should start with correct endpoint", 
+            inAppRequest.getPath().startsWith("/" + IterableConstants.ENDPOINT_GET_INAPP_MESSAGES));
 
         // check if request was sent to track consent endpoint
         RecordedRequest consentRequest = server.takeRequest(1, TimeUnit.SECONDS);
@@ -1037,6 +1079,7 @@ public class IterableApiMergeUserEmailTests extends BaseTest {
         addResponse(IterableConstants.ENDPOINT_TRACK_UNKNOWN_SESSION);
         addResponse(IterableConstants.ENDPOINT_TRACK_PURCHASE);
         addResponse(IterableConstants.ENDPOINT_TRACK_PURCHASE);
+        addResponse(IterableConstants.ENDPOINT_GET_INAPP_MESSAGES);
         addResponse(IterableConstants.ENDPOINT_TRACK_CONSENT);
 
         // trigger track purchase event
@@ -1058,6 +1101,12 @@ public class IterableApiMergeUserEmailTests extends BaseTest {
         RecordedRequest secondPurchaseRequest = server.takeRequest(1, TimeUnit.SECONDS);
         assertNotNull("Purchase request should not be null", secondPurchaseRequest);
         assertEquals("/" + IterableConstants.ENDPOINT_TRACK_PURCHASE, secondPurchaseRequest.getPath());
+
+        // check if request was sent to getInAppMessages endpoint (triggered by completeUserLogin)
+        RecordedRequest inAppRequest = server.takeRequest(1, TimeUnit.SECONDS);
+        assertNotNull("InApp messages request should be sent", inAppRequest);
+        assertTrue("InApp messages request path should start with correct endpoint", 
+            inAppRequest.getPath().startsWith("/" + IterableConstants.ENDPOINT_GET_INAPP_MESSAGES));
 
         // check if request was sent to track consent endpoint
         RecordedRequest consentRequest = server.takeRequest(1, TimeUnit.SECONDS);

--- a/iterableapi/src/test/java/com/iterable/iterableapi/IterableApiMergeUserEmailTests.java
+++ b/iterableapi/src/test/java/com/iterable/iterableapi/IterableApiMergeUserEmailTests.java
@@ -371,7 +371,7 @@ public class IterableApiMergeUserEmailTests extends BaseTest {
         // check if request was sent to getInAppMessages endpoint (triggered by completeUserLogin)
         RecordedRequest inAppRequest = server.takeRequest(1, TimeUnit.SECONDS);
         assertNotNull("InApp messages request should be sent", inAppRequest);
-        assertTrue("InApp messages request path should start with correct endpoint", 
+        assertTrue("InApp messages request path should start with correct endpoint",
             inAppRequest.getPath().startsWith("/" + IterableConstants.ENDPOINT_GET_INAPP_MESSAGES));
 
         // check if request was sent to track consent endpoint
@@ -432,7 +432,7 @@ public class IterableApiMergeUserEmailTests extends BaseTest {
         // check if request was sent to getInAppMessages endpoint (triggered by completeUserLogin)
         RecordedRequest inAppRequest = server.takeRequest(1, TimeUnit.SECONDS);
         assertNotNull("InApp messages request should be sent", inAppRequest);
-        assertTrue("InApp messages request path should start with correct endpoint", 
+        assertTrue("InApp messages request path should start with correct endpoint",
             inAppRequest.getPath().startsWith("/" + IterableConstants.ENDPOINT_GET_INAPP_MESSAGES));
 
         // check if request was sent to track consent endpoint
@@ -490,7 +490,7 @@ public class IterableApiMergeUserEmailTests extends BaseTest {
         // check if request was sent to getInAppMessages endpoint (triggered by completeUserLogin)
         RecordedRequest inAppRequest = server.takeRequest(1, TimeUnit.SECONDS);
         assertNotNull("InApp messages request should be sent", inAppRequest);
-        assertTrue("InApp messages request path should start with correct endpoint", 
+        assertTrue("InApp messages request path should start with correct endpoint",
             inAppRequest.getPath().startsWith("/" + IterableConstants.ENDPOINT_GET_INAPP_MESSAGES));
 
         // check if request was sent to track consent endpoint
@@ -825,7 +825,7 @@ public class IterableApiMergeUserEmailTests extends BaseTest {
         // check if request was sent to getInAppMessages endpoint (triggered by completeUserLogin)
         RecordedRequest inAppRequest = server.takeRequest(1, TimeUnit.SECONDS);
         assertNotNull("InApp messages request should be sent", inAppRequest);
-        assertTrue("InApp messages request path should start with correct endpoint", 
+        assertTrue("InApp messages request path should start with correct endpoint",
             inAppRequest.getPath().startsWith("/" + IterableConstants.ENDPOINT_GET_INAPP_MESSAGES));
 
         // check if request was sent to track consent endpoint
@@ -889,7 +889,7 @@ public class IterableApiMergeUserEmailTests extends BaseTest {
         // check if request was sent to getInAppMessages endpoint (triggered by completeUserLogin)
         RecordedRequest inAppRequest = server.takeRequest(1, TimeUnit.SECONDS);
         assertNotNull("InApp messages request should be sent", inAppRequest);
-        assertTrue("InApp messages request path should start with correct endpoint", 
+        assertTrue("InApp messages request path should start with correct endpoint",
             inAppRequest.getPath().startsWith("/" + IterableConstants.ENDPOINT_GET_INAPP_MESSAGES));
 
         // check if request was sent to track consent endpoint
@@ -950,7 +950,7 @@ public class IterableApiMergeUserEmailTests extends BaseTest {
         // check if request was sent to getInAppMessages endpoint (triggered by completeUserLogin)
         RecordedRequest inAppRequest = server.takeRequest(1, TimeUnit.SECONDS);
         assertNotNull("InApp messages request should be sent", inAppRequest);
-        assertTrue("InApp messages request path should start with correct endpoint", 
+        assertTrue("InApp messages request path should start with correct endpoint",
             inAppRequest.getPath().startsWith("/" + IterableConstants.ENDPOINT_GET_INAPP_MESSAGES));
 
         // check if request was sent to track consent endpoint
@@ -1105,7 +1105,7 @@ public class IterableApiMergeUserEmailTests extends BaseTest {
         // check if request was sent to getInAppMessages endpoint (triggered by completeUserLogin)
         RecordedRequest inAppRequest = server.takeRequest(1, TimeUnit.SECONDS);
         assertNotNull("InApp messages request should be sent", inAppRequest);
-        assertTrue("InApp messages request path should start with correct endpoint", 
+        assertTrue("InApp messages request path should start with correct endpoint",
             inAppRequest.getPath().startsWith("/" + IterableConstants.ENDPOINT_GET_INAPP_MESSAGES));
 
         // check if request was sent to track consent endpoint

--- a/iterableapi/src/test/java/com/iterable/iterableapi/IterableApiMergeUserEmailTests.java
+++ b/iterableapi/src/test/java/com/iterable/iterableapi/IterableApiMergeUserEmailTests.java
@@ -373,7 +373,7 @@ public class IterableApiMergeUserEmailTests extends BaseTest {
         assertEquals("/" + IterableConstants.ENDPOINT_TRACK_CONSENT, consentRequest.getPath());
 
         // verify track consent request body contains proper isUserKnown flag
-        JSONObject consentRequestJson = new JSONObject(consentRequest.getBody().readUtf8());;
+        JSONObject consentRequestJson = new JSONObject(consentRequest.getBody().readUtf8());
         assertFalse(consentRequestJson.getBoolean(IterableConstants.KEY_IS_USER_KNOWN));
 
         // clear any pending requests
@@ -427,7 +427,7 @@ public class IterableApiMergeUserEmailTests extends BaseTest {
         assertEquals("/" + IterableConstants.ENDPOINT_TRACK_CONSENT, consentRequest.getPath());
 
         // verify track consent request body contains proper isUserKnown flag
-        JSONObject consentRequestJson = new JSONObject(consentRequest.getBody().readUtf8());;
+        JSONObject consentRequestJson = new JSONObject(consentRequest.getBody().readUtf8());
         assertFalse(consentRequestJson.getBoolean(IterableConstants.KEY_IS_USER_KNOWN));
 
         // clear any pending requests
@@ -478,7 +478,7 @@ public class IterableApiMergeUserEmailTests extends BaseTest {
         assertEquals("/" + IterableConstants.ENDPOINT_TRACK_CONSENT, consentRequest.getPath());
 
         // verify track consent request body contains proper isUserKnown flag
-        JSONObject consentRequestJson = new JSONObject(consentRequest.getBody().readUtf8());;
+        JSONObject consentRequestJson = new JSONObject(consentRequest.getBody().readUtf8());
         assertFalse(consentRequestJson.getBoolean(IterableConstants.KEY_IS_USER_KNOWN));
 
         // clear any pending requests
@@ -806,7 +806,7 @@ public class IterableApiMergeUserEmailTests extends BaseTest {
         assertEquals("/" + IterableConstants.ENDPOINT_TRACK_CONSENT, consentRequest.getPath());
 
         // verify track consent request body contains proper isUserKnown flag
-        JSONObject consentRequestJson = new JSONObject(consentRequest.getBody().readUtf8());;
+        JSONObject consentRequestJson = new JSONObject(consentRequest.getBody().readUtf8());
         assertFalse(consentRequestJson.getBoolean(IterableConstants.KEY_IS_USER_KNOWN));
 
         // clear any pending requests
@@ -863,7 +863,7 @@ public class IterableApiMergeUserEmailTests extends BaseTest {
         assertEquals("/" + IterableConstants.ENDPOINT_TRACK_CONSENT, consentRequest.getPath());
 
         // verify track consent request body contains proper isUserKnown flag
-        JSONObject consentRequestJson = new JSONObject(consentRequest.getBody().readUtf8());;
+        JSONObject consentRequestJson = new JSONObject(consentRequest.getBody().readUtf8());
         assertFalse(consentRequestJson.getBoolean(IterableConstants.KEY_IS_USER_KNOWN));
 
         // clear any pending requests
@@ -917,7 +917,7 @@ public class IterableApiMergeUserEmailTests extends BaseTest {
         assertEquals("/" + IterableConstants.ENDPOINT_TRACK_CONSENT, consentRequest.getPath());
 
         // verify track consent request body contains proper isUserKnown flag
-        JSONObject consentRequestJson = new JSONObject(consentRequest.getBody().readUtf8());;
+        JSONObject consentRequestJson = new JSONObject(consentRequest.getBody().readUtf8());
         assertFalse(consentRequestJson.getBoolean(IterableConstants.KEY_IS_USER_KNOWN));
 
         // clear any pending requests
@@ -1065,7 +1065,7 @@ public class IterableApiMergeUserEmailTests extends BaseTest {
         assertEquals("/" + IterableConstants.ENDPOINT_TRACK_CONSENT, consentRequest.getPath());
 
         // verify track consent request body contains proper isUserKnown flag
-        JSONObject consentRequestJson = new JSONObject(consentRequest.getBody().readUtf8());;
+        JSONObject consentRequestJson = new JSONObject(consentRequest.getBody().readUtf8());
         assertFalse(consentRequestJson.getBoolean(IterableConstants.KEY_IS_USER_KNOWN));
     }
 }


### PR DESCRIPTION
## 🔹 Jira Ticket(s) if any

* [MOB-11677](https://iterable.atlassian.net/browse/MOB-11677)
* [MOB-11739](https://iterable.atlassian.net/browse/MOB-11739)

## ✏️ Description

This pull request implements the storage of the time of consent and calling a new method, trackConsent, when a user logs in and replays events or an anonymous user is generated. Also addresses bug that prevents unknown user generation when user logs out.


[MOB-11677]: https://iterable.atlassian.net/browse/MOB-11677?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[MOB-11739]: https://iterable.atlassian.net/browse/MOB-11739?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ