### PR TITLE
Sumeru / #954 - Fix WebView render process crash handling

### DIFF
--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableWebViewClient.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableWebViewClient.java
@@ -1,9 +1,13 @@
 package com.iterable.iterableapi;
 
+import android.os.Build;
+import android.webkit.RenderProcessGoneDetail;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
 
 class IterableWebViewClient extends WebViewClient {
+    private static final String TAG = "IterableWebViewClient";
+
     IterableWebView.HTMLNotificationCallbacks inAppHTMLNotification;
 
     IterableWebViewClient(IterableWebView.HTMLNotificationCallbacks inAppHTMLNotification) {
@@ -20,5 +24,22 @@ class IterableWebViewClient extends WebViewClient {
     public void onPageFinished(WebView view, String url) {
         inAppHTMLNotification.setLoaded(true);
         view.postDelayed(inAppHTMLNotification::runResizeScript, 100);
+    }
+
+    @Override
+    public boolean onRenderProcessGone(WebView view, RenderProcessGoneDetail detail) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            boolean didCrash = detail.didCrash();
+            IterableLogger.e(TAG, "WebView render process gone. didCrash: " + didCrash);
+
+            // Destroy the WebView to clean up its internal state
+            if (view != null) {
+                view.destroy();
+            }
+
+            // Return true to indicate we handled this, preventing the app from crashing
+            return true;
+        }
+        return super.onRenderProcessGone(view, detail);
     }
 }


### PR DESCRIPTION
## Summary
- Add `onRenderProcessGone` handler to `IterableWebViewClient` to gracefully handle Chrome renderer process crashes
- When the render process dies, the WebView is destroyed to clean up internal state and `true` is returned to prevent the app from crashing
- Logs the crash event via `IterableLogger` for debugging purposes

## Test plan
- [ ] Verify the app no longer crashes when the Chrome WebView renderer process dies unexpectedly
- [ ] Verify in-app messages continue to function normally when no renderer crash occurs
- [ ] Verify the fix only activates on API 26+ (Android O) as `onRenderProcessGone` is not available on earlier versions
- [ ] Check logcat for the "WebView render process gone" error message when simulating a renderer crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)