### PR TITLE
[SDK-362] Fixing concurrency crash with register device token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Fixed `ConcurrentModificationException` crash during device token registration caused by concurrent access to `deviceAttributes`.
 
 ## [3.7.0]
 - Replaced the deprecated `AsyncTask`-based push notification handling with `WorkManager` for improved reliability and compatibility with modern Android versions. No action is required.

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
@@ -17,10 +17,11 @@ import com.iterable.iterableapi.util.DeviceInfoUtils;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Created by David Truong dt@iterable.com
@@ -55,7 +56,7 @@ public class IterableApi {
     private @Nullable IterableEmbeddedManager embeddedManager;
     private String inboxSessionId;
     private IterableAuthManager authManager;
-    private HashMap<String, String> deviceAttributes = new HashMap<>();
+    private ConcurrentHashMap<String, String> deviceAttributes = new ConcurrentHashMap<>();
     private IterableKeychain keychain;
 
 
@@ -159,7 +160,7 @@ public class IterableApi {
         );
     }
 
-    HashMap getDeviceAttributes() {
+    Map<String, String> getDeviceAttributes() {
         return deviceAttributes;
     }
 
@@ -695,7 +696,7 @@ public class IterableApi {
         }
     }
 
-    protected void registerDeviceToken(final @Nullable String email, final @Nullable String userId, final @Nullable String authToken, final @NonNull String applicationName, final @NonNull String deviceToken, final HashMap<String, String> deviceAttributes) {
+    protected void registerDeviceToken(final @Nullable String email, final @Nullable String userId, final @Nullable String authToken, final @NonNull String applicationName, final @NonNull String deviceToken, final Map<String, String> deviceAttributes) {
         if (deviceToken != null) {
             if (!checkSDKInitialization() && _userIdUnknown == null) {
                 if (sharedInstance.config.enableUnknownUserActivation) {
@@ -740,7 +741,7 @@ public class IterableApi {
      * @param deviceToken
      * @param dataFields
      */
-    protected void registerDeviceToken(@Nullable String email, @Nullable String userId, @Nullable String authToken, @NonNull String applicationName, @NonNull String deviceToken, @Nullable JSONObject dataFields, HashMap<String, String> deviceAttributes) {
+    protected void registerDeviceToken(@Nullable String email, @Nullable String userId, @Nullable String authToken, @NonNull String applicationName, @NonNull String deviceToken, @Nullable JSONObject dataFields, Map<String, String> deviceAttributes) {
         if (!checkSDKInitialization()) {
             return;
         }
@@ -1245,10 +1246,18 @@ public class IterableApi {
     }
 
     public void setDeviceAttribute(String key, String value) {
+        if (key == null || value == null) {
+            IterableLogger.e(TAG, "setDeviceAttribute: key and value must not be null");
+            return;
+        }
         deviceAttributes.put(key, value);
     }
 
     public void removeDeviceAttribute(String key) {
+        if (key == null) {
+            IterableLogger.e(TAG, "removeDeviceAttribute: key must not be null");
+            return;
+        }
         deviceAttributes.remove(key);
     }
 //endregion

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableApiClient.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableApiClient.java
@@ -14,8 +14,8 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 class IterableApiClient {
     private static final String TAG = "IterableApiClient";
@@ -623,7 +623,7 @@ class IterableApiClient {
         }
     }
 
-    protected void registerDeviceToken(@Nullable String email, @Nullable String userId, @Nullable String authToken, @NonNull String applicationName, @NonNull String deviceToken, @Nullable JSONObject dataFields, HashMap<String, String> deviceAttributes, @Nullable final IterableHelper.SuccessHandler successHandler, @Nullable final IterableHelper.FailureHandler failureHandler) {
+    protected void registerDeviceToken(@Nullable String email, @Nullable String userId, @Nullable String authToken, @NonNull String applicationName, @NonNull String deviceToken, @Nullable JSONObject dataFields, Map<String, String> deviceAttributes, @Nullable final IterableHelper.SuccessHandler successHandler, @Nullable final IterableHelper.FailureHandler failureHandler) {
         Context context = authProvider.getContext();
         JSONObject requestJSON = new JSONObject();
         try {
@@ -633,7 +633,7 @@ class IterableApiClient {
                 dataFields = new JSONObject();
             }
 
-            for (HashMap.Entry<String, String> entry : deviceAttributes.entrySet()) {
+            for (Map.Entry<String, String> entry : deviceAttributes.entrySet()) {
                 dataFields.put(entry.getKey(), entry.getValue());
             }
 


### PR DESCRIPTION
## 🔹 Jira Ticket(s) if any

* [SDK-362](https://iterable.atlassian.net/browse/SDK-362)

## ✏️ Description

### Root Cause

The SDK was using a non-thread-safe `HashMap` for `deviceAttributes`, which caused `ConcurrentModificationException` crashes when the map was modified from one thread while another thread was iterating over it during device token registration.

### Why This Happens

The crash occurred in the following scenario:

1. **Thread A** starts `registerDeviceToken()`, which iterates over `deviceAttributes` to copy them into the registration payload
2. **Thread B** calls `setDeviceAttribute()` or `removeDeviceAttribute()`, modifying the `HashMap`
3. **Thread A** detects the concurrent modification and throws `ConcurrentModificationException`

According to the crash stack trace from issue [#642](https://github.com/Iterable/iterable-android-sdk/issues/642):

```
java.util.ConcurrentModificationException
    at java.util.HashMap$HashIterator.nextNode(HashMap.java:1441)
    at java.util.HashMap$EntryIterator.next(HashMap.java:1475)
    at com.iterable.iterableapi.IterableApiClient.registerDeviceToken(IterableApiClient.java:426)
```

`HashMap` is **not thread-safe** and explicitly throws `ConcurrentModificationException` when concurrent modification is detected during iteration. This is a fail-fast mechanism to prevent data corruption.

### Fix

Replaced `HashMap<String, String>` with `ConcurrentHashMap<String, String>` for the `deviceAttributes` field. `ConcurrentHashMap` is specifically designed for concurrent access and provides thread-safety without explicit synchronization.

## Fixes
- Closes #642

## References
- [Java ConcurrentHashMap Documentation](https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/ConcurrentHashMap.html)

[SDK-362]: https://iterable.atlassian.net/browse/SDK-362?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ