### PR TITLE
SDK-325 BCIT Migrate temp domain setup to final custom domain

### DIFF
--- a/integration-tests/src/androidTest/java/com/iterable/integration/tests/DeepLinkIntegrationTest.kt
+++ b/integration-tests/src/androidTest/java/com/iterable/integration/tests/DeepLinkIntegrationTest.kt
@@ -49,13 +49,16 @@ class DeepLinkIntegrationTest : BaseIntegrationTest() {
         // Note: These URLs need to be configured in your Iterable project
         
         // App Link URL - should open the app directly (like iOS Universal Links)
-        const val TEST_APP_LINK_URL = "https://tsetester.com/update/hi"
+        const val TEST_APP_LINK_URL = "https://bcittesting.com/update/hi"
         
         // Wrapped link URL - SDK should unwrap this
-        const val TEST_WRAPPED_LINK_URL = "https://links.tsetester.com/a/click?_t=5cce074b113d48fa9ef346e4333ed8e8&_m=74aKPNrAjTpuZM4vZTDueu64xMdbHDz5Tn&_e=l6cj19GbssUn6h5qtXjRcC5os6azNW1cqdk9lsvmxxRl4ZTAW8mIB4IHJA97wE1i5f0eRDtm-KpgKI7-tM-Cly6umZo4P8HU8krftMYvL3T2sCpm3uFDBF2iJ5vQ-G6sqNMmae4_8jkE1DU9aKRhraZ1zzUZ3j-dFbQJrxdLt4tb0C7jnXSARVFf27FKFhBKnYSO23taBmf_4G5dTTXKmC_1CGnT9bu1nAwP-WMyYShoQhmjoGO9ppDCrVStSYPsimwub0h5XnC11g4u5yML_WZssgC7LSUOX7qCNOIDr9dLhrx2Rc2TY12k0maESyanjNgNZ4Lr8LMClCMJ3d9TMg%3D%3D"
+        // TODO(SDK-325): regenerate this wrapped link against the new Mobile SDK Testing
+        // project (post SDK-36). The _t/_m/_e tokens below are tied to the old project and
+        // will 404 against links.bcittesting.com until the link is regenerated.
+        const val TEST_WRAPPED_LINK_URL = "https://links.bcittesting.com/a/click?_t=TODO_REGENERATE_TOKEN&_m=TODO&_e=TODO"
         
         // Browser link URL - should open browser, not app (like iOS /u/ pattern links)
-        const val TEST_BROWSER_LINK_URL = "https://links.tsetester.com/u/click?url=https://iterable.com"
+        const val TEST_BROWSER_LINK_URL = "https://links.bcittesting.com/u/click?url=https://iterable.com"
         
         // Custom scheme deep links
         const val TEST_CUSTOM_SCHEME_URL = "iterable://deeplink/product/123"

--- a/integration-tests/src/main/AndroidManifest.xml
+++ b/integration-tests/src/main/AndroidManifest.xml
@@ -86,9 +86,9 @@
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
-                <!-- Test domain - matches iOS tsetester.com domain -->
+                <!-- Test domain - matches iOS bcittesting.com domain -->
                 <data android:scheme="https"
-                    android:host="tsetester.com"
+                    android:host="bcittesting.com"
                     android:pathPrefix="/update" />
             </intent-filter>
             
@@ -98,7 +98,7 @@
                 <category android:name="android.intent.category.BROWSABLE" />
                 <!-- Links domain for wrapped links -->
                 <data android:scheme="https"
-                    android:host="links.tsetester.com"
+                    android:host="links.bcittesting.com"
                     android:pathPrefix="/a/click" />
             </intent-filter>
             


### PR DESCRIPTION
## 🔹 Jira Ticket(s) if any

* [SDK-325](https://iterable.atlassian.net/browse/SDK-325)

## ✏️ Description

Migrating the BCIT integration tests off the temporary `tsetester.com` domain and onto the official engineering-owned `bcittesting.com` (procured via [IT-4410](https://iterable.atlassian.net/browse/IT-4410)).

### What changed

* `integration-tests/src/main/AndroidManifest.xml`: the two `autoVerify` intent filters for App Links now use `bcittesting.com` and `links.bcittesting.com` instead of `tsetester.com` / `links.tsetester.com`
* `DeepLinkIntegrationTest.kt`: `TEST_APP_LINK_URL`, `TEST_BROWSER_LINK_URL` and `TEST_WRAPPED_LINK_URL` constants point at the new domain. The wrapped URL value is stubbed with a `TODO_REGENERATE_TOKEN` placeholder and a `TODO(SDK-325)` comment, since the `_t/_m/_e` tokens are tied to the old Iterable project.

### Why the wrapped URL is a placeholder

The wrapped link tokens are project-scoped, so they will only become valid once [SDK-36](https://iterable.atlassian.net/browse/SDK-36) (the BCIT project migration to the eng org) lands and we can regenerate the link against the new project. I left a loud `TODO_REGENERATE_TOKEN` so any test run that uses it fails fast with a 404 instead of silently passing or hitting the old project.

### Dependencies / sequencing

This PR is intentionally **not ready to merge yet**. The order is:

1. Land [SDK-36](https://iterable.atlassian.net/browse/SDK-36) (new Mobile SDK Testing project)
2. Land iterable-infra [#15167](https://github.com/Iterable/iterable-infra/pull/15167) so `links.bcittesting.com` resolves and serves AASA / assetlinks
3. Configure the tracking + destination domain on the new Iterable project, upload AASA / assetlinks. The current Android `assetlinks.json` on `links.tsetester.com` is broken (malformed SHA-256 fingerprints, plus the package name does not match `com.iterable.integration.tests`), so I will regenerate it from scratch with the real signing-key SHA-256
4. Regenerate the wrapped link, replace the `TODO_REGENERATE_TOKEN` in this PR, then merge

[SDK-325]: https://iterable.atlassian.net/browse/SDK-325?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IT-4410]: https://iterable.atlassian.net/browse/IT-4410?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SDK-36]: https://iterable.atlassian.net/browse/SDK-36?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ