### PR TITLE
ci: migrate Instrumentation tests to ubuntu-latest with KVM + AVD cache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,8 +60,14 @@ jobs:
 
   instrumentation-tests:
     name: Instrumentation tests
-    runs-on: macos-15-intel
+    runs-on: ubuntu-latest
     steps:
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
@@ -75,10 +81,34 @@ jobs:
 
       - run: touch local.properties
 
-      - name: Test
-        uses: reactivecircus/android-emulator-runner@6b0df4b0efb23bb0ec63d881db79aefbc976e4b2 # v2.30.1
+      - name: AVD cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        id: avd-cache
         with:
-          api-level: 28
+          path: |
+            ~/.android/avd/*
+            ~/.android/adb*
+          key: avd-29-x86_64-v1
+
+      - name: Create AVD snapshot
+        if: steps.avd-cache.outputs.cache-hit != 'true'
+        uses: reactivecircus/android-emulator-runner@324029e2f414c084d8b15ba075288885e74aef9c # v2.34.0
+        with:
+          api-level: 29
+          arch: x86_64
+          force-avd-creation: false
+          emulator-options: -no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim
+          disable-animations: false
+          script: echo "Generated AVD snapshot."
+
+      - name: Test
+        uses: reactivecircus/android-emulator-runner@324029e2f414c084d8b15ba075288885e74aef9c # v2.34.0
+        with:
+          api-level: 29
+          arch: x86_64
+          force-avd-creation: false
+          emulator-options: -no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim
+          disable-animations: true
           script: ./gradlew :iterableapi:connectedCheck
 
       # Coverage reporting temporarily disabled


### PR DESCRIPTION
## Why

The required `Instrumentation tests` check has been flaking on `macos-15-intel` runners — see #1049, where the emulator never reached port 5554 and the job died in 32s during AVD/system-image setup. Master's `Build and Test` workflow shows the same job intermittently red across recent merges. GitHub is also winding down the Intel mac fleet.

## What

- Move the job to `ubuntu-latest` with nested-virtualization KVM enabled. This is the path officially recommended by `reactivecircus/android-emulator-runner`.
- Bump the action: `v2.30.1` → `v2.34.0` (still pinned to commit SHA).
- Switch to `api-level: 29` + `arch: x86_64` (better supported than the legacy API 28 x86 image, especially with newer SDK manager versions).
- Add `actions/cache` for the AVD plus a warm-up step that creates the snapshot once and caches it. Subsequent runs reuse it and skip cold AVD creation.
- Make emulator options explicit (`-no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim`) so behavior is reproducible.

## Expected wins

- ~3× faster than macOS (KVM > swiftshader on real hardware).
- Far fewer "emulator never booted" failures.
- AVD cache keeps warm runs ≲2 min.

## Risk / regressions to watch

- **API 28 → 29 behavior diffs.** Anything in `iterableapi:connectedCheck` that asserts on `Build.VERSION.SDK_INT == 28` or relies on permission semantics that changed in P→Q (e.g., scoped storage onset, foreground service tweaks) will need a tweak. Worth a grep before merge.
- **Linux file-system case sensitivity.** Any resource/asset/path lookup that worked by accident on case-insensitive macOS may surface here. Usually a good thing — bugs we should fix anyway.
- **x86 → x86_64 image.** No expected functional regression; x86_64 is a strict superset for the AOSP system images. Just heavier disk usage on the runner.
- **Cache key.** `avd-29-x86_64-v1` — bump the suffix any time we change `api-level`, `arch`, `target`, or system-image version, otherwise stale snapshots.
- **Action defaults changed in v2.34.0.** Most relevant: arbitrary `api-level` strings now allowed, `system-image-api-level` knob added, automotive/desktop targets supported. Nothing that should affect a stock `default` x86_64 setup, but flagged for completeness.
- **First run is slow.** No cache hit means full AVD creation (~5–7 min). Acceptable one-time cost; subsequent PRs hit the warm cache.
- **`gradle/actions/setup-gradle` (used implicitly by the action) caching collisions.** Should be a non-issue since we don't use it explicitly here, but keep an eye out if future jobs add it.
- **macOS-only test assumptions.** None known in `iterableapi:connectedCheck`, but if any test shells out or reads `/System/Library/...`-style paths it would break. Unit tests on `ubuntu-latest` already pass green, so `iterableapi` itself is portable.

## Test plan

- [ ] CI runs this PR's `Instrumentation tests` job on Ubuntu and goes green.
- [ ] Re-run a couple of times to validate cache-hit and cache-miss paths.
- [ ] Verify total job runtime is well under the macOS baseline.
- [ ] Cross-check #1049 (and any other flaky PRs) once this is merged to confirm flakiness is gone on master.

Made with [Cursor](https://cursor.com)