### PR TITLE
Sumeru / #1013 - Improve WebView creation error handling for in-app messages

### DIFF
--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableInAppFragmentHTMLNotification.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableInAppFragmentHTMLNotification.java
@@ -4,7 +4,6 @@ import android.app.Activity;
 import android.app.Dialog;
 import android.content.Context;
 import android.content.DialogInterface;
-import android.content.res.Resources;
 import android.graphics.Color;
 import android.graphics.Point;
 import android.graphics.Rect;

--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableInAppFragmentHTMLNotification.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableInAppFragmentHTMLNotification.java
@@ -203,6 +203,10 @@ public class IterableInAppFragmentHTMLNotification extends DialogFragment implem
 
         webView = createWebViewSafely(getContext());
         if (webView == null) {
+            IterableLogger.e(TAG, "WebView creation failed for message: " + messageId + ". In-app will be dismissed.");
+            if (clickCallback != null) {
+                clickCallback.execute(null);
+            }
             dismissAllowingStateLoss();
             return null;
         }
@@ -757,11 +761,8 @@ public class IterableInAppFragmentHTMLNotification extends DialogFragment implem
     private IterableWebView createWebViewSafely(Context context) {
         try {
             return new IterableWebView(context);
-        } catch (Resources.NotFoundException e) {
-            IterableLogger.e(TAG, "Failed to create WebView - system WebView resource issue", e);
-            return null;
-        } catch (RuntimeException e) {
-            IterableLogger.e(TAG, "Failed to create WebView - unexpected error", e);
+        } catch (Throwable e) {
+            IterableLogger.e(TAG, "Failed to create WebView", e);
             return null;
         }
     }


### PR DESCRIPTION
## Summary
- Catch all `Throwable` types (including `Error` subclasses like `UnsatisfiedLinkError`) during WebView creation, not just `RuntimeException`
- Notify host app via `clickCallback` when WebView creation fails, so the app is aware the in-app couldn't be shown
- Add detailed logging with `messageId` when WebView creation fails

## Test plan
- [ ] Verify in-app messages still display normally when WebView is healthy
- [ ] Verify graceful degradation when WebView is unavailable (e.g., disabled Chrome/System WebView)
- [ ] Verify the click callback is invoked with `null` when WebView fails
- [ ] Verify no crash occurs regardless of WebView state

🤖 Generated with [Claude Code](https://claude.com/claude-code)