### PR TITLE
SDK-307 Fix custom actions not working in background when SDK is not initialized

### DIFF
--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterablePushNotificationUtil.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterablePushNotificationUtil.java
@@ -18,7 +18,12 @@ class IterablePushNotificationUtil {
         boolean handled = false;
         if (pendingAction != null) {
             handled = executeAction(context, pendingAction);
-            pendingAction = null;
+            // Only clear pending action if it was handled.
+            // This allows the action to be processed later when SDK is fully initialized
+            // (e.g., when customActionHandler becomes available after initialize() is called).
+            if (handled) {
+                pendingAction = null;
+            }
         }
         return handled;
     }
@@ -38,6 +43,13 @@ class IterablePushNotificationUtil {
             IterableLogger.e(TAG, "handlePushAction: extras == null, can't handle push action");
             return;
         }
+
+        // Store the application context if not already set, so custom actions can be
+        // processed even when the SDK hasn't been fully initialized (e.g., openApp=false)
+        if (IterableApi.sharedInstance._applicationContext == null && context != null) {
+            IterableApi.sharedInstance._applicationContext = context.getApplicationContext();
+        }
+
         IterableNotificationData notificationData = new IterableNotificationData(intent.getExtras());
         String actionIdentifier = intent.getStringExtra(IterableConstants.ITERABLE_DATA_ACTION_IDENTIFIER);
         IterableAction action = null;

--- a/iterableapi/src/test/resources/push_payload_background_custom_action.json
+++ b/iterableapi/src/test/resources/push_payload_background_custom_action.json
@@ -1,0 +1,20 @@
+{
+  "campaignId": 5678,
+  "templateId": 8765,
+  "messageId": "background123456",
+  "isGhostPush": false,
+  "actionButtons": [
+    {
+      "identifier": "remindMeButton",
+      "title": "Remind me in 15 minutes",
+      "openApp": false,
+      "action": {
+        "type": "snoozeReminder",
+        "data": "{\"delay\":15}"
+      }
+    }
+  ],
+  "defaultAction": {
+    "type": null
+  }
+}


### PR DESCRIPTION
## What
Fixes custom actions not working when SDK is not initialized and `openApp=false`. This enables "snooze" type push notification flows where a button action can trigger a journey without opening the app.

**Jira ticket:** [SDK-307](https://iterable.atlassian.net/browse/SDK-307)

## Changes
- Store application context early in `handlePushAction()` so `getMainActivityContext()` returns non-null even before `initialize()` is called
- Only clear `pendingAction` if the action was actually handled, allowing deferred processing when SDK is initialized later with a `customActionHandler`

## Impact
- **Breaking changes**: None
- **Dependencies**: None
- **Performance**: No impact

## Testing
**How to test:**
1. Set up a push notification with an action button that has `openApp=false` and a custom action type
2. Receive the push while the app is backgrounded/not initialized
3. Tap the action button
4. Verify the custom action handler is called (either immediately if context is available, or when SDK initializes)

**Unit tests added:**
- `testBackgroundCustomActionWithNonInitializedSDK` - verifies context is stored even without SDK init
- `testBackgroundCustomActionProcessedAfterSDKInit` - verifies pending actions are processed after initialization

[SDK-307]: https://iterable.atlassian.net/browse/SDK-307?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ