### PR TITLE
[SDK-499] Synchronize EmbeddedSessionManager to fix embedded session races

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Fixed
+- Fixed a `NullPointerException` in `EmbeddedSessionManager.updateDisplayCountAndDuration()` that could crash apps calling embedded session methods off the main thread. `EmbeddedSessionManager` is now internally synchronized, which also fixes concurrent modification of its impression map and duplicate session tracking when `endSession()` raced with itself. Thanks to [@Shamyyoun](https://github.com/Shamyyoun) for the report and initial fix.
 - Fixed a race in JWT auth refresh scheduling that could leave overlapping timers active and repeatedly call `IterableAuthHandler.onAuthTokenRequested()`. Refresh scheduling now has a single task owner, rejects stale or duplicate tasks, and logs each schedule, skip, fire, cancellation, and error with its refresh reason.
 
 ## [3.10.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,11 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Fixed a `NullPointerException` in `EmbeddedSessionManager.updateDisplayCountAndDuration()` that could crash apps calling embedded session methods off the main thread. `EmbeddedSessionManager` is now internally synchronized, which also fixes concurrent modification of its impression map and duplicate session tracking when `endSession()` raced with itself. Thanks to [@Shamyyoun](https://github.com/Shamyyoun) for the report and initial fix.
 
 ## [3.10.1]
 ### Fixed
-- Fixed a `NullPointerException` in `EmbeddedSessionManager.updateDisplayCountAndDuration()` that could crash apps calling embedded session methods off the main thread. `EmbeddedSessionManager` is now internally synchronized, which also fixes concurrent modification of its impression map and duplicate session tracking when `endSession()` raced with itself. Thanks to [@Shamyyoun](https://github.com/Shamyyoun) for the report and initial fix.
 - Fixed a race in JWT auth refresh scheduling that could leave overlapping timers active and repeatedly call `IterableAuthHandler.onAuthTokenRequested()`. Refresh scheduling now has a single task owner, rejects stale or duplicate tasks, and logs each schedule, skip, fire, cancellation, and error with its refresh reason.
 
 ## [3.10.0]

--- a/iterableapi/src/main/java/com/iterable/iterableapi/EmbeddedImpressionData.kt
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/EmbeddedImpressionData.kt
@@ -9,7 +9,7 @@ data class EmbeddedImpressionData(
     val placementId: Long,
     var displayCount: Int = 0,
     var duration: Float = 0.0f,
-    var start: Date? = null
+    @Volatile var start: Date? = null
 ) {
     constructor(
         messageId: String,

--- a/iterableapi/src/main/java/com/iterable/iterableapi/EmbeddedImpressionData.kt
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/EmbeddedImpressionData.kt
@@ -9,7 +9,7 @@ data class EmbeddedImpressionData(
     val placementId: Long,
     var displayCount: Int = 0,
     var duration: Float = 0.0f,
-    @Volatile var start: Date? = null
+    var start: Date? = null
 ) {
     constructor(
         messageId: String,

--- a/iterableapi/src/main/java/com/iterable/iterableapi/EmbeddedSessionManager.kt
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/EmbeddedSessionManager.kt
@@ -108,10 +108,11 @@ public class EmbeddedSessionManager {
     }
 
     private fun updateDisplayCountAndDuration(impressionData: EmbeddedImpressionData): EmbeddedImpressionData {
-        if (impressionData.start != null) {
+        val start = impressionData.start
+        if (start != null) {
             impressionData.displayCount = impressionData.displayCount.plus(1)
             impressionData.duration =
-                impressionData.duration.plus((Date().time - impressionData.start!!.time) / 1000.0)
+                impressionData.duration.plus((Date().time - start.time) / 1000.0)
                     .toFloat()
             impressionData.start = null
         }

--- a/iterableapi/src/main/java/com/iterable/iterableapi/EmbeddedSessionManager.kt
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/EmbeddedSessionManager.kt
@@ -108,13 +108,15 @@ public class EmbeddedSessionManager {
     }
 
     private fun updateDisplayCountAndDuration(impressionData: EmbeddedImpressionData): EmbeddedImpressionData {
-        val start = impressionData.start
-        if (start != null) {
-            impressionData.displayCount = impressionData.displayCount.plus(1)
-            impressionData.duration =
-                impressionData.duration.plus((Date().time - start.time) / 1000.0)
-                    .toFloat()
-            impressionData.start = null
+        synchronized(impressionData) {
+            val start = impressionData.start
+            if (start != null) {
+                impressionData.displayCount = impressionData.displayCount.plus(1)
+                impressionData.duration =
+                    impressionData.duration.plus((Date().time - start.time) / 1000.0)
+                        .toFloat()
+                impressionData.start = null
+            }
         }
         return impressionData
     }

--- a/iterableapi/src/main/java/com/iterable/iterableapi/EmbeddedSessionManager.kt
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/EmbeddedSessionManager.kt
@@ -6,6 +6,10 @@ public class EmbeddedSessionManager {
 
     private val TAG = "EmbeddedSessionManager"
 
+    // Callers reach this class from arbitrary threads (see issue #1052), so every access to
+    // impressions, session, and the impression fields happens under this lock.
+    private val lock = Any()
+
     private var impressions: MutableMap<String, EmbeddedImpressionData> = mutableMapOf()
 
     var session: IterableEmbeddedSession = IterableEmbeddedSession(
@@ -13,40 +17,46 @@ public class EmbeddedSessionManager {
         null,
         null
     )
+        get() = synchronized(lock) { field }
+        set(value) = synchronized(lock) { field = value }
 
     fun isTracking(): Boolean {
-        return session.start != null
+        return synchronized(lock) { session.start != null }
     }
 
     fun startSession() {
-        if (isTracking()) {
-            IterableLogger.e(TAG, "Embedded session started twice")
-            return
-        }
+        synchronized(lock) {
+            if (isTracking()) {
+                IterableLogger.e(TAG, "Embedded session started twice")
+                return
+            }
 
-        session = IterableEmbeddedSession(
-            Date(),
-            null,
-            null
-        )
+            session = IterableEmbeddedSession(
+                Date(),
+                null,
+                null
+            )
+        }
     }
 
     fun endSession() {
-        if (!isTracking()) {
-            IterableLogger.e(TAG, "Embedded session ended without start")
-            return
-        }
+        val sessionToTrack = synchronized(lock) {
+            if (!isTracking()) {
+                IterableLogger.e(TAG, "Embedded session ended without start")
+                return
+            }
 
-        if(impressions.isNotEmpty()) {
+            if (impressions.isEmpty()) {
+                return
+            }
+
             endAllImpressions()
 
-            val sessionToTrack = IterableEmbeddedSession(
+            val tracked = IterableEmbeddedSession(
                 session.start,
                 Date(),
                 getImpressionList()
             )
-
-            IterableApi.getInstance().trackEmbeddedSession(sessionToTrack)
 
             //reset session for next session start
             session = IterableEmbeddedSession(
@@ -56,34 +66,43 @@ public class EmbeddedSessionManager {
             )
 
             impressions = mutableMapOf()
+
+            tracked
         }
+
+        // Tracking calls into IterableApi, so it runs after the lock is released.
+        IterableApi.getInstance().trackEmbeddedSession(sessionToTrack)
     }
 
     fun startImpression(messageId: String, placementId: Long) {
-        var impressionData: EmbeddedImpressionData? = impressions[messageId]
+        synchronized(lock) {
+            var impressionData: EmbeddedImpressionData? = impressions[messageId]
 
-        if (impressionData == null) {
-            impressionData = EmbeddedImpressionData(messageId, placementId)
-            impressions[messageId] = impressionData
+            if (impressionData == null) {
+                impressionData = EmbeddedImpressionData(messageId, placementId)
+                impressions[messageId] = impressionData
+            }
+
+            impressionData.start = Date()
         }
-
-        impressionData.start = Date()
     }
 
     fun pauseImpression(messageId: String) {
-        val impressionData: EmbeddedImpressionData? = impressions[messageId]
+        synchronized(lock) {
+            val impressionData: EmbeddedImpressionData? = impressions[messageId]
 
-        if (impressionData == null) {
-            IterableLogger.e(TAG, "onMessageImpressionEnded: impressionData not found")
-            return
+            if (impressionData == null) {
+                IterableLogger.e(TAG, "onMessageImpressionEnded: impressionData not found")
+                return
+            }
+
+            if (impressionData.start == null) {
+                IterableLogger.e(TAG, "onMessageImpressionEnded: impressionStarted is null")
+                return
+            }
+
+            updateDisplayCountAndDuration(impressionData)
         }
-
-        if (impressionData.start == null) {
-            IterableLogger.e(TAG, "onMessageImpressionEnded: impressionStarted is null")
-            return
-        }
-
-        updateDisplayCountAndDuration(impressionData)
     }
 
     private fun endAllImpressions() {
@@ -108,15 +127,13 @@ public class EmbeddedSessionManager {
     }
 
     private fun updateDisplayCountAndDuration(impressionData: EmbeddedImpressionData): EmbeddedImpressionData {
-        synchronized(impressionData) {
-            val start = impressionData.start
-            if (start != null) {
-                impressionData.displayCount = impressionData.displayCount.plus(1)
-                impressionData.duration =
-                    impressionData.duration.plus((Date().time - start.time) / 1000.0)
-                        .toFloat()
-                impressionData.start = null
-            }
+        val start = impressionData.start
+        if (start != null) {
+            impressionData.displayCount = impressionData.displayCount.plus(1)
+            impressionData.duration =
+                impressionData.duration.plus((Date().time - start.time) / 1000.0)
+                    .toFloat()
+            impressionData.start = null
         }
         return impressionData
     }

--- a/iterableapi/src/main/java/com/iterable/iterableapi/EmbeddedSessionManager.kt
+++ b/iterableapi/src/main/java/com/iterable/iterableapi/EmbeddedSessionManager.kt
@@ -50,12 +50,12 @@ public class EmbeddedSessionManager {
                 return
             }
 
-            endAllImpressions()
+            endAllImpressionsLocked()
 
             val tracked = IterableEmbeddedSession(
                 session.start,
                 Date(),
-                getImpressionList()
+                getImpressionListLocked()
             )
 
             //reset session for next session start
@@ -101,17 +101,19 @@ public class EmbeddedSessionManager {
                 return
             }
 
-            updateDisplayCountAndDuration(impressionData)
+            updateDisplayCountAndDurationLocked(impressionData)
         }
     }
 
-    private fun endAllImpressions() {
+    // The Locked suffix marks helpers that read or write impressions without taking the lock
+    // themselves: every caller must already hold it.
+    private fun endAllImpressionsLocked() {
         for (impressionData in impressions.values) {
-            updateDisplayCountAndDuration(impressionData)
+            updateDisplayCountAndDurationLocked(impressionData)
         }
     }
 
-    private fun getImpressionList(): List<IterableEmbeddedImpression>? {
+    private fun getImpressionListLocked(): List<IterableEmbeddedImpression>? {
         val impressionList: MutableList<IterableEmbeddedImpression> = ArrayList()
         for (impressionData in impressions.values) {
             impressionList.add(
@@ -126,7 +128,7 @@ public class EmbeddedSessionManager {
         return impressionList
     }
 
-    private fun updateDisplayCountAndDuration(impressionData: EmbeddedImpressionData): EmbeddedImpressionData {
+    private fun updateDisplayCountAndDurationLocked(impressionData: EmbeddedImpressionData): EmbeddedImpressionData {
         val start = impressionData.start
         if (start != null) {
             impressionData.displayCount = impressionData.displayCount.plus(1)

--- a/iterableapi/src/test/java/com/iterable/iterableapi/EmbeddedSessionManagerThreadSafetyTest.java
+++ b/iterableapi/src/test/java/com/iterable/iterableapi/EmbeddedSessionManagerThreadSafetyTest.java
@@ -28,6 +28,8 @@ public class EmbeddedSessionManagerThreadSafetyTest extends BaseTest {
         sessionManager = new EmbeddedSessionManager();
     }
 
+    // Pins existing behavior, not intended behavior: with no impressions, endSession() returns
+    // early and leaves the session open. Flip this assertion when SDK-701 is fixed.
     @Test
     public void endSessionWithoutImpressionsLeavesSessionRunning() {
         sessionManager.startSession();

--- a/iterableapi/src/test/java/com/iterable/iterableapi/EmbeddedSessionManagerThreadSafetyTest.java
+++ b/iterableapi/src/test/java/com/iterable/iterableapi/EmbeddedSessionManagerThreadSafetyTest.java
@@ -1,0 +1,92 @@
+package com.iterable.iterableapi;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+public class EmbeddedSessionManagerThreadSafetyTest extends BaseTest {
+
+    private EmbeddedSessionManager sessionManager;
+
+    @Before
+    public void setUp() {
+        IterableApi.sharedInstance = new IterableApi();
+        sessionManager = new EmbeddedSessionManager();
+    }
+
+    @Test
+    public void endSessionWithoutImpressionsLeavesSessionRunning() {
+        sessionManager.startSession();
+        sessionManager.endSession();
+
+        assertTrue(sessionManager.isTracking());
+    }
+
+    @Test
+    public void endSessionWithImpressionsResetsSession() {
+        sessionManager.startSession();
+        sessionManager.startImpression("message-1", 1L);
+        sessionManager.pauseImpression("message-1");
+        sessionManager.endSession();
+
+        assertFalse(sessionManager.isTracking());
+    }
+
+    @Test
+    public void concurrentSessionAndImpressionUpdatesDoNotThrow() throws Exception {
+        final int threadCount = 8;
+        final int iterations = 2000;
+        final CountDownLatch startGate = new CountDownLatch(1);
+        final CountDownLatch finishGate = new CountDownLatch(threadCount);
+        final List<Throwable> failures = Collections.synchronizedList(new ArrayList<Throwable>());
+
+        sessionManager.startSession();
+
+        for (int threadIndex = 0; threadIndex < threadCount; threadIndex++) {
+            final int role = threadIndex % 4;
+            new Thread(new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        startGate.await();
+                        for (int i = 0; i < iterations; i++) {
+                            String messageId = "message-" + (i % 4);
+                            switch (role) {
+                                case 0:
+                                    sessionManager.startImpression(messageId, i % 3);
+                                    break;
+                                case 1:
+                                    sessionManager.pauseImpression(messageId);
+                                    break;
+                                case 2:
+                                    sessionManager.endSession();
+                                    break;
+                                default:
+                                    sessionManager.startSession();
+                                    break;
+                            }
+                        }
+                    } catch (Throwable throwable) {
+                        failures.add(throwable);
+                    } finally {
+                        finishGate.countDown();
+                    }
+                }
+            }, "embedded-session-" + threadIndex).start();
+        }
+
+        startGate.countDown();
+
+        assertTrue("threads did not finish in time", finishGate.await(30, TimeUnit.SECONDS));
+        assertEquals("concurrent access failed: " + failures, 0, failures.size());
+    }
+}

--- a/iterableapi/src/test/java/com/iterable/iterableapi/EmbeddedSessionManagerThreadSafetyTest.java
+++ b/iterableapi/src/test/java/com/iterable/iterableapi/EmbeddedSessionManagerThreadSafetyTest.java
@@ -2,6 +2,7 @@ package com.iterable.iterableapi;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Before;
@@ -11,7 +12,11 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class EmbeddedSessionManagerThreadSafetyTest extends BaseTest {
 
@@ -39,6 +44,46 @@ public class EmbeddedSessionManagerThreadSafetyTest extends BaseTest {
         sessionManager.endSession();
 
         assertFalse(sessionManager.isTracking());
+    }
+
+    @Test
+    public void concurrentEndSessionTracksSessionOnlyOnce() throws Exception {
+        BlockingRecordingIterableApi recordingApi = new BlockingRecordingIterableApi();
+        IterableApi.sharedInstance = recordingApi;
+
+        sessionManager.startSession();
+        sessionManager.startImpression("message-1", 1L);
+        sessionManager.pauseImpression("message-1");
+
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try {
+            // Keep the first tracking call open while a second thread ends the same session.
+            Future<?> firstEnd = executor.submit(sessionManager::endSession);
+            assertTrue(
+                    "first endSession did not reach tracking",
+                    recordingApi.awaitFirstTrack(5, TimeUnit.SECONDS)
+            );
+
+            // The session must already be cleared, even though its first tracking call is blocked.
+            // Ending it again must therefore return without tracking the same session twice.
+            Future<?> secondEnd = executor.submit(sessionManager::endSession);
+            secondEnd.get(5, TimeUnit.SECONDS);
+
+            recordingApi.allowFirstTrackToFinish();
+            firstEnd.get(5, TimeUnit.SECONDS);
+        } finally {
+            recordingApi.allowFirstTrackToFinish();
+            executor.shutdownNow();
+        }
+
+        List<IterableEmbeddedSession> trackedSessions = recordingApi.getTrackedSessions();
+        assertEquals("the active session should be tracked exactly once", 1, trackedSessions.size());
+
+        List<IterableEmbeddedImpression> impressions = trackedSessions.get(0).getImpressions();
+        assertNotNull(impressions);
+        assertEquals(1, impressions.size());
+        assertEquals("message-1", impressions.get(0).getMessageId());
+        assertEquals(1, impressions.get(0).getDisplayCount());
     }
 
     @Test
@@ -88,5 +133,45 @@ public class EmbeddedSessionManagerThreadSafetyTest extends BaseTest {
 
         assertTrue("threads did not finish in time", finishGate.await(30, TimeUnit.SECONDS));
         assertEquals("concurrent access failed: " + failures, 0, failures.size());
+    }
+
+    private static class BlockingRecordingIterableApi extends IterableApi {
+        private final AtomicInteger trackCallCount = new AtomicInteger();
+        private final List<IterableEmbeddedSession> trackedSessions =
+                Collections.synchronizedList(new ArrayList<IterableEmbeddedSession>());
+        private final CountDownLatch firstTrackStarted = new CountDownLatch(1);
+        private final CountDownLatch allowFirstTrackToFinish = new CountDownLatch(1);
+
+        @Override
+        public void trackEmbeddedSession(IterableEmbeddedSession session) {
+            int callNumber = trackCallCount.incrementAndGet();
+            trackedSessions.add(session);
+
+            if (callNumber == 1) {
+                firstTrackStarted.countDown();
+                try {
+                    if (!allowFirstTrackToFinish.await(5, TimeUnit.SECONDS)) {
+                        throw new AssertionError("first tracking call was not released");
+                    }
+                } catch (InterruptedException exception) {
+                    Thread.currentThread().interrupt();
+                    throw new AssertionError("interrupted while waiting to finish tracking", exception);
+                }
+            }
+        }
+
+        boolean awaitFirstTrack(long timeout, TimeUnit unit) throws InterruptedException {
+            return firstTrackStarted.await(timeout, unit);
+        }
+
+        void allowFirstTrackToFinish() {
+            allowFirstTrackToFinish.countDown();
+        }
+
+        List<IterableEmbeddedSession> getTrackedSessions() {
+            synchronized (trackedSessions) {
+                return new ArrayList<>(trackedSessions);
+            }
+        }
     }
 }


### PR DESCRIPTION
# 📝 Summary

Makes `EmbeddedSessionManager` internally thread-safe, fixing a reported `NullPointerException` plus two further races in the same class.

###### 🎟️ Jira Ticket: [SDK-499](https://iterable.atlassian.net/browse/SDK-499)

## 📖 Description

`EmbeddedSessionManager` had no synchronization at all, and its impression API has no SDK-internal callers — it is driven entirely by integrator code, so it can be entered from any thread. Three races: the reported NPE in `updateDisplayCountAndDuration()` (null-check then `!!` on `start`, which `pauseImpression()` nulls in between), concurrent modification of the impression map, and duplicate session tracking when `endSession()` raced with itself.

All access to `session`, `impressions` and the impression fields now goes through one private lock. A single class-wide lock instead of a concurrent map because the invariants span several fields — `endSession()` has to end all impressions, snapshot the list and reset both fields as one step. `trackEmbeddedSession()` is called after the lock is released, since it re-enters `IterableApi` and integrator code.

`endSession()` still leaves the session running when there are no impressions. That is pre-existing behavior, changing it changes what gets reported, so it is tracked separately in SDK-701. A test pins the current behavior so that change is explicit when SDK-701 lands.

No public API change and no behavior change on the single-threaded path.

This development was started by contributor @Shamyyoun

## 🧪 How to test?

`./gradlew :iterableapi:testDebugUnitTest --tests "com.iterable.iterableapi.EmbeddedSessionManagerThreadSafetyTest"`

`concurrentSessionAndImpressionUpdatesDoNotThrow` races 8 threads over the session and impression API. Reverting the two source files to master reproduces the reported crash:

```
java.lang.AssertionError: concurrent access failed: [java.lang.NullPointerException] expected:<0> but was:<1>
```

Full `iterableapi` suite passed locally.

## 🧾 Changelog

- Fixed a `NullPointerException` in `EmbeddedSessionManager.updateDisplayCountAndDuration()` that could crash apps calling embedded session methods off the main thread. `EmbeddedSessionManager` is now internally synchronized, which also fixes concurrent modification of its impression map and duplicate session tracking when `endSession()` raced with itself. Thanks to [@Shamyyoun](https://github.com/Shamyyoun) for the report and initial fix.

## 📹 Loom recording if applicable

N/A

#### 🐞 Github Issues solved

Addresses #1052, supersedes #1053. Deliberately not using a closing keyword yet so merging doesn't auto-close the issue before we reply to the reporter.

#### 📚 Docs PR if applicable

N/A


[SDK-499]: https://iterable.atlassian.net/browse/SDK-499?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ