### PR TITLE
SDK-497 [ Android SDK ] Add callback for unknown user criteria fetching

### DIFF
--- a/iterableapi/src/main/java/com/iterable/iterableapi/IterableConfig.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/IterableConfig.java
@@ -147,6 +147,12 @@ public class IterableConfig {
     final IterableInAppDisplayMode inAppDisplayMode;
 
     /**
+     * Callback to allow the implementor to perform logic following a call to fetch
+     * unknown user creation criteria
+     */
+    final UnknownCriteriaReceivedCallback unknownCriteriaReceivedCallback;
+
+    /**
      * Base URL for Webview content loading. Specifically used to enable CORS for external resources.
      * If null or empty, defaults to empty string (original behavior with about:blank origin).
      * Set this to according to your CORS settings for example (e.g., "https://app.iterable.com") to allow external resource loading.
@@ -190,6 +196,7 @@ public class IterableConfig {
         mobileFrameworkInfo = builder.mobileFrameworkInfo;
         webViewBaseUrl = builder.webViewBaseUrl;
         inAppDisplayMode = builder.inAppDisplayMode;
+        unknownCriteriaReceivedCallback = builder.unknownCriteriaReceivedCallback;
     }
 
     public static class Builder {
@@ -219,6 +226,7 @@ public class IterableConfig {
         private IterableUnknownUserHandler iterableUnknownUserHandler;
         private String webViewBaseUrl;
         private IterableInAppDisplayMode inAppDisplayMode = IterableInAppDisplayMode.FORCE_EDGE_TO_EDGE;
+        private UnknownCriteriaReceivedCallback unknownCriteriaReceivedCallback;
 
         public Builder() {}
 
@@ -458,6 +466,15 @@ public class IterableConfig {
         @NonNull
         public Builder setMobileFrameworkInfo(@NonNull IterableAPIMobileFrameworkInfo mobileFrameworkInfo) {
             this.mobileFrameworkInfo = mobileFrameworkInfo;
+            return this;
+        }
+
+        /**
+         * Set a callback to signal completion of api calls to fetch criteria for unknown user creation.
+         * @param unknownCriteriaReceivedCallback Listener for unknown criteria api calls provided by the app
+         */
+        public Builder setUnknownCriteriaResultCallback(UnknownCriteriaReceivedCallback unknownCriteriaReceivedCallback) {
+            this.unknownCriteriaReceivedCallback = unknownCriteriaReceivedCallback;
             return this;
         }
 

--- a/iterableapi/src/main/java/com/iterable/iterableapi/UnknownCriteriaReceivedCallback.kt
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/UnknownCriteriaReceivedCallback.kt
@@ -1,0 +1,5 @@
+package com.iterable.iterableapi
+
+interface UnknownCriteriaReceivedCallback {
+    fun criteriaReceived()
+}

--- a/iterableapi/src/main/java/com/iterable/iterableapi/UnknownUserManager.java
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/UnknownUserManager.java
@@ -181,7 +181,9 @@ public class UnknownUserManager implements IterableActivityMonitor.AppStateCallb
                     SharedPreferences.Editor editor = sharedPref.edit();
                     editor.putString(IterableConstants.SHARED_PREFS_CRITERIA, mockDataObject.toString());
                     editor.apply();
-
+                    if (IterableApi.getInstance().config.unknownCriteriaReceivedCallback != null) {
+                        IterableApi.getInstance().config.unknownCriteriaReceivedCallback.criteriaReceived();
+                    }
                 } catch (JSONException e) {
                     e.printStackTrace();
                 }


### PR DESCRIPTION
Scenarios exist where userdata needs to be updated shortly after initialization. This update call fails since the unknown user criteria is fetched asynchronously and the criteria are needed to create the unknown user.

This callback will allow implementing apps to update the user after the criteria are fetched.

## 🔹 Jira Ticket(s) if any

* [SDK-XXXX](https://iterable.atlassian.net/browse/SDK-XXXX)

## ✏️ Description

> Please provide a brief description of what this pull request does.
