### PR TITLE
#485 - Fix NPE in syncWithRemoteQueue when message removed during sync

### DIFF
--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableInAppManager.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableInAppManager.java
@@ -339,20 +339,20 @@ public class IterableInAppManager implements IterableActivityMonitor.AppStateCal
         Map<String, IterableInAppMessage> remoteQueueMap = new HashMap<>();
 
         for (IterableInAppMessage message : remoteQueue) {
+            if (message == null) {
+                continue;
+            }
+
             remoteQueueMap.put(message.getMessageId(), message);
 
-            boolean isInAppStored = storage.getMessage(message.getMessageId()) != null;
+            IterableInAppMessage localMessage = storage.getMessage(message.getMessageId());
 
-            if (!isInAppStored) {
+            if (localMessage == null) {
                 storage.addMessage(message);
                 onMessageAdded(message);
 
                 changed = true;
-            }
-
-            if (isInAppStored) {
-                IterableInAppMessage localMessage = storage.getMessage(message.getMessageId());
-
+            } else {
                 boolean shouldOverwriteInApp = !localMessage.isRead() && message.isRead();
 
                 if (shouldOverwriteInApp) {
@@ -363,7 +363,11 @@ public class IterableInAppManager implements IterableActivityMonitor.AppStateCal
             }
         }
 
-        for (IterableInAppMessage localMessage : storage.getMessages()) {
+        List<IterableInAppMessage> localMessages = storage.getMessages();
+        for (IterableInAppMessage localMessage : localMessages) {
+            if (localMessage == null) {
+                continue;
+            }
             if (!remoteQueueMap.containsKey(localMessage.getMessageId())) {
                 storage.removeMessage(localMessage);
 


### PR DESCRIPTION
## Summary
- Adds a null check for `localMessage` after re-fetching from storage in `IterableInAppManager.syncWithRemoteQueue`
- Guards against a race condition where the message is removed between the existence check (`storage.getMessage() != null`) and the subsequent retrieval, which caused a `NullPointerException` when calling `isRead()` on a null reference

## Test plan
- [ ] Verify that `syncWithRemoteQueue` no longer throws NPE when a message is removed from storage between the existence check and re-fetch
- [ ] Verify that the normal sync flow (message exists and is updated) still works correctly
- [ ] Verify that read-state syncing from remote to local still functions as expected
- [ ] Run existing unit tests for `IterableInAppManager` to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)