### PR TITLE
Fix IterableEmbeddedView image height to match campaign preview

### DIFF
--- a/iterableapi-ui/src/main/res/layout-v21/card_view.xml
+++ b/iterableapi-ui/src/main/res/layout-v21/card_view.xml
@@ -16,13 +16,15 @@
     <com.google.android.material.imageview.ShapeableImageView
         android:id="@+id/embedded_message_image"
         android:layout_width="0dp"
-        android:layout_height="0dp"
+        android:layout_height="wrap_content"
+        android:adjustViewBounds="true"
         android:contentDescription=""
-        android:scaleType="centerCrop"
+        android:scaleType="fitCenter"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintBottom_toTopOf="@id/embedded_message_text_container"
+        app:layout_constraintVertical_bias="0.0"
         app:shapeAppearanceOverlay="@style/classCardStyle" />
 
     <LinearLayout

--- a/iterableapi-ui/src/main/res/layout/card_view.xml
+++ b/iterableapi-ui/src/main/res/layout/card_view.xml
@@ -17,13 +17,15 @@
     <com.google.android.material.imageview.ShapeableImageView
         android:id="@+id/embedded_message_image"
         android:layout_width="0dp"
-        android:layout_height="0dp"
+        android:layout_height="wrap_content"
+        android:adjustViewBounds="true"
         android:contentDescription=""
-        android:scaleType="centerCrop"
+        android:scaleType="fitCenter"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintBottom_toTopOf="@id/embedded_message_text_container"
+        app:layout_constraintVertical_bias="0.0"
         app:shapeAppearanceOverlay="@style/classCardStyle" />
 
     <LinearLayout


### PR DESCRIPTION
## Summary
- Fix embedded message image height to use wrap_content instead of 0dp in card_view.xml (both layout/ and layout-v21/)
- Add adjustViewBounds="true" and fitCenter scaleType for correct image display
- Add layout_constraintVertical_bias="0.0" to keep image pinned to top

## Test plan
- [ ] Verify embedded view displays images matching campaign preview
- [ ] Test with various image aspect ratios

🤖 Generated with [Claude Code](https://claude.com/claude-code)