### PR TITLE
SDK-412 UUA Naming inconsistencies

### DIFF
--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableApi.java
@@ -852,7 +852,7 @@ public class IterableApi {
             && sharedInstance.config.enableUnknownUserActivation
             && sharedInstance.getVisitorUsageTracked()) {
             sharedInstance.unknownUserManager.updateUnknownSession();
-            sharedInstance.unknownUserManager.getCriteria();
+            sharedInstance.unknownUserManager.getUnknownCriteria();
         }
 
         if (DeviceInfoUtils.isFireTV(context.getPackageManager())) {
@@ -1768,7 +1768,7 @@ public class IterableApi {
 
         if (isSetVisitorUsageTracked && config.enableUnknownUserActivation) {
             unknownUserManager.updateUnknownSession();
-            unknownUserManager.getCriteria();
+            unknownUserManager.getUnknownCriteria();
         }
     }
 

--- a/iterableapi/src/main/java/com/iterable/iterableapi/UnknownUserManager.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/UnknownUserManager.java
@@ -170,7 +170,7 @@ public class UnknownUserManager implements IterableActivityMonitor.AppStateCallb
         }
     }
 
-    void getCriteria() {
+    void getUnknownCriteria() {
         lastCriteriaFetch = System.currentTimeMillis();
 
         iterableApi.apiClient.getCriteriaList(data -> {
@@ -258,7 +258,7 @@ public class UnknownUserManager implements IterableActivityMonitor.AppStateCallb
             try {
                 int statusCode = (int) data.get(IterableConstants.HTTP_STATUS_CODE);
                 if (statusCode == 409) {
-                    getCriteria(); // refetch the criteria
+                    getUnknownCriteria(); // refetch the criteria
                 }
             } catch (JSONException e) {
                 e.printStackTrace();
@@ -498,7 +498,7 @@ public class UnknownUserManager implements IterableActivityMonitor.AppStateCallb
             && currentTime - lastCriteriaFetch >= IterableConstants.CRITERIA_FETCHING_COOLDOWN) {
 
             lastCriteriaFetch = currentTime;
-            this.getCriteria();
+            this.getUnknownCriteria();
             IterableLogger.d(TAG, "Fetching unknown user criteria - Foreground");
         }
     }


### PR DESCRIPTION
## 🔹 Jira Ticket(s) if any

* [SDK-412](https://iterable.atlassian.net/browse/SDK-412)

## ✏️ Description

Final piece of the cross-SDK Unknown User Activation (UUA) naming alignment. Android was already consistent with the locked convention everywhere except this one method.

## Change

- `UnknownUserManager.getCriteria()` is now `getUnknownCriteria()`. Method is package-private, so all three call sites (two in `IterableApi.java`, one self-call inside `UnknownUserManager.java`) are updated in this PR. No deprecated alias needed since there are no external consumers.

Everything else (config flag `setEnableUnknownUserActivation`, `mergeOnUnknownToKnown`, `itbl_userid_unknown`, `itbl_unknown_sessions`, session JSON field names, `eventType` discriminator) was already correct per the audit.

## Tests

Existing `IterableApiCriteriaFetchTests` exercises the renamed method through the public API by asserting on the criteria endpoint hit, so coverage is unchanged.



[SDK-412]: https://iterable.atlassian.net/browse/SDK-412?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ