### PR TITLE
Add callback for push notification click events

### DIFF
--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableConfig.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableConfig.java
@@ -135,6 +135,12 @@ public class IterableConfig {
     final IterableDecryptionFailureHandler decryptionFailureHandler;
 
     /**
+     * Handler for push notification click events.
+     * Called when a user taps on a push notification, providing the notification payload data.
+     */
+    final IterableNotificationClickHandler notificationClickHandler;
+
+    /**
      * Mobile framework information for the app
      */
     @Nullable
@@ -183,6 +189,7 @@ public class IterableConfig {
         decryptionFailureHandler = builder.decryptionFailureHandler;
         mobileFrameworkInfo = builder.mobileFrameworkInfo;
         webViewBaseUrl = builder.webViewBaseUrl;
+        notificationClickHandler = builder.notificationClickHandler;
     }
 
     public static class Builder {
@@ -211,6 +218,7 @@ public class IterableConfig {
         private IterableIdentityResolution identityResolution = new IterableIdentityResolution();
         private IterableUnknownUserHandler iterableUnknownUserHandler;
         private String webViewBaseUrl;
+        private IterableNotificationClickHandler notificationClickHandler;
 
         public Builder() {}
 
@@ -462,6 +470,18 @@ public class IterableConfig {
         @NonNull
         public Builder setWebViewBaseUrl(@Nullable String webViewBaseUrl) {
             this.webViewBaseUrl = webViewBaseUrl;
+            return this;
+        }
+
+        /**
+         * Set a handler for push notification click events.
+         * The handler will be called when a user taps on a push notification,
+         * providing the notification payload data.
+         * @param notificationClickHandler Notification click handler provided by the app
+         */
+        @NonNull
+        public Builder setNotificationClickHandler(@NonNull IterableNotificationClickHandler notificationClickHandler) {
+            this.notificationClickHandler = notificationClickHandler;
             return this;
         }
 

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableNotificationClickHandler.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableNotificationClickHandler.java
@@ -1,0 +1,21 @@
+package com.iterable.iterableapi;
+
+import android.os.Bundle;
+import androidx.annotation.NonNull;
+
+/**
+ * Handler interface for push notification click events.
+ * Register this handler through {@link IterableConfig.Builder#setNotificationClickHandler}
+ * to be notified when a user taps on a push notification.
+ */
+public interface IterableNotificationClickHandler {
+
+    /**
+     * Called when a push notification is clicked by the user.
+     *
+     * @param notificationData The parsed notification metadata (campaign ID, template ID, message ID, etc.)
+     * @param extras           The full Intent extras Bundle including the raw Iterable JSON payload
+     *                         under the key {@link IterableConstants#ITERABLE_DATA_KEY}
+     */
+    void onNotificationClicked(@NonNull IterableNotificationData notificationData, @NonNull Bundle extras);
+}

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableNotificationData.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableNotificationData.java
@@ -14,7 +14,7 @@ import java.util.List;
 /**
  * Created by davidtruong on 5/23/16.
  */
-class IterableNotificationData {
+public class IterableNotificationData {
     static final String TAG = "IterableNoticationData";
 
     private int campaignId;

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterablePushNotificationUtil.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterablePushNotificationUtil.java
@@ -36,6 +36,13 @@ class IterablePushNotificationUtil {
         // Automatic tracking
         IterableApi.sharedInstance.setPayloadData(action.intent);
         IterableApi.sharedInstance.setNotificationData(action.notificationData);
+
+        // Invoke notification click handler if registered
+        if (IterableApi.sharedInstance.config.notificationClickHandler != null && action.intent.getExtras() != null) {
+            IterableApi.sharedInstance.config.notificationClickHandler.onNotificationClicked(
+                    action.notificationData, action.intent.getExtras());
+        }
+
         IterableApi.sharedInstance.trackPushOpen(action.notificationData.getCampaignId(), action.notificationData.getTemplateId(),
                 action.notificationData.getMessageId(), action.dataFields);
 


### PR DESCRIPTION
## Summary
- Add `IterableNotificationClickHandler` callback interface for push notification click events
- Include payload data in launch Intent extras (already present via `itbl` key)
- Allow registration of click handler through `IterableConfig.Builder.setNotificationClickHandler()`
- Make `IterableNotificationData` public so it can be used in the callback

## Test plan
- [ ] Register click callback and verify it fires on notification tap
- [ ] Verify payload data is accessible in the callback (notificationData and extras Bundle)
- [ ] Verify backward compatibility without callback registered

🤖 Generated with [Claude Code](https://claude.com/claude-code)