### PR TITLE
[SDK-115] Re-enable BCIT embedded message test

### DIFF
--- a/integration-tests/src/androidTest/java/com/iterable/integration/tests/EmbeddedMessageIntegrationTest.kt
+++ b/integration-tests/src/androidTest/java/com/iterable/integration/tests/EmbeddedMessageIntegrationTest.kt
@@ -21,7 +21,6 @@ import org.json.JSONObject
 import org.junit.After
 import org.junit.Assert
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import java.util.concurrent.TimeUnit
@@ -110,12 +109,6 @@ class EmbeddedMessageIntegrationTest : BaseIntegrationTest() {
     }
     
     @Test
-    @Ignore(
-        "BCIT backend returns `placements: []` for our dated test user even with the " +
-        "iOS-shape isPremium false→true transition that works for iOS. Likely a BCIT " +
-        "Iterable-project configuration gap (no Android-targeting embedded campaign). " +
-        "Re-enable once the backend side is set up."
-    )
     fun testEmbeddedMessageMVP() {
         // Step 1: Ensure user is signed in
         Log.d(TAG, "📧 Step 1: Ensuring user is signed in...")
@@ -141,17 +134,17 @@ class EmbeddedMessageIntegrationTest : BaseIntegrationTest() {
         }
         Assert.assertTrue("FragmentContainerView should exist in EmbeddedMessageTestActivity", viewReady)
 
-        // Drive a clean isPremium false→true transition. Mirrors the iOS BCIT embedded
-        // test — the BCIT campaign sends on the eligibility transition, not on a flat
-        // eligibility check.
-        setIsPremium(false)
+        // Drive a clean standard→premium membership transition. Mirrors the iOS BCIT
+        // embedded test — the BCIT campaign's audience predicate is on
+        // `membershipLevel == "premium"`.
+        setMembershipLevel("standard")
         syncMessagesAndWait()
         Assert.assertFalse(
-            "User should not be eligible for placement $TEST_PLACEMENT_ID with isPremium=false",
+            "User should not be eligible for placement $TEST_PLACEMENT_ID with membershipLevel=standard",
             IterableApi.getInstance().embeddedManager.getPlacementIds().contains(TEST_PLACEMENT_ID)
         )
 
-        setIsPremium(true)
+        setMembershipLevel("premium")
         val placementIds = syncAndWaitForPlacement(TEST_PLACEMENT_ID, timeoutSeconds = 30)
         Assert.assertTrue(
             "Placement ID $TEST_PLACEMENT_ID should exist, but found: $placementIds",
@@ -260,8 +253,8 @@ class EmbeddedMessageIntegrationTest : BaseIntegrationTest() {
         Log.d(TAG, "✅✅✅ Test completed successfully! All steps passed.")
     }
 
-    private fun setIsPremium(value: Boolean) {
-        IterableApi.getInstance().updateUser(JSONObject().put("isPremium", value))
+    private fun setMembershipLevel(level: String) {
+        IterableApi.getInstance().updateUser(JSONObject().put("membershipLevel", level))
         Thread.sleep(3000)
     }
 

--- a/integration-tests/src/main/java/com/iterable/integration/tests/activities/EmbeddedMessageTestActivity.kt
+++ b/integration-tests/src/main/java/com/iterable/integration/tests/activities/EmbeddedMessageTestActivity.kt
@@ -38,46 +38,45 @@ class EmbeddedMessageTestActivity : AppCompatActivity() {
     
     private fun setupClickListeners() {
         checkIsPremiumButton.setOnClickListener {
-            checkIsPremiumStatus()
+            checkMembershipStatus()
         }
-        
+
         isPremiumSwitch.setOnCheckedChangeListener { _, isChecked ->
-            updateUserIsPremium(isChecked)
+            updateUserMembershipLevel(if (isChecked) "premium" else "standard")
         }
-        
+
         syncMessagesButton.setOnClickListener {
             syncEmbeddedMessages()
         }
     }
-    
-    private fun checkIsPremiumStatus() {
+
+    private fun checkMembershipStatus() {
         AlertDialog.Builder(this)
-            .setTitle("isPremium Status")
+            .setTitle("Membership Level")
             .setMessage("User data fields are stored on the server, not in the SDK.\n\n" +
-                    "To check isPremium status:\n" +
+                    "To check membershipLevel:\n" +
                     "1. Check server logs/dashboard\n" +
                     "2. Call server API to get user profile\n" +
                     "3. Check logcat for updateUser calls")
             .setPositiveButton("OK", null)
             .show()
     }
-    
-    private fun updateUserIsPremium(isPremium: Boolean) {
-        val statusText = if (isPremium) "true" else "false"
-        updateStatus("Updating user (isPremium = $statusText)...")
-        
+
+    private fun updateUserMembershipLevel(level: String) {
+        updateStatus("Updating user (membershipLevel = $level)...")
+
         val dataFields = JSONObject().apply {
-            put("isPremium", isPremium)
+            put("membershipLevel", level)
         }
-        
+
         isPremiumSwitch.isEnabled = false
         IterableApi.getInstance().updateUser(dataFields)
-        
-        Toast.makeText(this, "updateUser called (isPremium = $statusText)\nWait 5 seconds then sync messages", Toast.LENGTH_LONG).show()
-        
+
+        Toast.makeText(this, "updateUser called (membershipLevel = $level)\nWait a few seconds then sync messages", Toast.LENGTH_LONG).show()
+
         isPremiumSwitch.postDelayed({
             isPremiumSwitch.isEnabled = true
-            updateStatus("User updated (isPremium = $statusText) - Sync messages to verify")
+            updateStatus("User updated (membershipLevel = $level) — Sync messages to verify")
         }, 1000)
     }
     

--- a/integration-tests/src/main/res/layout/activity_embedded_message_test.xml
+++ b/integration-tests/src/main/res/layout/activity_embedded_message_test.xml
@@ -24,7 +24,7 @@
             android:id="@+id/btnCheckIsPremium"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="Check isPremium Status"
+            android:text="Check Membership Level"
             android:layout_marginBottom="8dp" />
 
         <LinearLayout
@@ -38,7 +38,7 @@
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_weight="1"
-                android:text="isPremium Status:"
+                android:text="Premium Member:"
                 android:textSize="16sp" />
             
             <android.widget.Switch


### PR DESCRIPTION
## Summary

Removes the `@Ignore` on `EmbeddedMessageIntegrationTest#testEmbeddedMessageMVP` after fixing two real bugs against the BCIT backend. Builds on the dated-user infrastructure already merged into the base branch (`SDK-115-bcit-ci`).

### Two bugs, both surfaced by comparing against iOS

1. **Wrong eligibility field.** The BCIT campaign's audience predicate is on `membershipLevel == "premium"`, not `isPremium == true`. Android was sending `isPremium`, so the audience never matched and `/api/embedded-messaging/messages` returned `placements: []`. iOS sends `membershipLevel: "premium" / "standard"` (`EmbeddedMessageTestViewModel.swift:90`); we now do the same in both the test and the on-screen toggle.
2. (Already on base via [#1061](https://github.com/Iterable/iterable-android-sdk/pull/1061): `IterableConfig.allowedProtocols = ["tester", "https", "http"]` so the SDK doesn't drop the `tester://testview` URL fired by the embedded deeplink button.)

### Scope of this PR

Three files, +28 / -36:

- `EmbeddedMessageIntegrationTest.kt` — `@Ignore` removed; the eligibility-transition step now sends `membershipLevel` (`standard` → `premium`) instead of `isPremium` (`false` → `true`).
- `EmbeddedMessageTestActivity.kt` — on-screen toggle and dialog rebranded "Membership Level" so the manual flow matches the test.
- `activity_embedded_message_test.xml` — button + label text updated.

The `isPremiumSwitch` field name is unchanged on purpose, to keep the diff minimal.

## Local verification

CI mode, dated user, full non-push suite:

```
./gradlew :integration-tests:connectedDebugAndroidTest \
  -Pandroid.testInstrumentationRunnerArguments.package=com.iterable.integration.tests \
  -Pandroid.testInstrumentationRunnerArguments.notClass=com.iterable.integration.tests.PushNotificationIntegrationTest \
  -Pandroid.testInstrumentationRunnerArguments.ci=true
```

`Tests 7/7 completed. (0 skipped) (0 failed) — BUILD SUCCESSFUL`.

## Test plan

- [x] CI's `Integration Tests (BCIT)` job is green.
- [ ] Manual sanity (optional): launch the app, paste today's dated email into the override card on MainActivity, open Embedded Message Test, toggle Premium Member on, tap Sync — placement 2157 appears and renders.
