### PR TITLE
SDK-499 Fix NPE race condition in EmbeddedSessionManager.updateDisplayCountAndDuration()

### DIFF
--- a/iterableapi/src/main/java/com/iterable/iterableapi/EmbeddedImpressionData.kt
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/EmbeddedImpressionData.kt
@@ -9,7 +9,7 @@ data class EmbeddedImpressionData(
     val placementId: Long,
     var displayCount: Int = 0,
     var duration: Float = 0.0f,
-    var start: Date? = null
+    @Volatile var start: Date? = null
 ) {
     constructor(
         messageId: String,

--- a/iterableapi/src/main/java/com/iterable/iterableapi/EmbeddedSessionManager.kt
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/EmbeddedSessionManager.kt
@@ -108,10 +108,11 @@ public class EmbeddedSessionManager {
     }
 
     private fun updateDisplayCountAndDuration(impressionData: EmbeddedImpressionData): EmbeddedImpressionData {
-        if (impressionData.start != null) {
+        val start = impressionData.start
+        if (start != null) {
             impressionData.displayCount = impressionData.displayCount.plus(1)
             impressionData.duration =
-                impressionData.duration.plus((Date().time - impressionData.start!!.time) / 1000.0)
+                impressionData.duration.plus((Date().time - start.time) / 1000.0)
                     .toFloat()
             impressionData.start = null
         }

--- a/iterableapi/src/main/java/com/iterable/iterableapi/EmbeddedSessionManager.kt
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/EmbeddedSessionManager.kt
@@ -108,13 +108,15 @@ public class EmbeddedSessionManager {
     }
 
     private fun updateDisplayCountAndDuration(impressionData: EmbeddedImpressionData): EmbeddedImpressionData {
-        val start = impressionData.start
-        if (start != null) {
-            impressionData.displayCount = impressionData.displayCount.plus(1)
-            impressionData.duration =
-                impressionData.duration.plus((Date().time - start.time) / 1000.0)
-                    .toFloat()
-            impressionData.start = null
+        synchronized(impressionData) {
+            val start = impressionData.start
+            if (start != null) {
+                impressionData.displayCount = impressionData.displayCount.plus(1)
+                impressionData.duration =
+                    impressionData.duration.plus((Date().time - start.time) / 1000.0)
+                        .toFloat()
+                impressionData.start = null
+            }
         }
         return impressionData
     }


### PR DESCRIPTION
## Jira Ticket

[SDK-499](https://iterable.atlassian.net/browse/SDK-499)

## Summary

Fixes a `NullPointerException` crash in `updateDisplayCountAndDuration()` caused by a TOCTOU (time-of-check/time-of-use) race condition.

Closes https://github.com/Iterable/iterable-android-sdk/issues/1052

---

## Problem

`EmbeddedImpressionData.start` is a plain `var Date?` with no synchronisation. The previous code checked `if (impressionData.start != null)` but then accessed `impressionData.start!!` in the body. When called concurrently from multiple threads (e.g. via `Dispatchers.Default` coroutines), another thread can set `start = null` between the null-check and the dereference, causing a crash:

```
Fatal Exception: java.lang.NullPointerException
  at com.iterable.iterableapi.EmbeddedSessionManager.updateDisplayCountAndDuration(EmbeddedSessionManager.kt:114)
  at com.iterable.iterableapi.EmbeddedSessionManager.endAllImpressions(EmbeddedSessionManager.kt:91)
  at com.iterable.iterableapi.EmbeddedSessionManager.endSession(EmbeddedSessionManager.kt:41)
  at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:704)
```

## Fix

Capture `impressionData.start` into a local `val` before the null-check. Because local variables are thread-confined (stack-allocated), the value cannot be changed by another thread after the null-check passes:

```kotlin
// Before
if (impressionData.start != null) {
    impressionData.duration = ... - impressionData.start!!.time  // ← NPE under concurrent access
}

// After
val start = impressionData.start
if (start != null) {
    impressionData.duration = ... - start.time  // ← safe, local val is immutable
}
```

This is the idiomatic Kotlin/Java pattern for safe null-check-then-use on shared mutable fields.

[SDK-499]: https://iterable.atlassian.net/browse/SDK-499?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ