### PR TITLE
fix: correct IterableEmbeddedView image height and scaleType (#997)

### DIFF
--- a/iterableapi-ui/src/main/res/layout-v21/banner_view.xml
+++ b/iterableapi-ui/src/main/res/layout-v21/banner_view.xml
@@ -51,7 +51,9 @@
     <ImageView
         android:id="@+id/embedded_message_image"
         android:layout_width="80dp"
-        android:layout_height="80dp"
+        android:layout_height="wrap_content"
+        android:adjustViewBounds="true"
+        android:scaleType="fitCenter"
         android:layout_marginTop="16dp"
         android:layout_marginEnd="16dp"
         android:contentDescription=""

--- a/iterableapi-ui/src/main/res/layout-v21/card_view.xml
+++ b/iterableapi-ui/src/main/res/layout-v21/card_view.xml
@@ -16,9 +16,10 @@
     <com.google.android.material.imageview.ShapeableImageView
         android:id="@+id/embedded_message_image"
         android:layout_width="0dp"
-        android:layout_height="0dp"
+        android:layout_height="wrap_content"
+        android:adjustViewBounds="true"
         android:contentDescription=""
-        android:scaleType="centerCrop"
+        android:scaleType="fitCenter"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
@@ -30,6 +31,7 @@
         android:layout_width="0dp"
         android:layout_height="@dimen/card_text_container_height"
         android:orientation="vertical"
+        app:layout_constraintTop_toBottomOf="@id/embedded_message_image"
         app:layout_constraintBottom_toTopOf="@id/embedded_message_buttons_container"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent">

--- a/iterableapi-ui/src/main/res/layout/banner_view.xml
+++ b/iterableapi-ui/src/main/res/layout/banner_view.xml
@@ -51,7 +51,9 @@
     <ImageView
         android:id="@+id/embedded_message_image"
         android:layout_width="80dp"
-        android:layout_height="80dp"
+        android:layout_height="wrap_content"
+        android:adjustViewBounds="true"
+        android:scaleType="fitCenter"
         android:layout_marginTop="16dp"
         android:layout_marginEnd="16dp"
         android:layout_marginRight="16dp"

--- a/iterableapi-ui/src/main/res/layout/card_view.xml
+++ b/iterableapi-ui/src/main/res/layout/card_view.xml
@@ -17,9 +17,10 @@
     <com.google.android.material.imageview.ShapeableImageView
         android:id="@+id/embedded_message_image"
         android:layout_width="0dp"
-        android:layout_height="0dp"
+        android:layout_height="wrap_content"
+        android:adjustViewBounds="true"
         android:contentDescription=""
-        android:scaleType="centerCrop"
+        android:scaleType="fitCenter"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
@@ -31,6 +32,7 @@
         android:layout_width="0dp"
         android:layout_height="@dimen/card_text_container_height"
         android:orientation="vertical"
+        app:layout_constraintTop_toBottomOf="@id/embedded_message_image"
         app:layout_constraintBottom_toTopOf="@id/embedded_message_buttons_container"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent">


### PR DESCRIPTION
## Summary
The `embedded_message_image` ImageView in the `IterableEmbeddedView` layout had a height of 0, causing images not to display when a Media URL was configured in a campaign.

## Changes
- Set `android:layout_height="wrap_content"` on the embedded message image view (was `0dp` in card_view.xml)
- Added `android:adjustViewBounds="true"` to maintain image aspect ratio
- Added `android:scaleType="fitCenter"` for proper scaling that matches campaign preview
- Added missing `app:layout_constraintTop_toBottomOf="@id/embedded_message_image"` on `embedded_message_text_container` in card_view.xml so it correctly positions below the image

Applied to all four layout files: `layout/card_view.xml`, `layout-v21/card_view.xml`, `layout/banner_view.xml`, and `layout-v21/banner_view.xml`.

## Test plan
- [ ] Verify embedded messages with Media URL display correctly
- [ ] Verify image height matches campaign preview proportions
- [ ] Verify embedded messages without media still display correctly
- [ ] Test on various screen sizes and densities

Made with [Cursor](https://cursor.com)