### PR TITLE
Allow customization of notification channel names

### DIFF
--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableConfig.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableConfig.java
@@ -141,12 +141,30 @@ public class IterableConfig {
     final IterableAPIMobileFrameworkInfo mobileFrameworkInfo;
 
     /**
+     * Custom notification channel name for push notifications.
+     * If set, this name will be used for all Iterable notification channels instead of
+     * deriving the channel name from the sound file name. This prevents non-human-readable
+     * sound file names from appearing as channel names in the device notification settings.
+     */
+    @Nullable
+    final String notificationChannelName;
+
+    /**
      * Base URL for Webview content loading. Specifically used to enable CORS for external resources.
      * If null or empty, defaults to empty string (original behavior with about:blank origin).
      * Set this to according to your CORS settings for example (e.g., "https://app.iterable.com") to allow external resource loading.
      */
     @Nullable
     final String webViewBaseUrl;
+
+    /**
+     * Get the configured notification channel name
+     * @return Custom notification channel name, or null if not configured
+     */
+    @Nullable
+    public String getNotificationChannelName() {
+        return notificationChannelName;
+    }
 
     /**
      * Get the configured WebView base URL
@@ -182,6 +200,7 @@ public class IterableConfig {
         iterableUnknownUserHandler = builder.iterableUnknownUserHandler;
         decryptionFailureHandler = builder.decryptionFailureHandler;
         mobileFrameworkInfo = builder.mobileFrameworkInfo;
+        notificationChannelName = builder.notificationChannelName;
         webViewBaseUrl = builder.webViewBaseUrl;
     }
 
@@ -210,6 +229,7 @@ public class IterableConfig {
         private int eventThresholdLimit = 100;
         private IterableIdentityResolution identityResolution = new IterableIdentityResolution();
         private IterableUnknownUserHandler iterableUnknownUserHandler;
+        private String notificationChannelName;
         private String webViewBaseUrl;
 
         public Builder() {}
@@ -450,6 +470,18 @@ public class IterableConfig {
         @NonNull
         public Builder setMobileFrameworkInfo(@NonNull IterableAPIMobileFrameworkInfo mobileFrameworkInfo) {
             this.mobileFrameworkInfo = mobileFrameworkInfo;
+            return this;
+        }
+
+        /**
+         * Set a custom notification channel name for push notifications.
+         * If set, this name will be used for all Iterable notification channels instead of
+         * deriving the channel name from the sound file name.
+         * @param notificationChannelName Custom channel name for notifications
+         */
+        @NonNull
+        public Builder setNotificationChannelName(@Nullable String notificationChannelName) {
+            this.notificationChannelName = notificationChannelName;
             return this;
         }
 

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableNotificationHelper.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableNotificationHelper.java
@@ -158,9 +158,21 @@ class IterableNotificationHelper {
 
             soundUri = getSoundUri(context, soundName, soundUrl);
 
-            String channelName = (soundUri == Settings.System.DEFAULT_NOTIFICATION_URI)
-                    ? getChannelName(context)
-                    : soundName;
+            // Use custom channel name from config if available, otherwise fall back to sound name
+            String customChannelName = null;
+            IterableConfig config = IterableApi.getInstance().config;
+            if (config != null) {
+                customChannelName = config.getNotificationChannelName();
+            }
+
+            String channelName;
+            if (customChannelName != null && !customChannelName.isEmpty()) {
+                channelName = customChannelName;
+            } else if (soundUri == Settings.System.DEFAULT_NOTIFICATION_URI) {
+                channelName = getChannelName(context);
+            } else {
+                channelName = soundName;
+            }
 
             String channelId = (soundUri == Settings.System.DEFAULT_NOTIFICATION_URI)
                     ? context.getPackageName()

--- a/iterableapi/src/test/java/com/iterable/iterableapi/IterableConfigTest.kt
+++ b/iterableapi/src/test/java/com/iterable/iterableapi/IterableConfigTest.kt
@@ -51,4 +51,19 @@ class IterableConfigTest {
         val config: IterableConfig = configBuilder.build()
         assertFalse(config.keychainEncryption)
     }
+
+    @Test
+    fun defaultNotificationChannelName() {
+        val configBuilder: IterableConfig.Builder = IterableConfig.Builder()
+        val config: IterableConfig = configBuilder.build()
+        assertThat(config.notificationChannelName, `is`(nullValue()))
+    }
+
+    @Test
+    fun setNotificationChannelName() {
+        val configBuilder: IterableConfig.Builder = IterableConfig.Builder()
+            .setNotificationChannelName("My App Notifications")
+        val config: IterableConfig = configBuilder.build()
+        assertThat(config.notificationChannelName, `is`("My App Notifications"))
+    }
 }


### PR DESCRIPTION
## Summary
- Add configuration option for custom notification channel names
- Prevent non-human-readable sound file names from being used as channel names

## Test plan
- [ ] Test with custom channel name configured
- [ ] Test without custom channel name (backward compatible)
- [ ] Verify notifications with custom sounds work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)