### PR TITLE
[SDK-395] Fix for possible NoSuchMethodException on android 5-10 versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Fixed possible `NoSuchMethodException` crash on Android 5-10 caused by using `Map.of()` which is unavailable on those versions
 
 ## [3.7.0]
 - Replaced the deprecated `AsyncTask`-based push notification handling with `WorkManager` for improved reliability and compatibility with modern Android versions. No action is required.

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableHelper.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableHelper.java
@@ -4,9 +4,8 @@ import android.net.Uri;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import org.json.JSONException;
 import org.json.JSONObject;
-
-import java.util.Map;
 
 /**
  * Created by David Truong dt@iterable.com
@@ -38,7 +37,17 @@ public class IterableHelper {
 }
 
 class IterableResponse {
-    static final JSONObject setEmailLocalSuccessResponse = new JSONObject(Map.of("message", "setEmail was completed locally."));
+    static final JSONObject setEmailLocalSuccessResponse;
+    static final JSONObject setReadLocalSuccessResponse;
 
-    static final JSONObject setReadLocalSuccessResponse = new JSONObject(Map.of("message", "setRead was completed locally."));
+    static {
+        JSONObject emailResponse = new JSONObject();
+        JSONObject readResponse = new JSONObject();
+        try {
+            emailResponse.put("message", "setEmail was completed locally.");
+            readResponse.put("message", "setRead was completed locally.");
+        } catch (JSONException ignored) {}
+        setEmailLocalSuccessResponse = emailResponse;
+        setReadLocalSuccessResponse = readResponse;
+    }
 }


### PR DESCRIPTION
## 🔹 Jira Ticket(s) if any

* [SDK-395](https://iterable.atlassian.net/browse/SDK-395)

## ✏️ Description

Removing Map.of from Iterable Response because on android 5 - 10 versions that method does not exist.


[SDK-395]: https://iterable.atlassian.net/browse/SDK-395?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ