### PR TITLE
SDK-500 In-app HTML messages ignore system light/dark theme on Android

### DIFF
--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableInAppFragmentHTMLNotification.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableInAppFragmentHTMLNotification.java
@@ -120,7 +120,7 @@ public class IterableInAppFragmentHTMLNotification extends DialogFragment implem
         this.backgroundAlpha = 0;
         this.messageId = "";
         insetPadding = new Rect();
-        this.setStyle(DialogFragment.STYLE_NO_FRAME, androidx.appcompat.R.style.Theme_AppCompat_NoActionBar);
+        this.setStyle(DialogFragment.STYLE_NO_FRAME, androidx.appcompat.R.style.Theme_AppCompat_DayNight_NoActionBar);
     }
 
     @Override
@@ -194,7 +194,7 @@ public class IterableInAppFragmentHTMLNotification extends DialogFragment implem
             applyWindowGravity(getDialog().getWindow(), "onCreateView");
         }
 
-        webView = createWebViewSafely(getContext());
+        webView = createWebViewSafely(getDialog().getContext());
         if (webView == null) {
             dismissAllowingStateLoss();
             return null;


### PR DESCRIPTION
In-app HTML messages always rendered the prefers-color-scheme: dark variant regardless of the system theme on API 33+. Two fixes:

- Switch DialogFragment style from Theme.AppCompat.NoActionBar (a dark theme: extends Theme.AppCompat, not Theme.AppCompat.Light) to Theme.AppCompat.DayNight.NoActionBar, so isLightTheme tracks the system mode.

- Build the WebView with the dialog's themed context instead of Fragment.getContext(), which returns the host activity context. On API 33+ WebView derives prefers-color-scheme from the hosting theme's isLightTheme attribute, so the DayNight fix only takes effect when the WebView is constructed under the dialog context.

## 🔹 Jira Ticket(s) if any

[SDK-500](https://iterable.atlassian.net/browse/SDK-500)

## ✏️ Description

See https://github.com/Iterable/iterable-android-sdk/issues/1056


[SDK-500]: https://iterable.atlassian.net/browse/SDK-500?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ