### PR TITLE
Add CLAUDE.md and build/test scripts for AI agents

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 The Iterable Android SDK integrates Android apps with [Iterable](https://www.iterable.com), a growth marketing platform. The SDK provides push notifications (FCM), in-app messaging, embedded messaging, mobile inbox, event tracking, deep linking, and user management.
 
-**Current version:** 3.7.0 | **Min SDK:** 21 (Android 5.0+) | **Language:** Java (75%) + Kotlin (25%)
+**Min SDK:** 21 (Android 5.0+) | **Language:** Java (75%) + Kotlin (25%)
 
 ## Quick Reference
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,19 +12,29 @@ The Iterable Android SDK integrates Android apps with [Iterable](https://www.ite
 
 ```bash
 # Build (incremental, fast)
-./gradlew build -x test
+./build.sh
 
 # Build (clean)
-./gradlew clean build -x test
+./build.sh --clean
 
 # Run all unit tests
-./gradlew :iterableapi:testDebugUnitTest
+./test.sh
 
 # Run a specific test class
-./gradlew :iterableapi:testDebugUnitTest --tests "*IterableApiTest*"
+./test.sh IterableApiTest
 
 # Run a specific test method
-./gradlew :iterableapi:testDebugUnitTest --tests "*IterableApiTest.testSetEmail*"
+./test.sh "IterableApiTest.testSetEmail"
+
+# List all available test classes
+./test.sh --list
+```
+
+The wrapper scripts (`build.sh`, `test.sh`) provide formatted output and error summaries. You can also use Gradle directly:
+
+```bash
+./gradlew build -x test                                                    # build
+./gradlew :iterableapi:testDebugUnitTest --tests "*IterableApiTest*"       # test
 ```
 
 ### Requirements

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,119 @@
+# CLAUDE.md - Iterable Android SDK
+
+## Project Overview
+
+The Iterable Android SDK integrates Android apps with [Iterable](https://www.iterable.com), a growth marketing platform. The SDK provides push notifications (FCM), in-app messaging, embedded messaging, mobile inbox, event tracking, deep linking, and user management.
+
+**Current version:** 3.7.0 | **Min SDK:** 21 (Android 5.0+) | **Language:** Java (75%) + Kotlin (25%)
+
+## Quick Reference
+
+### Build & Test
+
+```bash
+# Build (incremental, fast)
+./gradlew build -x test
+
+# Build (clean)
+./gradlew clean build -x test
+
+# Run all unit tests
+./gradlew :iterableapi:testDebugUnitTest
+
+# Run a specific test class
+./gradlew :iterableapi:testDebugUnitTest --tests "*IterableApiTest*"
+
+# Run a specific test method
+./gradlew :iterableapi:testDebugUnitTest --tests "*IterableApiTest.testSetEmail*"
+```
+
+### Requirements
+
+- JDK 17+
+- Android SDK with compileSdk 34
+- Gradle 8.0+ (use the wrapper: `./gradlew`)
+
+## Project Structure
+
+```
+iterableapi/              # Core SDK module (main deliverable)
+iterableapi-ui/           # UI components module (inbox, embedded views)
+app/                      # Internal test application for SDK integration testing
+sample-apps/              # Example apps demonstrating SDK usage (inbox-customization)
+integration-tests/        # End-to-end integration tests (requires emulator)
+tools/                    # CI/CD utilities (emulator wait script)
+```
+
+## Module Details
+
+### iterableapi (core SDK)
+- **Source:** `iterableapi/src/main/java/com/iterable/iterableapi/`
+- **Tests:** `iterableapi/src/test/java/com/iterable/iterableapi/`
+- ~94 source files, ~48 test files
+- Mostly Java with Kotlin for newer features (embedded messaging, encryption, keychain)
+
+### iterableapi-ui (UI components)
+- **Source:** `iterableapi-ui/src/main/java/com/iterable/iterableapi/ui/`
+- Inbox UI (Java) and Embedded views (Kotlin)
+- No unit tests in this module
+
+## Key Classes
+
+| Class | Purpose |
+|-------|---------|
+| `IterableApi.java` | Main SDK interface (singleton entry point) |
+| `IterableConfig.java` | SDK configuration builder |
+| `IterableApiClient.java` | Network communication / API calls |
+| `IterableAuthManager.java` | JWT authentication management |
+| `IterableKeychain.kt` | Secure token/credential storage |
+| `IterableInAppManager.java` | In-app message lifecycle management |
+| `IterableEmbeddedManager.kt` | Embedded message management |
+| `IterableConstants.java` | API endpoint paths and constants |
+| `IterableRequestTask.java` | Network request execution |
+| `IterableFirebaseMessagingService.java` | FCM push notification handling |
+| `IterableDeeplinkManager.java` | Deep link resolution |
+| `IterableNotificationHelper.java` | Push notification display |
+
+## Common Development Tasks
+
+### Adding a new API endpoint
+1. Add endpoint path constant to `IterableConstants.java`
+2. Add request method to `IterableApiClient.java`
+3. Add public-facing method to `IterableApi.java`
+4. Add tests in `iterableapi/src/test/java/`
+
+### Modifying authentication
+- Auth flow: `IterableAuthManager.java`
+- Token storage: `IterableKeychain.kt`
+- Auth failure handling: `AuthFailure.java`, `AuthFailureReason.java`
+
+### Adding a new model class
+- Create in `iterableapi/src/main/java/com/iterable/iterableapi/`
+- Implement `Parcelable` if passed between components
+- Add JSON serialization for network transport
+
+## Code Style
+
+- Checkstyle enforced (see `checkstyle.xml`)
+- No star imports
+- Max method length: 200 lines
+- Standard Java naming conventions (camelCase methods/vars, PascalCase types)
+- New features tend to use Kotlin; existing Java code stays Java unless refactored
+
+## CI/CD
+
+GitHub Actions workflows in `.github/workflows/`:
+- `build.yml` - Main build and test
+- `integration-tests.yml` - Full integration test suite
+- `inapp-e2e-tests.yml` - E2E tests for in-app messaging
+- `codeql.yml` - Code quality analysis
+- `prepare-release.yml` / `validate-release.yml` / `publish.yml` - Release pipeline
+
+## Testing Notes
+
+- Unit tests use Robolectric for Android framework simulation
+- Network tests use OkHttp MockWebServer
+- Mocking via Mockito (core + inline)
+- JSON assertions via JSONAssert
+- Test base class: `BaseTest.java`
+- Test utilities: `IterableTestUtils.java`, `InAppTestUtils.java`, `EmbeddedTestUtils.java`

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+# This script is to be used by LLMs and AI agents to build the Iterable Android SDK.
+# It uses Gradle to build the project and shows errors in a clean format.
+# It also checks if the build is successful and exits with the correct status.
+# 
+# Usage: ./agent/build.sh [--clean]
+#   --clean: Force a clean build (slower, but ensures clean state)
+
+# Note: Not using set -e because we need to handle build failures gracefully
+
+echo "Building Iterable Android SDK..."
+
+# Create a temporary file for the build output
+TEMP_OUTPUT=$(mktemp)
+
+# Function to clean up temp file on exit
+cleanup() {
+    rm -f "$TEMP_OUTPUT"
+}
+trap cleanup EXIT
+
+# Check if we have Android SDK
+if [ -z "$ANDROID_HOME" ] && [ -z "$ANDROID_SDK_ROOT" ]; then
+    echo "⚠️  Warning: ANDROID_HOME or ANDROID_SDK_ROOT not set. Build may fail if Android SDK is not in PATH."
+fi
+
+# Parse command line arguments for clean build option
+CLEAN_BUILD=false
+if [[ "$1" == "--clean" ]]; then
+    CLEAN_BUILD=true
+    echo "🧹 Clean build requested"
+fi
+
+# Run the build and capture all output
+if [ "$CLEAN_BUILD" = true ]; then
+    echo "🔨 Clean building all modules..."
+    ./gradlew clean build -x test --no-daemon --console=plain > "$TEMP_OUTPUT" 2>&1
+    BUILD_STATUS=$?
+else
+    echo "🔨 Building all modules (incremental)..."
+    ./gradlew build -x test --no-daemon --console=plain > "$TEMP_OUTPUT" 2>&1
+    BUILD_STATUS=$?
+fi
+
+# Show appropriate output based on build result
+if [ $BUILD_STATUS -eq 0 ]; then
+    echo "✅ Iterable Android SDK build succeeded!"
+    echo ""
+    echo "📦 Built modules:"
+    echo "  • iterableapi (core SDK)"
+    echo "  • iterableapi-ui (UI components)"
+    echo "  • app (sample app)"
+else
+    echo "❌ Iterable Android SDK build failed with status $BUILD_STATUS"
+    echo ""
+    echo "🔍 Build errors:"
+    
+    # Extract and show compilation errors with file paths and line numbers
+    grep -E "\.java:[0-9]+: error:|\.kt:[0-9]+: error:|error:|Error:|FAILURE:|Failed|Exception:" "$TEMP_OUTPUT" | head -20
+    
+    echo ""
+    echo "⚠️  Build warnings:"
+    grep -E "\.java:[0-9]+: warning:|\.kt:[0-9]+: warning:|warning:|Warning:" "$TEMP_OUTPUT" | head -10
+    
+    # If no specific errors found, show the failure section
+    if ! grep -q -E "\.java:[0-9]+: error:|\.kt:[0-9]+: error:|error:" "$TEMP_OUTPUT"; then
+        echo ""
+        echo "📋 Build failure details:"
+        grep -A 10 -B 2 "FAILURE\|BUILD FAILED" "$TEMP_OUTPUT" | head -15
+    fi
+    
+    echo ""
+    echo "💡 Common solutions:"
+    echo "  • Check Java version (JDK 17+ required)"
+    echo "  • Verify ANDROID_HOME is set correctly"
+    echo "  • Run './gradlew --stop' to kill daemon processes"
+    echo "  • Check dependencies in build.gradle files"
+fi
+
+exit $BUILD_STATUS 

--- a/build.sh
+++ b/build.sh
@@ -4,7 +4,7 @@
 # It uses Gradle to build the project and shows errors in a clean format.
 # It also checks if the build is successful and exits with the correct status.
 # 
-# Usage: ./agent/build.sh [--clean]
+# Usage: ./build.sh [--clean]
 #   --clean: Force a clean build (slower, but ensures clean state)
 
 # Note: Not using set -e because we need to handle build failures gracefully

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,269 @@
+#!/bin/bash
+
+# This script is to be used by LLMs and AI agents to run tests for the Iterable Android SDK.
+# It uses Gradle to run tests and provides clean output with filtering capabilities.
+
+set -e
+
+# Parse command line arguments
+FILTER=""
+LIST_TESTS=false
+
+if [[ $# -eq 1 ]]; then
+    if [[ "$1" == "--list" ]]; then
+        LIST_TESTS=true
+    else
+        FILTER="$1"
+        echo "🎯 Running tests with filter: $FILTER"
+    fi
+elif [[ $# -gt 1 ]]; then
+    echo "❌ Usage: $0 [filter|--list]"
+    echo "   filter: Test class name (e.g., 'IterableApiTest')"
+    echo "           or specific test (e.g., 'IterableApiTest.testSetEmail')"
+    echo "           or module:test (e.g., 'iterableapi:testDebugUnitTest --tests IterableApiTest')"
+    echo "   --list: List all available test classes"
+    exit 1
+fi
+
+# Handle test listing
+if [[ "$LIST_TESTS" == true ]]; then
+    echo "📋 Listing available test classes..."
+    
+    echo "📦 Available Test Classes:"
+    
+    # List test classes from iterableapi module
+    echo ""
+    echo "🔧 iterableapi module:"
+    if [[ -d "iterableapi/src/test/java/com/iterable/iterableapi" ]]; then
+        find iterableapi/src/test/java/com/iterable/iterableapi -name "*.java" -o -name "*.kt" | while read test_file; do
+            test_class=$(basename "$test_file" | sed 's/\.[^.]*$//')
+            # Count test methods in each file
+            test_count=$(grep -c "fun test\|@Test" "$test_file" 2>/dev/null || echo "0")
+            echo "  • $test_class ($test_count tests)"
+        done
+    fi
+    
+    # List test classes from iterableapi-ui module
+    echo ""
+    echo "🎨 iterableapi-ui module:"
+    if [[ -d "iterableapi-ui/src/test" ]]; then
+        find iterableapi-ui/src/test -name "*.java" -o -name "*.kt" 2>/dev/null | while read test_file; do
+            test_class=$(basename "$test_file" | sed 's/\.[^.]*$//')
+            test_count=$(grep -c "fun test\|@Test" "$test_file" 2>/dev/null || echo "0")
+            echo "  • $test_class ($test_count tests)"
+        done
+    else
+        echo "  (No unit tests found)"
+    fi
+    
+    # List test classes from app module
+    echo ""
+    echo "📱 app module:"
+    if [[ -d "app/src/test" ]]; then
+        find app/src/test -name "*.java" -o -name "*.kt" 2>/dev/null | while read test_file; do
+            test_class=$(basename "$test_file" | sed 's/\.[^.]*$//')
+            test_count=$(grep -c "fun test\|@Test" "$test_file" 2>/dev/null || echo "0")
+            echo "  • $test_class ($test_count tests)"
+        done
+    else
+        echo "  (No unit tests found)"
+    fi
+    
+    echo ""
+    echo "🔍 Example Usage:"
+    echo "  ./agent/test.sh IterableKeychainTest"
+    echo "  ./agent/test.sh \"IterableKeychainTest.testSaveAndGetEmail\""
+    echo "  ./agent/test.sh \":iterableapi:testDebugUnitTest --tests com.iterable.iterableapi.IterableKeychainTest\""
+    
+    exit 0
+fi
+
+echo "Running Iterable Android SDK tests..."
+
+# Build the gradle command
+if [[ -n "$FILTER" ]]; then
+    # If filter contains a colon, use it as-is (already in module:task format)
+    if [[ "$FILTER" == *":"* ]]; then
+        GRADLE_CMD="./gradlew $FILTER --no-daemon --console=plain --rerun-tasks"
+    # If filter contains a dot, convert TestClass.testMethod to wildcard format
+    elif [[ "$FILTER" == *"."* ]]; then
+        GRADLE_CMD="./gradlew :iterableapi:testDebugUnitTest --tests \"*$FILTER*\" --no-daemon --console=plain --rerun-tasks"
+    # Otherwise, assume it's just a test class name and use wildcard
+    else
+        GRADLE_CMD="./gradlew :iterableapi:testDebugUnitTest --tests \"*$FILTER*\" --no-daemon --console=plain --rerun-tasks"
+    fi
+else
+    # Run all tests with detailed test output (force execution to see individual tests)
+    GRADLE_CMD="./gradlew :iterableapi:testDebugUnitTest --no-daemon --console=plain --rerun-tasks"
+fi
+
+echo "🧪 Running: $GRADLE_CMD"
+echo "📊 Real-time progress:"
+echo "─────────────────────────────────────────────────────"
+
+# Create a temporary file for capturing output while showing progress
+TEMP_OUTPUT=$(mktemp)
+
+# Function to clean up temp file on exit
+cleanup() {
+    rm -f "$TEMP_OUTPUT"
+}
+trap cleanup EXIT
+
+# Run the tests with real-time output parsing
+eval $GRADLE_CMD 2>&1 | tee "$TEMP_OUTPUT" | while IFS= read -r line; do
+    # Pretty print different types of Gradle output
+    case "$line" in
+        *"> Task "*)
+            # Task execution - only show important ones, simplify build tasks
+            task_name=$(echo "$line" | sed 's/.*> Task //' | sed 's/ .*//')
+            case "$task_name" in
+                *"compile"*|*"build"*|*"generate"*|*"process"*|*"merge"*|*"package"*)
+                    # Only show building status once per batch of build tasks
+                    if [[ ! -f "/tmp/gradle_building_shown" ]]; then
+                        echo "🔨 Building..."
+                        touch "/tmp/gradle_building_shown"
+                    fi
+                    ;;
+            esac
+            ;;
+        *"BUILD SUCCESSFUL"*)
+            rm -f "/tmp/gradle_building_shown" 2>/dev/null
+            echo "✅ Build completed successfully!"
+            ;;
+        *"BUILD FAILED"*)
+            rm -f "/tmp/gradle_building_shown" 2>/dev/null
+            echo "❌ Build failed!"
+            ;;
+        # JUnit test execution patterns
+        *"Test"*"started"*|*"Test"*"STARTED"*)
+            test_name=$(echo "$line" | sed 's/.*Test //' | sed 's/ started.*//' | sed 's/ STARTED.*//')
+            echo "🔄 $test_name"
+            ;;
+        *"Test"*"passed"*|*"Test"*"PASSED"*)
+            test_name=$(echo "$line" | sed 's/.*Test //' | sed 's/ passed.*//' | sed 's/ PASSED.*//')
+            echo "✅ $test_name"
+            ;;
+        *"Test"*"failed"*|*"Test"*"FAILED"*)
+            test_name=$(echo "$line" | sed 's/.*Test //' | sed 's/ failed.*//' | sed 's/ FAILED.*//')
+            echo "❌ $test_name"
+            ;;
+        *"Test"*"skipped"*|*"Test"*"SKIPPED"*)
+            test_name=$(echo "$line" | sed 's/.*Test //' | sed 's/ skipped.*//' | sed 's/ SKIPPED.*//')
+            echo "⏭️ $test_name"
+            ;;
+        # Gradle test output patterns
+        *" > "*)
+            if [[ "$line" == *"STARTED"* ]]; then
+                test_name=$(echo "$line" | sed 's/.*> //' | sed 's/ STARTED.*//')
+                echo "🔄 $test_name"
+            elif [[ "$line" == *"PASSED"* ]]; then
+                test_name=$(echo "$line" | sed 's/.*> //' | sed 's/ PASSED.*//')
+                echo "✅ $test_name"
+            elif [[ "$line" == *"FAILED"* ]]; then
+                test_name=$(echo "$line" | sed 's/.*> //' | sed 's/ FAILED.*//')
+                echo "❌ $test_name"
+            elif [[ "$line" == *"SKIPPED"* ]]; then
+                test_name=$(echo "$line" | sed 's/.*> //' | sed 's/ SKIPPED.*//')
+                echo "⏭️ $test_name"
+            fi
+            ;;
+        # Also catch the full line format for context
+        *".* > "*)
+            if [[ "$line" == *"STARTED"* ]]; then
+                class_and_method=$(echo "$line" | sed 's/ STARTED.*//')
+                method_name=$(echo "$class_and_method" | sed 's/.*> //')
+                echo "🔄 $method_name"
+            elif [[ "$line" == *"PASSED"* ]]; then
+                class_and_method=$(echo "$line" | sed 's/ PASSED.*//')
+                method_name=$(echo "$class_and_method" | sed 's/.*> //')
+                echo "✅ $method_name"
+            elif [[ "$line" == *"FAILED"* ]]; then
+                class_and_method=$(echo "$line" | sed 's/ FAILED.*//')
+                method_name=$(echo "$class_and_method" | sed 's/.*> //')
+                echo "❌ $method_name"
+            elif [[ "$line" == *"SKIPPED"* ]]; then
+                class_and_method=$(echo "$line" | sed 's/ SKIPPED.*//')
+                method_name=$(echo "$class_and_method" | sed 's/.*> //')
+                echo "⏭️ $method_name"
+            fi
+            ;;
+        # Test summary and counts
+        *"tests completed"*|*"test passed"*|*"test failed"*|*"test skipped"*)
+            echo "📊 $line"
+            ;;
+        # Method level test info
+        *"testPassed"*|*"testFailed"*|*"testSkipped"*|*"testStarted"*)
+            method_name=$(echo "$line" | sed 's/.*testMethod=//' | sed 's/,.*//')
+            if [[ "$line" == *"testPassed"* ]]; then
+                echo "✅ $method_name"
+            elif [[ "$line" == *"testFailed"* ]]; then
+                echo "❌ $method_name"
+            elif [[ "$line" == *"testSkipped"* ]]; then
+                echo "⏭️ $method_name"
+            elif [[ "$line" == *"testStarted"* ]]; then
+                echo "🔄 $method_name"
+            fi
+            ;;
+        # General failures and errors
+        *"FAILED"*|*"ERROR"*|*"Exception"*|*"error"*)
+            echo "❌ $line"
+            ;;
+        # Success indicators for individual tests
+        *"PASSED"*)
+            if [[ "$line" == *"test"* ]] || [[ "$line" == *"Test"* ]]; then
+                echo "✅ $line"
+            fi
+            ;;
+        # Timing for tests only
+        *"seconds"*|*"ms"*)
+            if [[ "$line" == *"test"* ]] || [[ "$line" == *"Test"* ]]; then
+                echo "⏱️  $line"
+            fi
+            ;;
+        *)
+            # Catch specific test method patterns
+            if [[ "$line" == *"test"* ]] && ([[ "$line" == *"pass"* ]] || [[ "$line" == *"fail"* ]] || [[ "$line" == *"start"* ]] || [[ "$line" == *"complete"* ]]); then
+                echo "🧪 $line"
+            fi
+            ;;
+    esac
+done
+
+# Get the actual exit status from the temp file
+if grep -q "BUILD SUCCESSFUL" "$TEMP_OUTPUT"; then
+    echo "─────────────────────────────────────────────────────"
+    echo "✅ All tests completed successfully!"
+    
+    # Try to extract test summary
+    if grep -q "tests completed" "$TEMP_OUTPUT"; then
+        echo "📊 Test Summary:"
+        grep "tests completed\|test.*passed\|test.*failed\|test.*skipped" "$TEMP_OUTPUT" | tail -5
+    fi
+    
+    exit 0
+elif grep -q "BUILD FAILED" "$TEMP_OUTPUT"; then
+    echo "─────────────────────────────────────────────────────"
+    echo "❌ Tests failed!"
+    echo ""
+    echo "🔍 Failure Summary:"
+    
+    # Show specific test failures
+    grep -A 3 -B 1 "FAILED\|Failed\|failed.*test" "$TEMP_OUTPUT" | head -15
+    
+    # Show build failures if no test failures
+    if ! grep -q "test.*FAILED\|test.*failed" "$TEMP_OUTPUT"; then
+        echo ""
+        echo "📋 Build Error Details:"
+        grep -A 5 -B 2 "BUILD FAILED\|FAILURE:" "$TEMP_OUTPUT" | head -10
+    fi
+    
+    exit 1
+else
+    echo "─────────────────────────────────────────────────────"
+    echo "❌ Test execution failed"
+    echo ""
+    echo "🔍 Error details:"
+    grep -E "error:|Error:|FAILURE:|Failed|Exception:" "$TEMP_OUTPUT" | head -10
+    exit 1
+fi 

--- a/test.sh
+++ b/test.sh
@@ -71,9 +71,9 @@ if [[ "$LIST_TESTS" == true ]]; then
     
     echo ""
     echo "🔍 Example Usage:"
-    echo "  ./agent/test.sh IterableKeychainTest"
-    echo "  ./agent/test.sh \"IterableKeychainTest.testSaveAndGetEmail\""
-    echo "  ./agent/test.sh \":iterableapi:testDebugUnitTest --tests com.iterable.iterableapi.IterableKeychainTest\""
+    echo "  ./test.sh IterableKeychainTest"
+    echo "  ./test.sh \"IterableKeychainTest.testSaveAndGetEmail\""
+    echo "  ./test.sh \":iterableapi:testDebugUnitTest --tests com.iterable.iterableapi.IterableKeychainTest\""
     
     exit 0
 fi


### PR DESCRIPTION
## Summary
- Adds `CLAUDE.md` with project overview, build/test commands, key classes, module structure, and common development workflows for AI coding assistants
- Adds `build.sh` and `test.sh` wrapper scripts (from `feature/agent-scripts-android`) to repo root for formatted build/test output with error summaries and test filtering

## Context
This replaces the `agent/` directory approach from the previous PR with:
- **CLAUDE.md** at the repo root — the standard convention for AI agent onboarding docs
- **build.sh / test.sh** at the repo root — simpler paths, same functionality

## Test plan
- [ ] Verify `./build.sh` builds the SDK successfully
- [ ] Verify `./build.sh --clean` does a clean build
- [ ] Verify `./test.sh` runs all unit tests
- [ ] Verify `./test.sh IterableApiTest` filters to a specific test class
- [ ] Verify `./test.sh --list` lists available test classes
- [ ] Review CLAUDE.md content for accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)