### PR TITLE
Fix fatal crash in in-app popup WebView initialization

### DIFF
--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableInAppFragmentHTMLNotification.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableInAppFragmentHTMLNotification.java
@@ -760,8 +760,20 @@ public class IterableInAppFragmentHTMLNotification extends DialogFragment implem
         } catch (Resources.NotFoundException e) {
             IterableLogger.e(TAG, "Failed to create WebView - system WebView resource issue", e);
             return null;
+        } catch (android.util.AndroidRuntimeException e) {
+            // AndroidRuntimeException can be thrown when the WebView package is being updated
+            // or is unavailable, wrapping an InvocationTargetException from WebViewFactory.getProvider.
+            // See: https://github.com/nicai1900/MobileScreen/issues/2
+            IterableLogger.e(TAG, "Failed to create WebView - WebView provider unavailable. "
+                + "The system WebView may be updating or missing.", e);
+            return null;
         } catch (RuntimeException e) {
-            IterableLogger.e(TAG, "Failed to create WebView - unexpected error", e);
+            IterableLogger.e(TAG, "Failed to create WebView - unexpected runtime error", e);
+            return null;
+        } catch (Error e) {
+            // In rare cases, WebView initialization can throw an Error (e.g., UnsatisfiedLinkError
+            // when native WebView libraries cannot be loaded)
+            IterableLogger.e(TAG, "Failed to create WebView - fatal error during initialization", e);
             return null;
         }
     }

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableWebView.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableWebView.java
@@ -8,6 +8,7 @@ import android.webkit.WebView;
  * The custom html webView
  */
 class IterableWebView extends WebView {
+    private static final String TAG = "IterableWebView";
     static final String MIME_TYPE = "text/html";
     static final String ENCODING = "UTF-8";
 


### PR DESCRIPTION
## Summary
- Adds explicit catch for `AndroidRuntimeException` in `createWebViewSafely()` to handle WebView provider failures (e.g., WebView package being updated or unavailable)
- Adds catch for `Error` to handle rare native library loading failures (e.g., `UnsatisfiedLinkError`)
- Gracefully dismisses the in-app dialog and logs the error instead of crashing the app

## Test plan
- [ ] Test in-app popup display on devices with working WebView
- [ ] Verify crash is caught gracefully when WebView is unavailable

🤖 Generated with [Claude Code](https://claude.com/claude-code)