### PR TITLE
Handle WebView render process crash gracefully

### DIFF
--- a/iterableapi-ui/src/main/java/com/iterable/iterableapi/ui/inbox/IterableInboxMessageFragment.java
+++ b/iterableapi-ui/src/main/java/com/iterable/iterableapi/ui/inbox/IterableInboxMessageFragment.java
@@ -1,13 +1,16 @@
 package com.iterable.iterableapi.ui.inbox;
 
 import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.webkit.RenderProcessGoneDetail;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
 
@@ -22,6 +25,7 @@ import java.util.List;
 public class IterableInboxMessageFragment extends Fragment {
     public static final String ARG_MESSAGE_ID = "messageId";
     public static final String STATE_LOADED = "loaded";
+    private static final String TAG = "IterableInboxMsgFrag";
 
     private String messageId;
     private WebView webView;
@@ -99,6 +103,32 @@ public class IterableInboxMessageFragment extends Fragment {
                 getActivity().finish();
             }
             return true;
+        }
+
+        @Override
+        public boolean onRenderProcessGone(WebView view, RenderProcessGoneDetail detail) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                boolean didCrash = detail.didCrash();
+                Log.w(TAG, "WebView render process gone. didCrash: " + didCrash);
+
+                // Clean up the WebView to prevent further issues
+                if (view != null) {
+                    try {
+                        view.destroy();
+                    } catch (Exception e) {
+                        Log.e(TAG, "Error destroying WebView after render process gone", e);
+                    }
+                }
+
+                // Close the fragment's activity since the WebView is no longer usable
+                if (getActivity() != null) {
+                    getActivity().finish();
+                }
+
+                // Return true to prevent the app from crashing
+                return true;
+            }
+            return super.onRenderProcessGone(view, detail);
         }
     };
 }

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableWebViewClient.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableWebViewClient.java
@@ -1,9 +1,13 @@
 package com.iterable.iterableapi;
 
+import android.os.Build;
+import android.webkit.RenderProcessGoneDetail;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
 
 class IterableWebViewClient extends WebViewClient {
+    private static final String TAG = "IterableWebViewClient";
+
     IterableWebView.HTMLNotificationCallbacks inAppHTMLNotification;
 
     IterableWebViewClient(IterableWebView.HTMLNotificationCallbacks inAppHTMLNotification) {
@@ -20,5 +24,26 @@ class IterableWebViewClient extends WebViewClient {
     public void onPageFinished(WebView view, String url) {
         inAppHTMLNotification.setLoaded(true);
         view.postDelayed(inAppHTMLNotification::runResizeScript, 100);
+    }
+
+    @Override
+    public boolean onRenderProcessGone(WebView view, RenderProcessGoneDetail detail) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            boolean didCrash = detail.didCrash();
+            IterableLogger.w(TAG, "WebView render process gone. didCrash: " + didCrash);
+
+            // Clean up the WebView to prevent further issues
+            if (view != null) {
+                try {
+                    view.destroy();
+                } catch (Exception e) {
+                    IterableLogger.e(TAG, "Error destroying WebView after render process gone", e);
+                }
+            }
+
+            // Return true to prevent the app from crashing
+            return true;
+        }
+        return super.onRenderProcessGone(view, detail);
     }
 }


### PR DESCRIPTION
## Summary
- Add `onRenderProcessGone` handler to `IterableWebViewClient` to prevent app crashes when the Chromium renderer process dies
- Add the same handler to the anonymous `WebViewClient` in `IterableInboxMessageFragment` for inbox message WebViews
- Both handlers log the crash event, clean up the WebView via `destroy()`, and return `true` to absorb the crash

## Test plan
- [ ] Verify WebView in-app messages display and function normally
- [ ] Verify inbox message WebViews display and function normally
- [ ] Verify Chromium renderer crash does not crash the host app (Android O+)
- [ ] Verify behavior on pre-Android O devices (falls through to default behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)