### PR TITLE
Add inbox header customization options

### DIFF
--- a/iterableapi-ui/src/main/AndroidManifest.xml
+++ b/iterableapi-ui/src/main/AndroidManifest.xml
@@ -5,7 +5,8 @@
         <activity
             android:name=".inbox.IterableInboxActivity"
             android:exported="false"
-            android:label="Inbox" />
+            android:label="Inbox"
+            android:theme="@style/IterableInboxActivityTheme" />
         <activity
             android:name=".inbox.IterableInboxMessageActivity"
             android:exported="false"/>

--- a/iterableapi-ui/src/main/java/com/iterable/iterableapi/ui/inbox/IterableInboxActivity.java
+++ b/iterableapi-ui/src/main/java/com/iterable/iterableapi/ui/inbox/IterableInboxActivity.java
@@ -2,8 +2,12 @@ package com.iterable.iterableapi.ui.inbox;
 
 import android.content.Intent;
 import android.os.Bundle;
+import android.view.Gravity;
+import android.widget.TextView;
+
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.Toolbar;
 
 import com.iterable.iterableapi.IterableConstants;
 import com.iterable.iterableapi.IterableLogger;
@@ -18,19 +22,48 @@ import static com.iterable.iterableapi.ui.inbox.IterableInboxFragment.ITEM_LAYOU
  * Supports optional extras:
  * {@link IterableInboxFragment#INBOX_MODE} - {@link InboxMode} value with the inbox mode
  * {@link IterableInboxFragment#ITEM_LAYOUT_ID} - Layout resource id for inbox items
+ * <p>
+ * To customize the toolbar header, use {@link #setInboxCustomization(IterableInboxCustomization)}
+ * or set customization via intent extras:
+ * {@link #EXTRA_TITLE_CENTER_ALIGNED} - boolean to center-align the title
+ * {@link #EXTRA_SHOW_CLOSE_BUTTON} - boolean to show a close button
  */
 public class IterableInboxActivity extends AppCompatActivity {
     private static final String TAG = "IterableInboxActivity";
     public static final String ACTIVITY_TITLE = "activityTitle";
+    public static final String EXTRA_TITLE_CENTER_ALIGNED = "iterableTitleCenterAligned";
+    public static final String EXTRA_SHOW_CLOSE_BUTTON = "iterableShowCloseButton";
+
+    @Nullable
+    private static IterableInboxCustomization pendingCustomization;
+
+    /**
+     * Set toolbar customization to be applied when the activity is created.
+     * This must be called before starting the activity. The customization is consumed
+     * once applied and will not persist across activity recreations.
+     *
+     * @param customization The customization to apply
+     */
+    public static void setInboxCustomization(@Nullable IterableInboxCustomization customization) {
+        pendingCustomization = customization;
+    }
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         IterableLogger.printInfo();
         setContentView(R.layout.iterable_inbox_activity);
+
+        Toolbar toolbar = findViewById(R.id.iterable_inbox_toolbar);
+        setSupportActionBar(toolbar);
+
         IterableInboxFragment inboxFragment;
 
         Intent intent = getIntent();
+        String titleText = null;
+        boolean titleCenterAligned = false;
+        boolean showCloseButton = false;
+
         if (intent != null) {
             Object inboxModeExtra = intent.getSerializableExtra(INBOX_MODE);
             int itemLayoutId = intent.getIntExtra(ITEM_LAYOUT_ID, 0);
@@ -48,11 +81,29 @@ public class IterableInboxActivity extends AppCompatActivity {
             inboxFragment = IterableInboxFragment.newInstance(inboxMode, itemLayoutId, noMessageTitle, noMessageBody);
 
             if (intent.getStringExtra(ACTIVITY_TITLE) != null) {
-                setTitle(intent.getStringExtra(ACTIVITY_TITLE));
+                titleText = intent.getStringExtra(ACTIVITY_TITLE);
             }
+
+            titleCenterAligned = intent.getBooleanExtra(EXTRA_TITLE_CENTER_ALIGNED, false);
+            showCloseButton = intent.getBooleanExtra(EXTRA_SHOW_CLOSE_BUTTON, false);
         } else {
             inboxFragment = IterableInboxFragment.newInstance();
         }
+
+        // Apply programmatic customization (takes precedence over intent extras)
+        IterableInboxCustomization customization = pendingCustomization;
+        pendingCustomization = null;
+
+        if (customization != null) {
+            if (customization.getTitle() != null) {
+                titleText = customization.getTitle();
+            }
+            titleCenterAligned = customization.isTitleCenterAligned();
+            showCloseButton = customization.isShowCloseButton();
+        }
+
+        // Configure toolbar
+        configureToolbar(toolbar, titleText, titleCenterAligned, showCloseButton, customization);
 
         if (savedInstanceState == null) {
             getSupportFragmentManager().beginTransaction()
@@ -61,4 +112,37 @@ public class IterableInboxActivity extends AppCompatActivity {
         }
     }
 
+    private void configureToolbar(Toolbar toolbar, @Nullable String titleText, boolean titleCenterAligned, boolean showCloseButton, @Nullable IterableInboxCustomization customization) {
+        if (titleCenterAligned) {
+            // Use the custom centered TextView instead of the default title
+            if (getSupportActionBar() != null) {
+                getSupportActionBar().setDisplayShowTitleEnabled(false);
+            }
+            TextView centeredTitle = findViewById(R.id.iterable_inbox_toolbar_title);
+            centeredTitle.setVisibility(android.view.View.VISIBLE);
+            centeredTitle.setText(titleText != null ? titleText : "Inbox");
+
+            // Center the TextView in the toolbar
+            Toolbar.LayoutParams params = new Toolbar.LayoutParams(
+                    Toolbar.LayoutParams.WRAP_CONTENT,
+                    Toolbar.LayoutParams.WRAP_CONTENT,
+                    Gravity.CENTER
+            );
+            centeredTitle.setLayoutParams(params);
+        } else if (titleText != null) {
+            setTitle(titleText);
+        }
+
+        if (showCloseButton) {
+            toolbar.setNavigationIcon(R.drawable.ic_close_black_24dp);
+            toolbar.setNavigationContentDescription("Close");
+            toolbar.setNavigationOnClickListener(v -> {
+                if (customization != null && customization.getCloseButtonListener() != null) {
+                    customization.getCloseButtonListener().onClick(v);
+                } else {
+                    finish();
+                }
+            });
+        }
+    }
 }

--- a/iterableapi-ui/src/main/java/com/iterable/iterableapi/ui/inbox/IterableInboxCustomization.java
+++ b/iterableapi-ui/src/main/java/com/iterable/iterableapi/ui/inbox/IterableInboxCustomization.java
@@ -1,0 +1,142 @@
+package com.iterable.iterableapi.ui.inbox;
+
+import android.view.View;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+/**
+ * Configuration class for customizing the inbox toolbar/header appearance and behavior.
+ * <p>
+ * Use the {@link Builder} to create an instance with the desired customization options.
+ * <p>
+ * Example usage:
+ * <pre>
+ * IterableInboxCustomization customization = new IterableInboxCustomization.Builder()
+ *     .setTitle("My Inbox")
+ *     .setTitleCenterAligned(true)
+ *     .setShowCloseButton(true)
+ *     .setCloseButtonListener(v -&gt; finish())
+ *     .build();
+ * </pre>
+ */
+public class IterableInboxCustomization {
+
+    @Nullable
+    private final String title;
+
+    private final boolean titleCenterAligned;
+
+    private final boolean showCloseButton;
+
+    @Nullable
+    private final View.OnClickListener closeButtonListener;
+
+    private IterableInboxCustomization(@NonNull Builder builder) {
+        this.title = builder.title;
+        this.titleCenterAligned = builder.titleCenterAligned;
+        this.showCloseButton = builder.showCloseButton;
+        this.closeButtonListener = builder.closeButtonListener;
+    }
+
+    /**
+     * @return The toolbar title, or null to use the default
+     */
+    @Nullable
+    public String getTitle() {
+        return title;
+    }
+
+    /**
+     * @return Whether the title should be center-aligned
+     */
+    public boolean isTitleCenterAligned() {
+        return titleCenterAligned;
+    }
+
+    /**
+     * @return Whether the close button should be shown
+     */
+    public boolean isShowCloseButton() {
+        return showCloseButton;
+    }
+
+    /**
+     * @return The click listener for the close button, or null for default behavior
+     */
+    @Nullable
+    public View.OnClickListener getCloseButtonListener() {
+        return closeButtonListener;
+    }
+
+    /**
+     * Builder for creating {@link IterableInboxCustomization} instances.
+     */
+    public static class Builder {
+        @Nullable
+        private String title;
+        private boolean titleCenterAligned = false;
+        private boolean showCloseButton = false;
+        @Nullable
+        private View.OnClickListener closeButtonListener;
+
+        /**
+         * Set the toolbar title text.
+         *
+         * @param title The title to display
+         * @return This builder for chaining
+         */
+        @NonNull
+        public Builder setTitle(@Nullable String title) {
+            this.title = title;
+            return this;
+        }
+
+        /**
+         * Set whether the title should be center-aligned in the toolbar.
+         *
+         * @param centerAligned true to center-align the title
+         * @return This builder for chaining
+         */
+        @NonNull
+        public Builder setTitleCenterAligned(boolean centerAligned) {
+            this.titleCenterAligned = centerAligned;
+            return this;
+        }
+
+        /**
+         * Set whether a close button (X) should be shown in the toolbar.
+         *
+         * @param showCloseButton true to show the close button
+         * @return This builder for chaining
+         */
+        @NonNull
+        public Builder setShowCloseButton(boolean showCloseButton) {
+            this.showCloseButton = showCloseButton;
+            return this;
+        }
+
+        /**
+         * Set a custom click listener for the close button.
+         * If not set and the close button is shown, clicking it will finish the activity.
+         *
+         * @param listener The click listener
+         * @return This builder for chaining
+         */
+        @NonNull
+        public Builder setCloseButtonListener(@Nullable View.OnClickListener listener) {
+            this.closeButtonListener = listener;
+            return this;
+        }
+
+        /**
+         * Build the customization instance.
+         *
+         * @return A new {@link IterableInboxCustomization} instance
+         */
+        @NonNull
+        public IterableInboxCustomization build() {
+            return new IterableInboxCustomization(this);
+        }
+    }
+}

--- a/iterableapi-ui/src/main/res/drawable/ic_close_black_24dp.xml
+++ b/iterableapi-ui/src/main/res/drawable/ic_close_black_24dp.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+    <path
+        android:fillColor="@android:color/black"
+        android:pathData="M19,6.41L17.59,5 12,10.59 6.41,5 5,6.41 10.59,12 5,17.59 6.41,19 12,13.41 17.59,19 19,17.59 13.41,12z"/>
+</vector>

--- a/iterableapi-ui/src/main/res/layout/iterable_inbox_activity.xml
+++ b/iterableapi-ui/src/main/res/layout/iterable_inbox_activity.xml
@@ -1,7 +1,33 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/container"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".inbox.IterableInboxActivity" />
+    android:orientation="vertical"
+    tools:context=".inbox.IterableInboxActivity">
+
+    <androidx.appcompat.widget.Toolbar
+        android:id="@+id/iterable_inbox_toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"
+        android:background="?attr/colorPrimary"
+        app:popupTheme="@style/ThemeOverlay.AppCompat.Light">
+
+        <TextView
+            android:id="@+id/iterable_inbox_toolbar_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textSize="20sp"
+            android:textStyle="bold"
+            android:textColor="?android:attr/textColorPrimary"
+            android:visibility="gone" />
+
+    </androidx.appcompat.widget.Toolbar>
+
+    <FrameLayout
+        android:id="@+id/container"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+
+</LinearLayout>

--- a/iterableapi-ui/src/main/res/values/attrs.xml
+++ b/iterableapi-ui/src/main/res/values/attrs.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <declare-styleable name="IterableInboxActivity">
+        <attr name="iterableInboxTitleCenterAligned" format="boolean" />
+        <attr name="iterableInboxShowCloseButton" format="boolean" />
+        <attr name="iterableInboxTitle" format="string" />
+    </declare-styleable>
+</resources>

--- a/iterableapi-ui/src/main/res/values/colors.xml
+++ b/iterableapi-ui/src/main/res/values/colors.xml
@@ -32,4 +32,6 @@
     <color name="title_text_color">#3D3A3B</color>
     <color name="body_text_color">#787174</color>
 
+    <color name="iterableInboxToolbarBackground">#FFFFFF</color>
+
 </resources>

--- a/iterableapi-ui/src/main/res/values/styles.xml
+++ b/iterableapi-ui/src/main/res/values/styles.xml
@@ -6,4 +6,9 @@
         <item name="cornerSizeBottomRight">0dp</item>
         <item name="cornerSizeBottomLeft">0dp</item>
     </style>
+
+    <style name="IterableInboxActivityTheme" parent="Theme.AppCompat.Light.NoActionBar">
+        <item name="colorPrimary">@color/iterableInboxToolbarBackground</item>
+        <item name="colorPrimaryDark">@color/iterableInboxToolbarBackground</item>
+    </style>
 </resources>


### PR DESCRIPTION
## Summary
- Add `IterableInboxCustomization` builder class for configuring inbox toolbar appearance
- Support center-aligned title and close button (with custom click handler) in `IterableInboxActivity`
- Configurable via programmatic API (`setInboxCustomization`) or intent extras (`EXTRA_TITLE_CENTER_ALIGNED`, `EXTRA_SHOW_CLOSE_BUTTON`)

## Test plan
- [ ] Test center-aligned inbox title via `IterableInboxCustomization.Builder().setTitleCenterAligned(true)`
- [ ] Test close button visibility and click handling
- [ ] Test intent extras for title alignment and close button
- [ ] Verify default behavior unchanged (toolbar shows with standard left-aligned title, no close button)

🤖 Generated with [Claude Code](https://claude.com/claude-code)