### PR TITLE
[SDK-115] Drop racy parallel pre-build step from inapp-e2e-tests workflow

### DIFF
--- a/.github/workflows/inapp-e2e-tests.yml
+++ b/.github/workflows/inapp-e2e-tests.yml
@@ -70,16 +70,21 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
-            
-      - name: Pre-download Gradle and Build (Parallel with Emulator)
-        run: |
-          echo "Pre-downloading Gradle and building while emulator boots..."
-          # Download Gradle wrapper in background
-          ./gradlew --version &
-          # Start building APKs in background  
-          ./gradlew :integration-tests:assembleDebug :integration-tests:assembleDebugAndroidTest --no-daemon &
-          echo "Build started in background..."
-            
+
+      # SDK-170 follow-up: the previous "Pre-download Gradle and Build (Parallel with
+      # Emulator)" step backgrounded `./gradlew :integration-tests:assembleDebug
+      # :integration-tests:assembleDebugAndroidTest --no-daemon &`. On macos-15-intel
+      # the background process was resource-starved during emulator boot and usually
+      # finished or stalled before the action's Gradle started, so the race window
+      # was tiny. After we migrated to ubuntu-latest + KVM (commit 7d4a80ba), both
+      # Gradle processes get real CPU and run in true parallel, racing on
+      # `integration-tests/build/intermediates/merged_res_blame_folder/` and failing
+      # `:integration-tests:mergeDebugAndroidTestResources` with
+      # "Failed to create MD5 hash for file ... values-az.json as it does not exist".
+      #
+      # The action's `script:` invokes `./gradlew :integration-tests:connectedDebugAndroidTest`
+      # which transitively assembles the APKs, so removing the pre-build loses nothing
+      # except the (broken) parallelism. Wall-clock impact: ~30-90s on cold Gradle cache.
       - name: Run UI Tests with Emulator (KVM / x86_64)
         uses: ReactiveCircus/android-emulator-runner@v2
         with:


### PR DESCRIPTION
## Summary

First commit of SDK-115 (stabilising the BCIT integration-test suite in CI). This single change unblocks the in-app E2E check that has been red on every PR since 2026-05-18.

Supersedes #1055 (open since 2026-05-21, mergeable + all checks green, but unattended). If #1055 lands first, this PR becomes an empty no-op and I'll close it.

## Root cause (verbatim from the workflow comment added in this commit)

The previous `Pre-download Gradle and Build (Parallel with Emulator)` step backgrounded:

```
./gradlew :integration-tests:assembleDebug :integration-tests:assembleDebugAndroidTest --no-daemon &
```

On the old `macos-15-intel` runner this background process was CPU-starved by emulator boot, so the race window was tiny and nobody noticed. After commit `7d4a80ba` migrated the job to `ubuntu-latest` + KVM, both Gradle processes get real CPU and run in true parallel, racing on `integration-tests/build/intermediates/merged_res_blame_folder/` and failing `:integration-tests:mergeDebugAndroidTestResources` with:

```
Failed to create MD5 hash for file ... values-az.json as it does not exist
```

The action's `script:` already invokes `./gradlew :integration-tests:connectedDebugAndroidTest`, which transitively assembles the APKs, so the pre-build step is pure (broken) optimisation. Wall-clock cost of removing it: ~30-90s on cold Gradle cache.

## SDK-115 roadmap (this PR is step 1 of N)

Follow-up PRs on top of this one will:

- Consolidate `integration-tests.yml` (broken duplicate, uses non-BCIT secrets, `macos-latest`, dead `develop` trigger) into the surviving `inapp-e2e-tests.yml`.
- Expand the test selection from the single `InAppMessageIntegrationTest#testInAppMessageMVP` to a matrix covering Push, Embedded, and Deep Link integration tests (the suite that the BCIT Iterable project was set up for).
- Make push-sync timeouts env-configurable, replace the hard-coded notification-search strings with a `TestConstants` constant.
- Tail `logcat.txt` into `$GITHUB_STEP_SUMMARY` on failure so PR reviewers don't need to download artifacts.
- Optional hygiene: stop committing `integration-tests/google-services.json` (inject via secret).

## Test plan

- [ ] CI runs the `In-App Message E2E Tests (34)` check on this PR and it goes green (prior evidence: same commit was green on #1055 in 7m44s).
- [ ] Verify no other workflow regresses.


Made with [Cursor](https://cursor.com)