### PR TITLE
Sumeru / #638 - Prevent TransactionTooLargeException for large in-app messages

### DIFF
--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableInAppFragmentHTMLNotification.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableInAppFragmentHTMLNotification.java
@@ -201,6 +201,14 @@ public class IterableInAppFragmentHTMLNotification extends DialogFragment implem
             applyWindowGravity(getDialog().getWindow(), "onCreateView");
         }
 
+        // If htmlString is null (e.g., after state restoration where it was stripped
+        // to prevent TransactionTooLargeException), dismiss the fragment gracefully.
+        if (htmlString == null) {
+            IterableLogger.w(TAG, "HTML content not available, dismissing in-app notification");
+            dismissAllowingStateLoss();
+            return null;
+        }
+
         webView = createWebViewSafely(getContext());
         if (webView == null) {
             dismissAllowingStateLoss();
@@ -321,6 +329,14 @@ public class IterableInAppFragmentHTMLNotification extends DialogFragment implem
     public void onSaveInstanceState(@NonNull Bundle outState) {
         super.onSaveInstanceState(outState);
         outState.putBoolean(IN_APP_OPEN_TRACKED, true);
+
+        // Remove the HTML string from arguments to prevent TransactionTooLargeException
+        // when large in-app HTML (>250KB) is persisted via the saved state bundle.
+        // The HTML will be re-read from arguments on recreation if needed.
+        Bundle args = getArguments();
+        if (args != null) {
+            args.remove(HTML_STRING);
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary
- Strip HTML content from fragment arguments during `onSaveInstanceState` to avoid exceeding the Binder transaction limit (~1MB) when large in-app HTML (>250KB) is persisted via the saved state bundle.
- Gracefully dismiss the in-app notification fragment if HTML content is unavailable after state restoration (e.g., when it was stripped to prevent the crash).

## Test plan
- [ ] Verify that in-app messages with large HTML content (>250KB) no longer cause `TransactionTooLargeException` when the activity goes through save/restore state cycles (e.g., backgrounding the app, rotating the device).
- [ ] Verify that if the fragment is recreated after state restoration with stripped HTML, it dismisses gracefully without a crash.
- [ ] Verify that normal-sized in-app messages continue to display and function correctly.
- [ ] Verify that in-app open tracking is not duplicated on state restoration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)