### PR TITLE
Replace RuntimeException with graceful handling when SDK not initialized

### DIFF
--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
@@ -998,20 +998,22 @@ public class IterableApi {
      * Make sure the Iterable API is initialized before calling this method.
      * @return {@link IterableInAppManager} instance
      */
-    @NonNull
+    @Nullable
     public IterableInAppManager getInAppManager() {
         if (inAppManager == null) {
-            throw new RuntimeException("IterableApi must be initialized before calling getInAppManager(). " +
+            IterableLogger.e(TAG, "IterableApi must be initialized before calling getInAppManager(). " +
                     "Make sure you call IterableApi#initialize() in Application#onCreate");
+            return null;
         }
         return inAppManager;
     }
 
-    @NonNull
+    @Nullable
     public IterableEmbeddedManager getEmbeddedManager() {
         if (embeddedManager == null) {
-            throw new RuntimeException("IterableApi must be initialized before calling getEmbeddedManager(). " +
+            IterableLogger.e(TAG, "IterableApi must be initialized before calling getEmbeddedManager(). " +
                     "Make sure you call IterableApi#initialize() in Application#onCreate");
+            return null;
         }
         return embeddedManager;
     }


### PR DESCRIPTION
## Summary
- Replace undocumented RuntimeExceptions with logged warnings and null returns
- SDK methods now fail gracefully when called before initialization

## Test plan
- [ ] Call getInAppManager() before initialization - should log warning, not crash
- [ ] Call getInAppManager() after initialization - should work normally
- [ ] Verify other similar methods also handle gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)