### PR TITLE
Sumeru / #984 - Remove insecure AES/CBC/PKCS5Padding for new encryption

### DIFF
--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableDataEncryptor.kt
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableDataEncryptor.kt
@@ -83,8 +83,8 @@ class IterableDataEncryptor {
                     ITERABLE_KEY_ALIAS,
                     KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT
                 )
-                    .setBlockModes(KeyProperties.BLOCK_MODE_GCM, KeyProperties.BLOCK_MODE_CBC)
-                    .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE, KeyProperties.ENCRYPTION_PADDING_PKCS7)
+                    .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+                    .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
                     .build()
 
                 keyGenerator.init(keySpec)
@@ -127,11 +127,10 @@ class IterableDataEncryptor {
 
         try {
             val data = value.toByteArray(Charsets.UTF_8)
-            val encryptedData = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
-                encryptModern(data)
-            } else {
-                encryptLegacy(data)
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.KITKAT) {
+                throw UnsupportedOperationException("Encryption requires Android API 19 (KitKat) or higher")
             }
+            val encryptedData = encryptModern(data)
 
             // Combine isModern flag, IV length, IV, and encrypted data
             val combined = ByteArray(1 + 1 + encryptedData.iv.size + encryptedData.data.size)
@@ -185,10 +184,6 @@ class IterableDataEncryptor {
 
     @TargetApi(Build.VERSION_CODES.KITKAT)
     private fun encryptModern(data: ByteArray): EncryptedData {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.KITKAT) {
-            return encryptLegacy(data)
-        }
-        
         val cipher = Cipher.getInstance(TRANSFORMATION_MODERN)
         cipher.init(Cipher.ENCRYPT_MODE, getKey())
         val iv = cipher.iv
@@ -196,7 +191,9 @@ class IterableDataEncryptor {
         return EncryptedData(encrypted, iv, true)
     }
 
-    private fun encryptLegacy(data: ByteArray): EncryptedData {
+    @Deprecated("Legacy CBC encryption is insecure due to padding oracle vulnerability. Only retained for testing backward compatibility of decryption.")
+    @VisibleForTesting
+    fun encryptLegacy(data: ByteArray): EncryptedData {
         val cipher = Cipher.getInstance(TRANSFORMATION_LEGACY)
         val iv = generateIV(isModern = false)
         val spec = IvParameterSpec(iv)

--- a/iterableapi/src/test/java/com/iterable/iterableapi/IterableDataEncryptorTest.java
+++ b/iterableapi/src/test/java/com/iterable/iterableapi/IterableDataEncryptorTest.java
@@ -306,29 +306,38 @@ public class IterableDataEncryptorTest extends BaseTest {
     public void testEncryptionAcrossApiLevels() {
         String testData = "test data for cross-version compatibility";
 
-        // Test API 16 (Legacy)
-        setFinalStatic(Build.VERSION.class, "SDK_INT", Build.VERSION_CODES.JELLY_BEAN);
-        String encryptedOnApi16 = encryptor.encrypt(testData);
-
-        // Test API 18 (Legacy)
-        setFinalStatic(Build.VERSION.class, "SDK_INT", Build.VERSION_CODES.JELLY_BEAN_MR2);
-        String encryptedOnApi18 = encryptor.encrypt(testData);
-        assertEquals("Legacy decryption should work on API 18", testData, encryptor.decrypt(encryptedOnApi16));
+        // Create legacy-encrypted data using encryptLegacy directly for backward compat testing
+        byte[] testBytes = testData.getBytes(java.nio.charset.StandardCharsets.UTF_8);
+        IterableDataEncryptor.EncryptedData legacyEncrypted = encryptor.encryptLegacy(testBytes);
+        // Manually build the combined format: flag(0) + ivLength + iv + data
+        byte[] combined = new byte[1 + 1 + legacyEncrypted.getIv().length + legacyEncrypted.getData().length];
+        combined[0] = 0; // legacy flag
+        combined[1] = (byte) legacyEncrypted.getIv().length;
+        System.arraycopy(legacyEncrypted.getIv(), 0, combined, 2, legacyEncrypted.getIv().length);
+        System.arraycopy(legacyEncrypted.getData(), 0, combined, 2 + legacyEncrypted.getIv().length, legacyEncrypted.getData().length);
+        String legacyEncryptedStr = Base64.encodeToString(combined, Base64.NO_WRAP);
 
         // Test API 19 (Modern - First version with GCM support)
         setFinalStatic(Build.VERSION.class, "SDK_INT", Build.VERSION_CODES.KITKAT);
         String encryptedOnApi19 = encryptor.encrypt(testData);
-        assertEquals("Should decrypt legacy data on API 19", testData, encryptor.decrypt(encryptedOnApi16));
-        assertEquals("Should decrypt legacy data on API 19", testData, encryptor.decrypt(encryptedOnApi18));
+        assertEquals("Should decrypt legacy data on API 19", testData, encryptor.decrypt(legacyEncryptedStr));
 
         // Test API 23 (Modern with KeyStore)
         setFinalStatic(Build.VERSION.class, "SDK_INT", Build.VERSION_CODES.M);
         String encryptedOnApi23 = encryptor.encrypt(testData);
-        assertEquals("Should decrypt legacy data on API 23", testData, encryptor.decrypt(encryptedOnApi16));
+        assertEquals("Should decrypt legacy data on API 23", testData, encryptor.decrypt(legacyEncryptedStr));
         assertEquals("Should decrypt API 19 data on API 23", testData, encryptor.decrypt(encryptedOnApi19));
 
-        // Test that modern encryption fails on legacy devices
+        // Test that encryption on pre-KitKat throws UnsupportedOperationException
         setFinalStatic(Build.VERSION.class, "SDK_INT", Build.VERSION_CODES.JELLY_BEAN);
+        try {
+            encryptor.encrypt(testData);
+            fail("Should throw UnsupportedOperationException on pre-KitKat");
+        } catch (UnsupportedOperationException e) {
+            assertEquals("Encryption requires Android API 19 (KitKat) or higher", e.getMessage());
+        }
+
+        // Test that modern encryption fails to decrypt on legacy devices
         try {
             encryptor.decrypt(encryptedOnApi19);
             fail("Should not be able to decrypt modern encryption on legacy device");
@@ -348,12 +357,6 @@ public class IterableDataEncryptorTest extends BaseTest {
     @Test
     public void testEncryptionMethodFlag() {
         String testData = "test data for encryption method verification";
-
-        // Test legacy encryption flag (API 16)
-        setFinalStatic(Build.VERSION.class, "SDK_INT", Build.VERSION_CODES.JELLY_BEAN);
-        String legacyEncrypted = encryptor.encrypt(testData);
-        byte[] legacyBytes = Base64.decode(legacyEncrypted, Base64.NO_WRAP);
-        assertEquals("Legacy encryption should have flag 0", 0, legacyBytes[0]);
 
         // Test modern encryption flag (API 19)
         setFinalStatic(Build.VERSION.class, "SDK_INT", Build.VERSION_CODES.KITKAT);
@@ -402,17 +405,22 @@ public class IterableDataEncryptorTest extends BaseTest {
 
     @Test
     public void testDecryptManipulatedVersionFlag() {
-        // Test on API 16 device
-        setFinalStatic(Build.VERSION.class, "SDK_INT", Build.VERSION_CODES.JELLY_BEAN);
-
+        // Create legacy-encrypted data using encryptLegacy directly
         String testData = "test data";
-        String encrypted = encryptor.encrypt(testData);
-        byte[] bytes = Base64.decode(encrypted, Base64.NO_WRAP);
+        byte[] testBytes = testData.getBytes(java.nio.charset.StandardCharsets.UTF_8);
+        IterableDataEncryptor.EncryptedData legacyEncrypted = encryptor.encryptLegacy(testBytes);
+        byte[] combined = new byte[1 + 1 + legacyEncrypted.getIv().length + legacyEncrypted.getData().length];
+        combined[0] = 0; // legacy flag
+        combined[1] = (byte) legacyEncrypted.getIv().length;
+        System.arraycopy(legacyEncrypted.getIv(), 0, combined, 2, legacyEncrypted.getIv().length);
+        System.arraycopy(legacyEncrypted.getData(), 0, combined, 2 + legacyEncrypted.getIv().length, legacyEncrypted.getData().length);
 
         // Change version flag from legacy (0) to modern (1)
-        bytes[0] = 1;
-        String manipulated = Base64.encodeToString(bytes, Base64.NO_WRAP);
+        combined[0] = 1;
+        String manipulated = Base64.encodeToString(combined, Base64.NO_WRAP);
 
+        // Test on API 16 device - should fail because modern decryption is not available
+        setFinalStatic(Build.VERSION.class, "SDK_INT", Build.VERSION_CODES.JELLY_BEAN);
         try {
             encryptor.decrypt(manipulated);
             fail("Should throw exception for manipulated version flag");
@@ -424,31 +432,42 @@ public class IterableDataEncryptorTest extends BaseTest {
 
     @Test
     public void testLegacyEncryptionAndDecryption() {
-        // Set to API 16 (Legacy)
-        setFinalStatic(Build.VERSION.class, "SDK_INT", Build.VERSION_CODES.JELLY_BEAN);
-
         String testData = "test data for legacy encryption";
-        String encrypted = encryptor.encrypt(testData);
-        String decrypted = encryptor.decrypt(encrypted);
 
-        assertEquals("Legacy encryption/decryption should work on API 16", testData, decrypted);
+        // Verify encrypt() throws on pre-KitKat
+        setFinalStatic(Build.VERSION.class, "SDK_INT", Build.VERSION_CODES.JELLY_BEAN);
+        try {
+            encryptor.encrypt(testData);
+            fail("Should throw UnsupportedOperationException on pre-KitKat");
+        } catch (UnsupportedOperationException e) {
+            assertEquals("Encryption requires Android API 19 (KitKat) or higher", e.getMessage());
+        }
 
-        // Verify it's using legacy encryption
-        byte[] encryptedBytes = Base64.decode(encrypted, Base64.NO_WRAP);
+        // Create legacy-encrypted data using encryptLegacy directly
+        byte[] testBytes = testData.getBytes(java.nio.charset.StandardCharsets.UTF_8);
+        IterableDataEncryptor.EncryptedData legacyEncrypted = encryptor.encryptLegacy(testBytes);
+        byte[] combined = new byte[1 + 1 + legacyEncrypted.getIv().length + legacyEncrypted.getData().length];
+        combined[0] = 0; // legacy flag
+        combined[1] = (byte) legacyEncrypted.getIv().length;
+        System.arraycopy(legacyEncrypted.getIv(), 0, combined, 2, legacyEncrypted.getIv().length);
+        System.arraycopy(legacyEncrypted.getData(), 0, combined, 2 + legacyEncrypted.getIv().length, legacyEncrypted.getData().length);
+        String legacyEncryptedStr = Base64.encodeToString(combined, Base64.NO_WRAP);
+
+        // Verify it has legacy encryption flag
+        byte[] encryptedBytes = Base64.decode(legacyEncryptedStr, Base64.NO_WRAP);
         assertEquals("Should use legacy encryption flag", 0, encryptedBytes[0]);
 
-        // Test on API 18
-        setFinalStatic(Build.VERSION.class, "SDK_INT", Build.VERSION_CODES.JELLY_BEAN_MR2);
-        String decryptedOnApi18 = encryptor.decrypt(encrypted);
-        assertEquals("Legacy data should be decryptable on API 18", testData, decryptedOnApi18);
+        // Verify legacy data can still be decrypted on any API level
+        String decryptedOnLegacy = encryptor.decrypt(legacyEncryptedStr);
+        assertEquals("Legacy data should be decryptable on legacy device", testData, decryptedOnLegacy);
 
-        String encryptedOnApi18 = encryptor.encrypt(testData);
-        String decryptedFromApi18 = encryptor.decrypt(encryptedOnApi18);
-        assertEquals("API 18 encryption/decryption should work", testData, decryptedFromApi18);
+        setFinalStatic(Build.VERSION.class, "SDK_INT", Build.VERSION_CODES.KITKAT);
+        String decryptedOnApi19 = encryptor.decrypt(legacyEncryptedStr);
+        assertEquals("Legacy data should be decryptable on API 19", testData, decryptedOnApi19);
 
-        // Verify API 18 also uses legacy encryption
-        byte[] api18EncryptedBytes = Base64.decode(encryptedOnApi18, Base64.NO_WRAP);
-        assertEquals("Should use legacy encryption flag on API 18", 0, api18EncryptedBytes[0]);
+        setFinalStatic(Build.VERSION.class, "SDK_INT", Build.VERSION_CODES.M);
+        String decryptedOnApi23 = encryptor.decrypt(legacyEncryptedStr);
+        assertEquals("Legacy data should be decryptable on API 23", testData, decryptedOnApi23);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Always use AES/GCM/NoPadding for new encryption, eliminating the insecure AES/CBC/PKCS5Padding path
- Throw `UnsupportedOperationException` on pre-KitKat devices instead of falling back to vulnerable CBC mode
- Retain legacy CBC decryption for backward compatibility with existing encrypted data
- Remove CBC block mode from new AndroidKeyStore key generation

## Test plan
- [ ] Verify existing encrypted data (email, userId, authToken) can still be decrypted after upgrade
- [ ] Verify new encryption always uses GCM (flag byte = 1 in encrypted output)
- [ ] Run `IterableDataEncryptorTest` — updated tests validate legacy decrypt + modern-only encrypt
- [ ] Test on a fresh install to verify key generation uses GCM-only spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)