### PR TITLE
chore: add CHANGELOG.md check workflow on PRs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,6 +9,9 @@
 ## 🧪 How to test?
 > How to test the changes added?
 
+## 🧾 Changelog
+> Add an entry to `CHANGELOG.md`. If this PR has no customer facing changes, write "No customer facing changes" here to skip the changelog check.
+
 ## 📹 Loom recording if applicable
 > If it helps the reviewer, add a short Loom going over the changes or showcasing the change in behavior.
 

--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -1,0 +1,42 @@
+name: Changelog Check
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  changelog:
+    name: Verify CHANGELOG update
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check CHANGELOG.md update or opt-out
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const optOut = 'No customer facing changes';
+            const body = context.payload.pull_request.body || '';
+
+            if (body.toLowerCase().includes(optOut.toLowerCase())) {
+              core.info(`PR description contains "${optOut}", skipping CHANGELOG.md check.`);
+              return;
+            }
+
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+              per_page: 100,
+            });
+
+            const changed = files.some((f) => f.filename === 'CHANGELOG.md');
+            if (changed) {
+              core.info('CHANGELOG.md was updated.');
+              return;
+            }
+
+            core.setFailed(
+              'CHANGELOG.md was not updated. Add a CHANGELOG.md entry, or if this PR has no customer facing changes, add "No customer facing changes" to the PR description to justify skipping the changelog.'
+            );


### PR DESCRIPTION
# 📝 Summary
> _This should be a 150 characters summary of the changes on this PR_

Add a CI check that fails PRs when `CHANGELOG.md` is not updated, unless the description declares "No customer facing changes".

###### 🎟️ Jira Ticket: N/A — internal CI tooling

## 📖 Description
> Please provide a description of what this pull request does.

Adds `.github/workflows/changelog-check`, a workflow that runs on every PR (`opened`, `edited`, `synchronize`, `reopened`). The check passes when either `CHANGELOG.md` is among the PR's changed files, or the PR description contains the phrase "No customer facing changes". Otherwise it fails with a message explaining how to resolve it.

Also adds a `🧾 Changelog` section to the PR template documenting the opt-out phrase. Read-only token, no checkout, fork-safe, and not restricted by base branch so it covers every PR.

## 🧪 How to test?
> How to test the changes added?

- Open a PR that does not touch `CHANGELOG.md` and omits the opt-out phrase → the check fails.
- Edit the description to add "No customer facing changes" (or update `CHANGELOG.md`) → the check passes on the next run without a new commit.

## 🧾 Changelog
> Add an entry to `CHANGELOG.md`. If this PR has no customer facing changes, write "No customer facing changes" here to skip the changelog check.

No customer facing changes

## 📹 Loom recording if applicable
N/A

#### 🐞 Github Issues solved
N/A

#### 📚 Docs PR if applicable
N/A
