### PR TITLE
Add method to reset notification payload data

### DIFF
--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
@@ -1245,6 +1245,15 @@ public class IterableApi {
         return _payloadData;
     }
 
+    /**
+     * Resets the notification payload data by setting it to null.
+     * Call this method after you have finished processing the notification payload
+     * to prevent stale data from being returned by {@link #getPayloadData()}.
+     */
+    public void clearPayloadData() {
+        _payloadData = null;
+    }
+
     public void setDeviceAttribute(String key, String value) {
         if (key == null || value == null) {
             IterableLogger.e(TAG, "setDeviceAttribute: key and value must not be null");


### PR DESCRIPTION
## Summary
- Add clearPayloadData() method to IterableApi
- Allows users to reset notification payload after processing

## Test plan
- [ ] Set payload data via notification, call clearPayloadData(), verify getPayloadData() returns null
- [ ] Verify normal notification payload flow still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)